### PR TITLE
fix(frontend): prevent Add Source dialog clipping (#546)

### DIFF
--- a/frontend/src/components/sources/AddSourceDialog.tsx
+++ b/frontend/src/components/sources/AddSourceDialog.tsx
@@ -534,15 +534,16 @@ export function AddSourceDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[700px] p-0">
-        <DialogHeader className="px-6 pt-6 pb-0">
+      <DialogContent className="sm:max-w-[700px] p-0 flex flex-col max-h-[calc(100vh-2rem)]">
+        <DialogHeader className="px-6 pt-6 pb-0 flex-shrink-0">
           <DialogTitle>{t.sources.addNew}</DialogTitle>
           <DialogDescription>
             {t.sources.processDescription}
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="min-w-0">
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+          <div className="flex-1 min-h-0 overflow-y-auto">
           <WizardContainer
             currentStep={currentStep}
             steps={WIZARD_STEPS}
@@ -583,9 +584,10 @@ export function AddSourceDialog({
               />
             )}
           </WizardContainer>
+          </div>
 
           {/* Navigation */}
-          <div className="flex justify-between items-center px-6 py-4 border-t border-border bg-muted">
+          <div className="flex flex-shrink-0 justify-between items-center px-6 py-4 border-t border-border bg-muted">
             <Button 
               type="button" 
               variant="outline" 


### PR DESCRIPTION
## Description

Fixes modal clipping in the Add Source dialog by constraining dialog height and making the wizard content area scrollable while keeping header and footer fixed.

## Related Issue

Fixes #546

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [ ] Tested locally with Docker
- [x] Tested locally with development setup
- [ ] Added new unit tests
- [ ] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)

**Test Details:**
Manually verified the Add Source dialog in local dev setup:
- Opened dialog and navigated all wizard steps.
- Confirmed dialog no longer clips at smaller viewport heights.
- Confirmed middle content scrolls while header/footer remain accessible.
- Confirmed submit/cancel/step navigation still behave as expected.

## Design Alignment

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [x] Simplicity Over Features
- [ ] API-First Architecture
- [ ] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**
This applies a minimal, scoped UI fix to existing dialog layout behavior without introducing new features or global component changes.

## Checklist

### Code Quality
- [ ] My code follows PEP 8 style guidelines (Python)
- [x] My code follows TypeScript best practices (Frontend)
- [ ] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

N/A

## Additional Context

This PR intentionally contains only the scoped modal clipping fix for Add Source dialog and excludes unrelated changes discussed in prior review feedback.

## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] This PR addresses an approved issue that was assigned to me
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")

---

**Thank you for contributing to Open Notebook!** 🎉
