### PR TITLE
feat: add SSE token streaming for notebook chat

### DIFF
--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -418,7 +418,16 @@ async def _stream_execute_chat(
 
     from open_notebook.ai.provision import provision_langchain_model
     from open_notebook.utils import clean_thinking_content
+    from open_notebook.utils.error_classifier import classify_error
     from open_notebook.utils.text_utils import extract_text_content
+
+    # Initialize before try so the finally block can reference them even if an
+    # exception is raised before model provisioning completes.
+    accumulated = ""
+    persisted = False
+    state_values: Dict[str, Any] = {}
+    full_session_id = ""
+    session: Optional[ChatSession] = None
 
     try:
         full_session_id = (
@@ -442,7 +451,7 @@ async def _stream_execute_chat(
             config=RunnableConfig(configurable={"thread_id": full_session_id}),
         )
 
-        state_values: Dict[str, Any] = (
+        state_values = (
             dict(current_state.values) if current_state else {}
         )
         state_values["messages"] = list(state_values.get("messages", []))
@@ -461,10 +470,15 @@ async def _stream_execute_chat(
             str(payload), model_override, "chat", max_tokens=8192
         )
 
-        accumulated = ""
-        persisted = False
         async for chunk in model.astream(payload):
             content = getattr(chunk, "content", "") or ""
+            # Some providers (Anthropic, etc.) return content as a list of
+            # content-block dicts rather than a string. Normalize to string.
+            if isinstance(content, list):
+                content = "".join(
+                    c.get("text", "") if isinstance(c, dict) else str(c)
+                    for c in content
+                )
             if content:
                 accumulated += content
                 yield f'data: {json.dumps({"type": "token", "content": content})}\n\n'
@@ -486,18 +500,22 @@ async def _stream_execute_chat(
             f"  Session ID: {request.session_id}\n"
             f"  Traceback:\n{traceback.format_exc()}"
         )
-        yield f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
+        # Use classify_error to map raw exceptions to a user-friendly message
+        # and avoid leaking internal details to the client.
+        _, user_message = classify_error(e)
+        yield f'data: {json.dumps({"type": "error", "message": user_message})}\n\n'
     finally:
-        if accumulated and not persisted:
+        if accumulated and not persisted and full_session_id:
             try:
                 cleaned = clean_thinking_content(extract_text_content(accumulated))
                 if cleaned:
                     await asyncio.to_thread(
                         chat_graph.update_state,
                         config=RunnableConfig(configurable={"thread_id": full_session_id}),
-                        values={"messages": state_values["messages"] + [AIMessage(content=cleaned)]},
+                        values={"messages": state_values.get("messages", []) + [AIMessage(content=cleaned)]},
                     )
-                    await session.save()
+                    if session is not None:
+                        await session.save()
             except Exception:
                 pass
 

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 import traceback
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from langchain_core.runnables import RunnableConfig
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -406,6 +408,92 @@ async def execute_chat(request: ExecuteChatRequest):
             f"  Traceback:\n{traceback.format_exc()}"
         )
         raise HTTPException(status_code=500, detail=f"Error executing chat: {str(e)}")
+
+
+async def _stream_execute_chat(
+    request: ExecuteChatRequest,
+) -> AsyncGenerator[str, None]:
+    from ai_prompter import Prompter
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    from open_notebook.ai.provision import provision_langchain_model
+    from open_notebook.utils import clean_thinking_content
+    from open_notebook.utils.text_utils import extract_text_content
+
+    try:
+        full_session_id = (
+            request.session_id
+            if request.session_id.startswith("chat_session:")
+            else f"chat_session:{request.session_id}"
+        )
+        session = await ChatSession.get(full_session_id)
+        if not session:
+            yield f'data: {json.dumps({"type": "error", "message": "Session not found"})}\n\n'
+            return
+
+        model_override = (
+            request.model_override
+            if request.model_override is not None
+            else getattr(session, "model_override", None)
+        )
+
+        current_state = await asyncio.to_thread(
+            chat_graph.get_state,
+            config=RunnableConfig(configurable={"thread_id": full_session_id}),
+        )
+
+        state_values: Dict[str, Any] = (
+            dict(current_state.values) if current_state else {}
+        )
+        state_values["messages"] = list(state_values.get("messages", []))
+        state_values["context"] = request.context
+        state_values["model_override"] = model_override
+        state_values["messages"].append(HumanMessage(content=request.message))
+
+        yield f'data: {json.dumps({"type": "user_message", "content": request.message})}\n\n'
+
+        system_prompt = Prompter(prompt_template="chat/system").render(
+            data=state_values  # type: ignore[arg-type]
+        )
+        payload = [SystemMessage(content=system_prompt)] + state_values["messages"]
+
+        model = await provision_langchain_model(
+            str(payload), model_override, "chat", max_tokens=8192
+        )
+
+        accumulated = ""
+        async for chunk in model.astream(payload):
+            content = getattr(chunk, "content", "") or ""
+            if content:
+                accumulated += content
+                yield f'data: {json.dumps({"type": "token", "content": content})}\n\n'
+
+        cleaned_content = clean_thinking_content(extract_text_content(accumulated))
+        await asyncio.to_thread(
+            chat_graph.update_state,
+            config=RunnableConfig(configurable={"thread_id": full_session_id}),
+            values={"messages": state_values["messages"] + [AIMessage(content=cleaned_content)]},
+        )
+        await session.save()
+
+        yield f'data: {json.dumps({"type": "complete"})}\n\n'
+
+    except Exception as e:
+        logger.error(
+            f"Error streaming chat: {str(e)}\n"
+            f"  Session ID: {request.session_id}\n"
+            f"  Traceback:\n{traceback.format_exc()}"
+        )
+        yield f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
+
+
+@router.post("/chat/execute/stream")
+async def execute_chat_stream(request: ExecuteChatRequest):
+    """Execute a chat request and stream the AI response as Server-Sent Events."""
+    return StreamingResponse(
+        _stream_execute_chat(request),
+        media_type="text/event-stream",
+    )
 
 
 @router.post("/chat/context", response_model=BuildContextResponse)

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -462,6 +462,7 @@ async def _stream_execute_chat(
         )
 
         accumulated = ""
+        persisted = False
         async for chunk in model.astream(payload):
             content = getattr(chunk, "content", "") or ""
             if content:
@@ -475,6 +476,7 @@ async def _stream_execute_chat(
             values={"messages": state_values["messages"] + [AIMessage(content=cleaned_content)]},
         )
         await session.save()
+        persisted = True
 
         yield f'data: {json.dumps({"type": "complete"})}\n\n'
 
@@ -485,6 +487,19 @@ async def _stream_execute_chat(
             f"  Traceback:\n{traceback.format_exc()}"
         )
         yield f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
+    finally:
+        if accumulated and not persisted:
+            try:
+                cleaned = clean_thinking_content(extract_text_content(accumulated))
+                if cleaned:
+                    await asyncio.to_thread(
+                        chat_graph.update_state,
+                        config=RunnableConfig(configurable={"thread_id": full_session_id}),
+                        values={"messages": state_values["messages"] + [AIMessage(content=cleaned)]},
+                    )
+                    await session.save()
+            except Exception:
+                pass
 
 
 @router.post("/chat/execute/stream")
@@ -492,7 +507,15 @@ async def execute_chat_stream(request: ExecuteChatRequest):
     """Execute a chat request and stream the AI response as Server-Sent Events."""
     return StreamingResponse(
         _stream_execute_chat(request),
-        media_type="text/event-stream",
+        media_type="text/plain",
+        headers={
+            # Prevent intermediate proxies from compressing or buffering the
+            # stream; required for per-token delivery through Next.js rewrite
+            # proxy which otherwise applies gzip (buffered) when the client
+            # sends Accept-Encoding: gzip.
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -535,13 +535,14 @@ async def execute_chat_stream(request: ExecuteChatRequest):
     """Execute a chat request and stream the AI response as Server-Sent Events."""
     return StreamingResponse(
         _stream_execute_chat(request),
-        media_type="text/plain",
+        media_type="text/event-stream",
         headers={
-            # Prevent intermediate proxies from compressing or buffering the
-            # stream; required for per-token delivery through Next.js rewrite
-            # proxy which otherwise applies gzip (buffered) when the client
-            # sends Accept-Encoding: gzip.
-            "Cache-Control": "no-cache, no-transform",
+            # SSE is delivered through a dedicated Next.js route handler
+            # (frontend/src/app/api/chat/execute/stream/route.ts) rather than
+            # the rewrites() proxy, which buffers gzipped streams to
+            # completion. These headers also stop intermediate proxies from
+            # compressing or buffering, preserving per-token delivery.
+            "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",
         },
     )

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -472,6 +472,7 @@ async def _stream_execute_chat(
         )
 
         accumulated = ""
+        persisted = False
         async for chunk in model.astream(payload):
             content = getattr(chunk, "content", "") or ""
             if content:
@@ -485,6 +486,7 @@ async def _stream_execute_chat(
             values={"messages": state_values["messages"] + [AIMessage(content=cleaned_content)]},
         )
         await session.save()
+        persisted = True
 
         yield f'data: {json.dumps({"type": "complete"})}\n\n'
 
@@ -495,6 +497,19 @@ async def _stream_execute_chat(
             f"  Traceback:\n{traceback.format_exc()}"
         )
         yield f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
+    finally:
+        if accumulated and not persisted:
+            try:
+                cleaned = clean_thinking_content(extract_text_content(accumulated))
+                if cleaned:
+                    await asyncio.to_thread(
+                        chat_graph.update_state,
+                        config=RunnableConfig(configurable={"thread_id": full_session_id}),
+                        values={"messages": state_values["messages"] + [AIMessage(content=cleaned)]},
+                    )
+                    await session.save()
+            except Exception:
+                pass
 
 
 @router.post("/chat/execute/stream")
@@ -502,7 +517,15 @@ async def execute_chat_stream(request: ExecuteChatRequest):
     """Execute a chat request and stream the AI response as Server-Sent Events."""
     return StreamingResponse(
         _stream_execute_chat(request),
-        media_type="text/event-stream",
+        media_type="text/plain",
+        headers={
+            # Prevent intermediate proxies from compressing or buffering the
+            # stream; required for per-token delivery through Next.js rewrite
+            # proxy which otherwise applies gzip (buffered) when the client
+            # sends Accept-Encoding: gzip.
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -428,7 +428,16 @@ async def _stream_execute_chat(
 
     from open_notebook.ai.provision import provision_langchain_model
     from open_notebook.utils import clean_thinking_content
+    from open_notebook.utils.error_classifier import classify_error
     from open_notebook.utils.text_utils import extract_text_content
+
+    # Initialize before try so the finally block can reference them even if an
+    # exception is raised before model provisioning completes.
+    accumulated = ""
+    persisted = False
+    state_values: Dict[str, Any] = {}
+    full_session_id = ""
+    session: Optional[ChatSession] = None
 
     try:
         full_session_id = (
@@ -452,7 +461,7 @@ async def _stream_execute_chat(
             config=RunnableConfig(configurable={"thread_id": full_session_id}),
         )
 
-        state_values: Dict[str, Any] = (
+        state_values = (
             dict(current_state.values) if current_state else {}
         )
         state_values["messages"] = list(state_values.get("messages", []))
@@ -471,10 +480,15 @@ async def _stream_execute_chat(
             str(payload), model_override, "chat", max_tokens=8192
         )
 
-        accumulated = ""
-        persisted = False
         async for chunk in model.astream(payload):
             content = getattr(chunk, "content", "") or ""
+            # Some providers (Anthropic, etc.) return content as a list of
+            # content-block dicts rather than a string. Normalize to string.
+            if isinstance(content, list):
+                content = "".join(
+                    c.get("text", "") if isinstance(c, dict) else str(c)
+                    for c in content
+                )
             if content:
                 accumulated += content
                 yield f'data: {json.dumps({"type": "token", "content": content})}\n\n'
@@ -496,18 +510,22 @@ async def _stream_execute_chat(
             f"  Session ID: {request.session_id}\n"
             f"  Traceback:\n{traceback.format_exc()}"
         )
-        yield f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
+        # Use classify_error to map raw exceptions to a user-friendly message
+        # and avoid leaking internal details to the client.
+        _, user_message = classify_error(e)
+        yield f'data: {json.dumps({"type": "error", "message": user_message})}\n\n'
     finally:
-        if accumulated and not persisted:
+        if accumulated and not persisted and full_session_id:
             try:
                 cleaned = clean_thinking_content(extract_text_content(accumulated))
                 if cleaned:
                     await asyncio.to_thread(
                         chat_graph.update_state,
                         config=RunnableConfig(configurable={"thread_id": full_session_id}),
-                        values={"messages": state_values["messages"] + [AIMessage(content=cleaned)]},
+                        values={"messages": state_values.get("messages", []) + [AIMessage(content=cleaned)]},
                     )
-                    await session.save()
+                    if session is not None:
+                        await session.save()
             except Exception:
                 pass
 

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 import traceback
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from langchain_core.runnables import RunnableConfig
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -416,6 +418,92 @@ async def execute_chat(request: ExecuteChatRequest):
             f"  Traceback:\n{traceback.format_exc()}"
         )
         raise HTTPException(status_code=500, detail=f"Error executing chat: {str(e)}")
+
+
+async def _stream_execute_chat(
+    request: ExecuteChatRequest,
+) -> AsyncGenerator[str, None]:
+    from ai_prompter import Prompter
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    from open_notebook.ai.provision import provision_langchain_model
+    from open_notebook.utils import clean_thinking_content
+    from open_notebook.utils.text_utils import extract_text_content
+
+    try:
+        full_session_id = (
+            request.session_id
+            if request.session_id.startswith("chat_session:")
+            else f"chat_session:{request.session_id}"
+        )
+        session = await ChatSession.get(full_session_id)
+        if not session:
+            yield f'data: {json.dumps({"type": "error", "message": "Session not found"})}\n\n'
+            return
+
+        model_override = (
+            request.model_override
+            if request.model_override is not None
+            else getattr(session, "model_override", None)
+        )
+
+        current_state = await asyncio.to_thread(
+            chat_graph.get_state,
+            config=RunnableConfig(configurable={"thread_id": full_session_id}),
+        )
+
+        state_values: Dict[str, Any] = (
+            dict(current_state.values) if current_state else {}
+        )
+        state_values["messages"] = list(state_values.get("messages", []))
+        state_values["context"] = request.context
+        state_values["model_override"] = model_override
+        state_values["messages"].append(HumanMessage(content=request.message))
+
+        yield f'data: {json.dumps({"type": "user_message", "content": request.message})}\n\n'
+
+        system_prompt = Prompter(prompt_template="chat/system").render(
+            data=state_values  # type: ignore[arg-type]
+        )
+        payload = [SystemMessage(content=system_prompt)] + state_values["messages"]
+
+        model = await provision_langchain_model(
+            str(payload), model_override, "chat", max_tokens=8192
+        )
+
+        accumulated = ""
+        async for chunk in model.astream(payload):
+            content = getattr(chunk, "content", "") or ""
+            if content:
+                accumulated += content
+                yield f'data: {json.dumps({"type": "token", "content": content})}\n\n'
+
+        cleaned_content = clean_thinking_content(extract_text_content(accumulated))
+        await asyncio.to_thread(
+            chat_graph.update_state,
+            config=RunnableConfig(configurable={"thread_id": full_session_id}),
+            values={"messages": state_values["messages"] + [AIMessage(content=cleaned_content)]},
+        )
+        await session.save()
+
+        yield f'data: {json.dumps({"type": "complete"})}\n\n'
+
+    except Exception as e:
+        logger.error(
+            f"Error streaming chat: {str(e)}\n"
+            f"  Session ID: {request.session_id}\n"
+            f"  Traceback:\n{traceback.format_exc()}"
+        )
+        yield f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
+
+
+@router.post("/chat/execute/stream")
+async def execute_chat_stream(request: ExecuteChatRequest):
+    """Execute a chat request and stream the AI response as Server-Sent Events."""
+    return StreamingResponse(
+        _stream_execute_chat(request),
+        media_type="text/event-stream",
+    )
 
 
 @router.post("/chat/context", response_model=BuildContextResponse)

--- a/frontend/src/app/(dashboard)/notebooks/components/ChatColumn.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/ChatColumn.tsx
@@ -97,6 +97,8 @@ export function ChatColumn({ notebookId, contextSelections, sources, sourcesLoad
       contextType="notebook"
       messages={chat.messages}
       isStreaming={chat.isSending}
+      streamingContent={chat.streamingContent}
+      onStop={chat.stopStreaming}
       contextIndicators={null}
       onSendMessage={(message, modelOverride) => chat.sendMessage(message, modelOverride)}
       modelOverride={chat.currentSession?.model_override ?? chat.pendingModelOverride ?? undefined}

--- a/frontend/src/app/api/chat/execute/stream/route.ts
+++ b/frontend/src/app/api/chat/execute/stream/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server'
+import { sseProxy } from '../../../_sse-proxy'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  return sseProxy(req, '/api/chat/execute/stream')
+}

--- a/frontend/src/components/source/ChatPanel.tsx
+++ b/frontend/src/components/source/ChatPanel.tsx
@@ -102,9 +102,16 @@ export function ChatPanel({
     }
   }
 
-  // Auto-scroll to bottom when new messages arrive or streaming content updates
+  // Auto-scroll to bottom: smooth on new messages, instant during streaming
+  // (per-token smooth scroll causes jank and prevents users from staying
+  // scrolled up to read earlier content).
+  const lastMessageCountRef = useRef(messages.length)
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const messageAdded = messages.length !== lastMessageCountRef.current
+    lastMessageCountRef.current = messages.length
+    messagesEndRef.current?.scrollIntoView({
+      behavior: messageAdded ? 'smooth' : 'auto',
+    })
   }, [messages, streamingContent])
 
   const handleSend = () => {

--- a/frontend/src/components/source/ChatPanel.tsx
+++ b/frontend/src/components/source/ChatPanel.tsx
@@ -312,7 +312,6 @@ export function ChatPanel({
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={`${t('chat.sendPlaceholder')} (${t('chat.pressToSend').replace('{key}', keyHint)})`}
-              disabled={isStreaming}
               className="flex-1 min-h-[40px] max-h-[100px] resize-none py-2 px-3 min-w-0"
               rows={1}
             />

--- a/frontend/src/components/source/ChatPanel.tsx
+++ b/frontend/src/components/source/ChatPanel.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { Bot, User, Send, Loader2, FileText, Lightbulb, StickyNote, Clock } from 'lucide-react'
+import { Bot, User, Send, Square, Loader2, FileText, Lightbulb, StickyNote, Clock } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import {
@@ -35,6 +35,10 @@ interface NotebookContextStats {
 interface ChatPanelProps {
   messages: SourceChatMessage[]
   isStreaming: boolean
+  // Partial content of the AI response currently being generated (SSE token deltas)
+  streamingContent?: string
+  // Stop in-flight streaming response (cancel client + server generation)
+  onStop?: () => void
   contextIndicators: SourceChatContextIndicator | null
   onSendMessage: (message: string, modelOverride?: string) => void
   modelOverride?: string
@@ -59,6 +63,8 @@ interface ChatPanelProps {
 export function ChatPanel({
   messages,
   isStreaming,
+  streamingContent,
+  onStop,
   contextIndicators,
   onSendMessage,
   modelOverride,
@@ -96,10 +102,10 @@ export function ChatPanel({
     }
   }
 
-  // Auto-scroll to bottom when new messages arrive
+  // Auto-scroll to bottom when new messages arrive or streaming content updates
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+  }, [messages, streamingContent])
 
   const handleSend = () => {
     if (input.trim() && !isStreaming) {
@@ -230,8 +236,15 @@ export function ChatPanel({
                     <Bot className="h-4 w-4" />
                   </div>
                 </div>
-                <div className="rounded-lg px-4 py-2 bg-muted">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                <div className="rounded-lg px-4 py-2 bg-muted min-w-0 max-w-[85%]">
+                  {streamingContent ? (
+                    <AIMessageContent
+                      content={streamingContent}
+                      onReferenceClick={handleReferenceClick}
+                    />
+                  ) : (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  )}
                 </div>
               </div>
             )}
@@ -303,18 +316,30 @@ export function ChatPanel({
               className="flex-1 min-h-[40px] max-h-[100px] resize-none py-2 px-3 min-w-0"
               rows={1}
             />
-            <Button
-              onClick={handleSend}
-              disabled={!input.trim() || isStreaming}
-              size="icon"
-              className="h-[40px] w-[40px] flex-shrink-0"
-            >
-              {isStreaming ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </Button>
+            {isStreaming && onStop ? (
+              <Button
+                onClick={onStop}
+                size="icon"
+                variant="destructive"
+                className="h-[40px] w-[40px] flex-shrink-0"
+                aria-label="Stop"
+              >
+                <Square className="h-4 w-4 fill-current" />
+              </Button>
+            ) : (
+              <Button
+                onClick={handleSend}
+                disabled={!input.trim() || isStreaming}
+                size="icon"
+                className="h-[40px] w-[40px] flex-shrink-0"
+              >
+                {isStreaming ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+              </Button>
+            )}
           </div>
         </div>
       </CardContent>

--- a/frontend/src/components/source/ChatPanel.tsx
+++ b/frontend/src/components/source/ChatPanel.tsx
@@ -314,7 +314,6 @@ export function ChatPanel({
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={`${t('chat.sendPlaceholder')} (${t('chat.pressToSend').replace('{key}', keyHint)})`}
-              disabled={isStreaming}
               className="flex-1 min-h-[40px] max-h-[100px] resize-none py-2 px-3 min-w-0"
               rows={1}
             />

--- a/frontend/src/components/source/ChatPanel.tsx
+++ b/frontend/src/components/source/ChatPanel.tsx
@@ -104,9 +104,16 @@ export function ChatPanel({
     }
   }
 
-  // Auto-scroll to bottom when new messages arrive or streaming content updates
+  // Auto-scroll to bottom: smooth on new messages, instant during streaming
+  // (per-token smooth scroll causes jank and prevents users from staying
+  // scrolled up to read earlier content).
+  const lastMessageCountRef = useRef(messages.length)
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const messageAdded = messages.length !== lastMessageCountRef.current
+    lastMessageCountRef.current = messages.length
+    messagesEndRef.current?.scrollIntoView({
+      behavior: messageAdded ? 'smooth' : 'auto',
+    })
   }, [messages, streamingContent])
 
   const handleSend = () => {

--- a/frontend/src/components/source/ChatPanel.tsx
+++ b/frontend/src/components/source/ChatPanel.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { Bot, User, Send, Loader2, FileText, Lightbulb, StickyNote, Clock } from 'lucide-react'
+import { Bot, User, Send, Square, Loader2, FileText, Lightbulb, StickyNote, Clock } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
@@ -37,6 +37,10 @@ interface NotebookContextStats {
 interface ChatPanelProps {
   messages: SourceChatMessage[]
   isStreaming: boolean
+  // Partial content of the AI response currently being generated (SSE token deltas)
+  streamingContent?: string
+  // Stop in-flight streaming response (cancel client + server generation)
+  onStop?: () => void
   contextIndicators: SourceChatContextIndicator | null
   onSendMessage: (message: string, modelOverride?: string) => void
   modelOverride?: string
@@ -61,6 +65,8 @@ interface ChatPanelProps {
 export function ChatPanel({
   messages,
   isStreaming,
+  streamingContent,
+  onStop,
   contextIndicators,
   onSendMessage,
   modelOverride,
@@ -98,10 +104,10 @@ export function ChatPanel({
     }
   }
 
-  // Auto-scroll to bottom when new messages arrive
+  // Auto-scroll to bottom when new messages arrive or streaming content updates
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+  }, [messages, streamingContent])
 
   const handleSend = () => {
     if (input.trim() && !isStreaming) {
@@ -232,8 +238,15 @@ export function ChatPanel({
                     <Bot className="h-4 w-4" />
                   </div>
                 </div>
-                <div className="rounded-lg px-4 py-2 bg-muted">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                <div className="rounded-lg px-4 py-2 bg-muted min-w-0 max-w-[85%]">
+                  {streamingContent ? (
+                    <AIMessageContent
+                      content={streamingContent}
+                      onReferenceClick={handleReferenceClick}
+                    />
+                  ) : (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  )}
                 </div>
               </div>
             )}
@@ -305,18 +318,30 @@ export function ChatPanel({
               className="flex-1 min-h-[40px] max-h-[100px] resize-none py-2 px-3 min-w-0"
               rows={1}
             />
-            <Button
-              onClick={handleSend}
-              disabled={!input.trim() || isStreaming}
-              size="icon"
-              className="h-[40px] w-[40px] flex-shrink-0"
-            >
-              {isStreaming ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </Button>
+            {isStreaming && onStop ? (
+              <Button
+                onClick={onStop}
+                size="icon"
+                variant="destructive"
+                className="h-[40px] w-[40px] flex-shrink-0"
+                aria-label="Stop"
+              >
+                <Square className="h-4 w-4 fill-current" />
+              </Button>
+            ) : (
+              <Button
+                onClick={handleSend}
+                disabled={!input.trim() || isStreaming}
+                size="icon"
+                className="h-[40px] w-[40px] flex-shrink-0"
+              >
+                {isStreaming ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+              </Button>
+            )}
           </div>
         </div>
       </CardContent>

--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -59,6 +59,58 @@ export const chatApi = {
     return response.data
   },
 
+  // Messaging with SSE token streaming (uses relative URL for Docker compatibility)
+  sendMessageStream: async (
+    data: SendNotebookChatMessageRequest,
+    signal?: AbortSignal
+  ) => {
+    // Get auth token using the same logic as apiClient interceptor
+    let token = null
+    if (typeof window !== 'undefined') {
+      const authStorage = localStorage.getItem('auth-storage')
+      if (authStorage) {
+        try {
+          const { state } = JSON.parse(authStorage)
+          if (state?.token) {
+            token = state.token
+          }
+        } catch (error) {
+          console.error('Error parsing auth storage:', error)
+        }
+      }
+    }
+
+    // Use relative URL to leverage Next.js rewrites
+    const url = '/api/chat/execute/stream'
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
+      body: JSON.stringify(data),
+      signal,
+    })
+
+    if (!response.ok) {
+      let errorMessage = `HTTP error! status: ${response.status}`
+      try {
+        const errorData = await response.json()
+        errorMessage = errorData.detail || errorData.message || errorMessage
+      } catch {
+        errorMessage = response.statusText || errorMessage
+      }
+      throw new Error(errorMessage)
+    }
+
+    if (!response.body) {
+      throw new Error('No response body received')
+    }
+
+    return response.body
+  },
+
   buildContext: async (data: BuildContextRequest) => {
     const response = await apiClient.post<BuildContextResponse>(
       `/chat/context`,

--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -80,7 +80,9 @@ export const chatApi = {
       }
     }
 
-    // Use relative URL to leverage Next.js rewrites
+    // Relative URL handled by the dedicated SSE route handler
+    // (app/api/chat/execute/stream/route.ts), which proxies to the backend
+    // without the rewrites() gzip buffering that breaks streaming.
     const url = '/api/chat/execute/stream'
 
     const response = await fetch(url, {

--- a/frontend/src/lib/hooks/useNotebookChat.ts
+++ b/frontend/src/lib/hooks/useNotebookChat.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { getApiErrorMessage } from '@/lib/utils/error-handler'
@@ -29,10 +29,15 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null)
   const [messages, setMessages] = useState<NotebookChatMessage[]>([])
   const [isSending, setIsSending] = useState(false)
+  const [streamingContent, setStreamingContent] = useState<string>('')
   const [tokenCount, setTokenCount] = useState<number>(0)
   const [charCount, setCharCount] = useState<number>(0)
   // Pending model override for when user changes model before a session exists
   const [pendingModelOverride, setPendingModelOverride] = useState<string | null>(null)
+  // AbortController for in-flight streaming request
+  const abortControllerRef = useRef<AbortController | null>(null)
+  // Track accumulated content for partial preservation on cancel
+  const accumulatedRef = useRef<string>('')
 
   // Fetch sessions for this notebook
   const {
@@ -172,7 +177,7 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     return response.context
   }, [notebookId, sources, notes, contextSelections])
 
-  // Send message (synchronous, no streaming)
+  // Send message (SSE streaming via /chat/execute/stream)
   const sendMessage = useCallback(async (message: string, modelOverride?: string) => {
     let sessionId = currentSessionId
 
@@ -211,30 +216,98 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     }
     setMessages(prev => [...prev, userMessage])
     setIsSending(true)
+    setStreamingContent('')
+    accumulatedRef.current = ''
+
+    // Set up abort controller for this request
+    const controller = new AbortController()
+    abortControllerRef.current = controller
 
     try {
-      // Build context and send message
+      // Build context and send message via streaming endpoint
       const context = await buildContext()
-      const response = await chatApi.sendMessage({
-        session_id: sessionId,
-        message,
-        context,
-        model_override: modelOverride ?? (currentSession?.model_override ?? undefined)
-      })
+      const stream = await chatApi.sendMessageStream(
+        {
+          session_id: sessionId,
+          message,
+          context,
+          model_override: modelOverride ?? (currentSession?.model_override ?? undefined),
+        },
+        controller.signal
+      )
 
-      // Update messages with API response
-      setMessages(response.messages)
+      const reader = stream.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let accumulated = ''
 
-      // Refetch current session to get updated data
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const jsonStr = line.slice(6).trim()
+            if (!jsonStr) continue
+            const event = JSON.parse(jsonStr) as {
+              type: string
+              content?: string
+              message?: string
+            }
+
+            if (event.type === 'token' && event.content) {
+              accumulated += event.content
+              accumulatedRef.current = accumulated
+              setStreamingContent(accumulated)
+            } else if (event.type === 'error') {
+              throw new Error(event.message || 'Stream error occurred')
+            }
+            // 'user_message' and 'complete' events are informational only
+          } catch (e) {
+            if (e instanceof SyntaxError) {
+              console.error('Error parsing SSE data:', e, 'Line:', line)
+              // Don't throw - continue processing other lines
+            } else {
+              throw e
+            }
+          }
+        }
+      }
+
+      // Refetch session to get authoritative message list from server
       await refetchCurrentSession()
     } catch (err: unknown) {
-      const error = err as { response?: { data?: { detail?: string } }, message?: string };
-      console.error('Error sending message:', error)
-      toast.error(getApiErrorMessage(error.response?.data?.detail || error.message, (key) => t(key), 'apiErrors.failedToSendMessage'))
-      // Remove optimistic message on error
-      setMessages(prev => prev.filter(msg => !msg.id.startsWith('temp-')))
+      // AbortError is expected when user stops streaming; keep optimistic
+      // user message so they can see what they asked, and refetch session
+      // in case the server persisted a partial response.
+      const error = err as { name?: string; message?: string; response?: { data?: { detail?: string } } }
+      if (error.name === 'AbortError') {
+        // Keep partial AI response visible (local only, not persisted)
+        const partial = accumulatedRef.current
+        if (partial) {
+          setMessages(prev => [...prev, {
+            id: `partial-${Date.now()}`,
+            type: 'ai',
+            content: partial,
+            timestamp: new Date().toISOString()
+          }])
+        }
+      } else {
+        console.error('Error sending message:', error)
+        toast.error(getApiErrorMessage(error.response?.data?.detail || error.message, (key) => t(key), 'apiErrors.failedToSendMessage'))
+        // Remove optimistic message on error
+        setMessages(prev => prev.filter(msg => !msg.id.startsWith('temp-')))
+      }
     } finally {
+      setStreamingContent('')
       setIsSending(false)
+      abortControllerRef.current = null
+      accumulatedRef.current = ''
     }
   }, [
     notebookId,
@@ -246,6 +319,18 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     queryClient,
     t
   ])
+
+  // Stop in-flight streaming response
+  const stopStreaming = useCallback(() => {
+    abortControllerRef.current?.abort()
+  }, [])
+
+  // Abort in-flight stream on unmount
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort()
+    }
+  }, [])
 
   // Switch session
   const switchSession = useCallback((sessionId: string) => {
@@ -306,6 +391,7 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     currentSessionId,
     messages,
     isSending,
+    streamingContent,
     loadingSessions,
     tokenCount,
     charCount,
@@ -317,6 +403,7 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     deleteSession,
     switchSession,
     sendMessage,
+    stopStreaming,
     setModelOverride,
     refetchSessions
   }

--- a/frontend/src/lib/hooks/useNotebookChat.ts
+++ b/frontend/src/lib/hooks/useNotebookChat.ts
@@ -60,14 +60,19 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     enabled: !!notebookId && !!currentSessionId
   })
 
-  // Update messages when current session changes, but not during active
-  // streaming — the optimistic user message would be overwritten by the
-  // server state which does not yet include the in-flight turn.
+  // Track isSending in a ref so the sync effect reads it without depending
+  // on it. We only react to currentSession changes (e.g., a fresh session
+  // fetch), not to isSending toggles — otherwise stopping a stream would
+  // re-fire this effect with stale session data and overwrite the locally
+  // preserved partial response immediately after setIsSending(false).
+  const isSendingRef = useRef(false)
+  isSendingRef.current = isSending
+
   useEffect(() => {
-    if (currentSession?.messages && !isSending) {
+    if (currentSession?.messages && !isSendingRef.current) {
       setMessages(currentSession.messages)
     }
-  }, [currentSession, isSending])
+  }, [currentSession])
 
   // Auto-select most recent session when sessions are loaded
   useEffect(() => {
@@ -281,8 +286,14 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
         }
       }
 
-      // Refetch session to get authoritative message list from server
-      await refetchCurrentSession()
+      // Refetch canonical session state and apply it explicitly. The sync
+      // effect may skip the cache-driven update because isSending can still
+      // be true when the re-render fires (awaits break React batching), so
+      // set messages directly from the fresh data to avoid that race.
+      const freshSession = await refetchCurrentSession()
+      if (freshSession.data?.messages) {
+        setMessages(freshSession.data.messages)
+      }
     } catch (err: unknown) {
       // AbortError is expected when user stops streaming; keep optimistic
       // user message so they can see what they asked, and refetch session

--- a/frontend/src/lib/hooks/useNotebookChat.ts
+++ b/frontend/src/lib/hooks/useNotebookChat.ts
@@ -60,12 +60,14 @@ export function useNotebookChat({ notebookId, sources, notes, contextSelections 
     enabled: !!notebookId && !!currentSessionId
   })
 
-  // Update messages when current session changes
+  // Update messages when current session changes, but not during active
+  // streaming — the optimistic user message would be overwritten by the
+  // server state which does not yet include the in-flight turn.
   useEffect(() => {
-    if (currentSession?.messages) {
+    if (currentSession?.messages && !isSending) {
       setMessages(currentSession.messages)
     }
-  }, [currentSession])
+  }, [currentSession, isSending])
 
   // Auto-select most recent session when sessions are loaded
   useEffect(() => {


### PR DESCRIPTION
## Summary

Adds `POST /api/chat/execute/stream`, a Server-Sent Events streaming variant of the existing `/api/chat/execute` endpoint, and updates the notebook chat frontend to consume it with real-time token rendering and a stop button.

## Event format

```
data: {"type": "user_message", "content": "..."}
data: {"type": "token", "content": "delta"}    (repeated)
data: {"type": "complete"}
data: {"type": "error", "message": "..."}      (on failure)
```

## Backward compatibility

The existing `/api/chat/execute` endpoint is unchanged. This is purely additive. Source chat is unaffected.

## Changes

**Backend** (`api/routers/chat.py`):
- New endpoint `POST /api/chat/execute/stream`
- Streams token deltas via `model.astream()` from the provisioned langchain chat model
- Session state persisted via `chat_graph.update_state` on completion
- Partial AI response persisted on client disconnect (best-effort via `finally` block)
- Uses `media_type="text/plain"` consistent with the existing `/api/search/ask` endpoint
- Sets `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no` to prevent gzip buffering through the Next.js rewrite proxy

**Frontend**:
- `chat.ts`: `sendMessageStream()` using fetch + ReadableStream + AbortSignal
- `useNotebookChat.ts`: SSE consumer with `streamingContent` state, stop/cancel support, partial preservation on abort, type-ahead input during streaming
- `ChatPanel.tsx`: streaming AI message bubble with live markdown rendering, stop button
- `ChatColumn.tsx`: pass new props

## Example

```bash
curl -N -X POST http://localhost:5055/api/chat/execute/stream \
  -H "Authorization: Bearer $OPEN_NOTEBOOK_PASSWORD" \
  -H "Content-Type: application/json" \
  -d '{"session_id":"chat_session:...","message":"...","context":{}}'
```