### PR TITLE
 Feat: enhance Episode and Speaker Profiles panels with improved UI elements

### DIFF
--- a/frontend/src/components/podcasts/EpisodeProfilesPanel.tsx
+++ b/frontend/src/components/podcasts/EpisodeProfilesPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Copy, Edit3, MoreVertical, Trash2, Users } from 'lucide-react'
+import { Copy, Edit3, FileText, MoreVertical, Trash2, Users } from 'lucide-react'
 
 import { EpisodeProfile, SpeakerProfile } from '@/lib/types/podcasts'
 import {
@@ -71,16 +71,24 @@ export function EpisodeProfilesPanel({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Episode profiles</h2>
-          <p className="text-sm text-muted-foreground">
-            Define reusable generation settings for your shows.
-          </p>
+      {/* Distinctive header with blue/indigo accent for production/generation focus */}
+      <div className="rounded-lg border-l-4 border-l-blue-500 bg-gradient-to-r from-blue-50 to-transparent dark:from-blue-950/30 dark:to-transparent p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-blue-100 p-2 dark:bg-blue-900/50">
+              <FileText className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Episode profiles</h2>
+              <p className="text-sm text-muted-foreground">
+                Define reusable generation settings for your shows.
+              </p>
+            </div>
+          </div>
+          <Button onClick={() => setCreateOpen(true)} disabled={disableCreate} className="bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-300">
+            Create profile
+          </Button>
         </div>
-        <Button onClick={() => setCreateOpen(true)} disabled={disableCreate}>
-          Create profile
-        </Button>
       </div>
 
       {disableCreate ? (
@@ -90,7 +98,8 @@ export function EpisodeProfilesPanel({
       ) : null}
 
       {sortedProfiles.length === 0 ? (
-        <div className="rounded-lg border border-dashed bg-muted/30 p-10 text-center text-sm text-muted-foreground">
+        <div className="rounded-lg border border-dashed border-blue-200 bg-blue-50/50 dark:border-blue-800 dark:bg-blue-950/20 p-10 text-center text-sm text-muted-foreground">
+          <FileText className="mx-auto mb-2 h-8 w-8 text-blue-400" />
           No episode profiles yet. Create one to kickstart podcast generation.
         </div>
       ) : (
@@ -102,7 +111,7 @@ export function EpisodeProfilesPanel({
             )
 
             return (
-              <Card key={profile.id} className="shadow-sm">
+              <Card key={profile.id} className="shadow-sm border-l-2 border-l-blue-300 dark:border-l-blue-700">
                 <CardHeader className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                   <div>
                     <CardTitle className="text-lg font-semibold">

--- a/frontend/src/components/podcasts/SpeakerProfilesPanel.tsx
+++ b/frontend/src/components/podcasts/SpeakerProfilesPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Copy, Edit3, MoreVertical, Trash2, Volume2 } from 'lucide-react'
+import { Copy, Edit3, Mic, MoreVertical, Trash2, Volume2 } from 'lucide-react'
 
 import { SpeakerProfile } from '@/lib/types/podcasts'
 import {
@@ -62,18 +62,29 @@ export function SpeakerProfilesPanel({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Speaker profiles</h2>
-          <p className="text-sm text-muted-foreground">
-            Configure voices and personalities for generated episodes.
-          </p>
+      {/* Distinctive header with amber/orange accent for voice/speaker focus */}
+      <div className="rounded-lg border-l-4 border-l-amber-500 bg-gradient-to-r from-amber-50 to-transparent dark:from-amber-950/30 dark:to-transparent p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-amber-100 p-2 dark:bg-amber-900/50">
+              <Mic className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Speaker profiles</h2>
+              <p className="text-sm text-muted-foreground">
+                Configure voices and personalities for generated episodes.
+              </p>
+            </div>
+          </div>
+          <Button onClick={() => setCreateOpen(true)} className="bg-amber-600 hover:bg-amber-700 text-white">
+            Create speaker
+          </Button>
         </div>
-        <Button onClick={() => setCreateOpen(true)}>Create speaker</Button>
       </div>
 
       {sortedProfiles.length === 0 ? (
-        <div className="rounded-lg border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+        <div className="rounded-lg border border-dashed border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20 p-8 text-center text-sm text-muted-foreground">
+          <Mic className="mx-auto mb-2 h-8 w-8 text-amber-400" />
           No speaker profiles yet. Create one to make episode templates available.
         </div>
       ) : (
@@ -83,7 +94,7 @@ export function SpeakerProfilesPanel({
             const deleteDisabled = usageCount > 0
 
             return (
-              <Card key={profile.id} className="shadow-sm">
+              <Card key={profile.id} className="shadow-sm border-l-2 border-l-amber-300 dark:border-l-amber-700">
                 <CardHeader className="flex flex-col gap-2">
                   <div className="flex items-center justify-between gap-2">
                     <div>


### PR DESCRIPTION
## Description

Improve visual distinction between Speaker Profiles and Episode Profiles panels in the podcast templates UI. Previously, both panels had identical styling, making it difficult for users to quickly differentiate between them at a glance. This PR adds distinct color themes:

- **Speaker Profiles Panel**: Amber/orange theme with microphone icon
- **Episode Profiles Panel**: Blue theme with document icon

Each panel now features:
- A themed gradient header with an icon
- Color-coded buttons matching the theme
- Subtle left border accent on profile cards
- Themed empty states

## Related Issue

<!-- This PR should be linked to an approved issue. If not, please create an issue first. -->

Fixes #<!-- issue number -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [x] Tested locally with Docker
- [ ] Tested locally with development setup
- [ ] Added new unit tests
- [ ] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)

**Test Details:**

1. Started the application using Docker Compose
2. Navigated to the Podcasts page → Templates tab
3. Verified Speaker Profiles panel displays with amber/orange theme
4. Verified Episode Profiles panel displays with blue theme
5. Tested both panels with existing profiles and empty states
6. Verified dark mode compatibility for both themes
7. Tested create/edit dialogs still function correctly

## Design Alignment

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [x] Simplicity Over Features
- [ ] API-First Architecture
- [ ] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**

This PR improves UX by making the interface more intuitive without adding complexity. The visual differentiation helps users quickly identify which panel they're working with, reducing cognitive load and potential configuration mistakes.

## Checklist

### Code Quality
- [ ] My code follows PEP 8 style guidelines (Python)
- [x] My code follows TypeScript best practices (Frontend)
- [ ] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [x] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots showing the before/after of the Speaker Profiles (amber) and Episode Profiles (blue) panels -->

<img width="1425" height="800" alt="image" src="https://github.com/user-attachments/assets/91e6a0ac-9d7a-4f1c-8c76-266464e1584d" />

## Additional Context

### Files Changed
- `frontend/src/components/podcasts/SpeakerProfilesPanel.tsx` - Added amber/orange color theme with Mic icon
- `frontend/src/components/podcasts/EpisodeProfilesPanel.tsx` - Added blue color theme with FileText icon

### Design Decisions
- **Color choices**: Amber for speakers (warm, voice-related) and blue for episodes (cool, structured content) create intuitive visual associations
- **Icon choices**: Microphone for speakers, document for episode templates
- **Consistent structure**: Both panels follow the same layout pattern for consistency while using different colors for differentiation

## Pre-Submission Verification

Before submitting, please verify:

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [ ] This PR addresses an approved issue that was assigned to me
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")

---

**Suggested PR Title:** `feat(ui): add visual distinction between speaker and episode profile panels`

**Suggested Branch Name:** `feat/podcast-profiles-visual-distinction`

---

**Thank you for contributing to Open Notebook!** 🎉
