### PR TITLE
Removed the telemetry from Streamlit

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -5,6 +5,7 @@ maxMessageSize = 500
 
 [browser]
 serverPort = 8502
+gatherUsageStats = false  # Streamlit, I'm not mad, just disappointed.
 
 [theme]
 


### PR DESCRIPTION
Streamlit sends request to a Fivetran endpoint for telemetry. I have added to the config to remove this behavior.