### PR TITLE
fix: inject notebook name and description into chat system prompt

### DIFF
--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -342,6 +342,15 @@ async def execute_chat(request: ExecuteChatRequest):
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
 
+        # Fetch notebook linked to this session
+        notebook_query = await repo_query(
+            "SELECT out FROM refers_to WHERE in = $session_id",
+            {"session_id": ensure_record_id(full_session_id)},
+        )
+        notebook = None
+        if notebook_query:
+            notebook = await Notebook.get(notebook_query[0]["out"])
+
         # Determine model override (per-request override takes precedence over session-level)
         model_override = (
             request.model_override
@@ -360,6 +369,7 @@ async def execute_chat(request: ExecuteChatRequest):
         state_values = current_state.values if current_state else {}
         state_values["messages"] = state_values.get("messages", [])
         state_values["context"] = request.context
+        state_values["notebook"] = notebook
         state_values["model_override"] = model_override
 
         # Add user message to state

--- a/prompts/chat/system.jinja
+++ b/prompts/chat/system.jinja
@@ -11,7 +11,8 @@ Whenever a user asks you a question, you need to identify the query context and 
 {% if notebook %}
 # PROJECT INFORMATION
 
-{{notebook}}
+**Name:** {{notebook.name}}
+**Description:** {{notebook.description}}
 {% endif %}
 
 {% if context %}


### PR DESCRIPTION
## Summary

- Fetch the notebook linked to the chat session via the `refers_to` relationship in the `/chat/execute` endpoint
- Pass the notebook object into the LangGraph state so the Jinja2 template can render it
- Update the chat system prompt template to render `notebook.name` and `notebook.description` instead of the raw object

Closes #685

## Test plan

- [x] All 135 existing tests pass
- [ ] Open a notebook with a name and description, start a chat session, and verify the LLM response is contextually aware of the notebook topic