### PR TITLE
fix: Add httpx[socks]>=0.27.0 Dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "langchain-groq>=0.2.1",
     "groq>=0.12.0",
     "python-dotenv>=1.0.1",
+    "httpx[socks]>=0.27.0",
     "sdblpy",
 ]
 


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds a new dependency, `httpx[socks]>=0.27.0`, to the `dependencies` list.

FIX #48