### PR TITLE
fix: stream SSE responses end-to-end through Next.js proxy

### DIFF
--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -147,7 +147,12 @@ async def ask_knowledge_base(ask_request: AskRequest):
             stream_ask_response(
                 ask_request.question, strategy_model, answer_model, final_answer_model
             ),
-            media_type="text/plain",
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
         )
 
     except HTTPException:

--- a/api/routers/source_chat.py
+++ b/api/routers/source_chat.py
@@ -539,11 +539,11 @@ async def send_message_to_source_chat(
                 message=request.message,
                 model_override=model_override,
             ),
-            media_type="text/plain",
+            media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
-                "Content-Type": "text/plain; charset=utf-8",
+                "X-Accel-Buffering": "no",
             },
         )
 

--- a/frontend/src/app/api/_sse-proxy.ts
+++ b/frontend/src/app/api/_sse-proxy.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from 'next/server'
+
+const INTERNAL_API_URL = process.env.INTERNAL_API_URL || 'http://localhost:5055'
+
+export async function sseProxy(req: NextRequest, upstreamPath: string) {
+  const body = await req.text()
+  const auth = req.headers.get('authorization')
+
+  const upstream = await fetch(`${INTERNAL_API_URL}${upstreamPath}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(auth ? { Authorization: auth } : {}),
+      Accept: 'text/event-stream',
+    },
+    body,
+    cache: 'no-store',
+  })
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: { 'Content-Type': upstream.headers.get('content-type') ?? 'application/json' },
+    })
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/frontend/src/app/api/search/ask/route.ts
+++ b/frontend/src/app/api/search/ask/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server'
+import { sseProxy } from '../../_sse-proxy'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  return sseProxy(req, '/api/search/ask')
+}

--- a/frontend/src/app/api/sources/[sourceId]/chat/sessions/[sessionId]/messages/route.ts
+++ b/frontend/src/app/api/sources/[sourceId]/chat/sessions/[sessionId]/messages/route.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from 'next/server'
+import { sseProxy } from '../../../../../../_sse-proxy'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ sourceId: string; sessionId: string }> }
+) {
+  const { sourceId, sessionId } = await params
+  return sseProxy(
+    req,
+    `/api/sources/${encodeURIComponent(sourceId)}/chat/sessions/${encodeURIComponent(sessionId)}/messages`
+  )
+}


### PR DESCRIPTION
## Problem

The `/api/search/ask` and `/api/sources/{source_id}/chat/sessions/{session_id}/messages` endpoints emit Server-Sent Events (`data: ...\n\n`) but declare `media_type="text/plain"`. Combined with Next.js 16 `rewrites()` proxy buffering non-SSE content types, the frontend's `ReadableStream` never receives chunks progressively. The UI sits at `Processing...` indefinitely even though the backend logs `200 OK` right away.

## Root cause

Two layers need to change for streaming to actually reach the browser:

1. **Backend advertises the wrong Content-Type.** `StreamingResponse(..., media_type="text/plain")` makes intermediaries assume the body is plain text and buffer it.
2. **Next.js 16 `rewrites()` proxy buffers text/event-stream too.** Even after fixing (1), Next.js' built-in rewrites handler in standalone mode reads the upstream body to completion before forwarding. There is no stable config flag in Next 15/16 to disable this for SSE.

Reproducible with `curl -N` from the host:
- `curl -N :5055/api/search/ask` streams chunks in real time after fix 1.
- `curl -N :8502/api/search/ask` still buffers after fix 1; needs fix 2.

## Fix

**Backend** (`api/routers/search.py`, `api/routers/source_chat.py`): switch to `media_type="text/event-stream"` and add `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`.

**Frontend**: add `src/app/api/_sse-proxy.ts` helper and two App Router route handlers (`/api/search/ask`, `/api/sources/[sourceId]/chat/sessions/[sessionId]/messages`). They return `upstream.body` as a `ReadableStream`, which Next.js streams without buffering. Reuses the existing `INTERNAL_API_URL` env var so all deployment topologies keep working.

## Verification

- `curl -Ni -X POST http://localhost:8502/api/search/ask ...` now returns `Content-Type: text/event-stream` with chunks at distinct timestamps.
- Playwright: browser `fetch('/api/search/ask')` receives `strategy` / `answer` / `final_answer` / `complete` events progressively; the Ask UI renders each stage as it arrives.
- `GET /api/search/ask` returns `405 Method Not Allowed` (confirms the new route handler is routed, not the rewrite).
- Non-streaming API paths continue through `next.config.ts` rewrites unchanged.

## Scope

- No public API changes.
- No frontend hook changes (same relative URLs).
- No new dependencies.
- Route handlers set `runtime = 'nodejs'` + `dynamic = 'force-dynamic'` for `output: 'standalone'` compatibility.
