### PR TITLE
Fix OpenAI model discovery base URL override

### DIFF
--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -480,6 +480,12 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
     api_key = config.get("api_key")
     base_url = config.get("base_url")
 
+    def models_endpoint(url: str) -> str:
+        trimmed = url.rstrip("/")
+        if trimmed.endswith("/models"):
+            return trimmed
+        return f"{trimmed}/models"
+
     # Static model lists for providers without a listing API
     STATIC_MODELS: Dict[str, List[str]] = {
         "anthropic": [
@@ -546,7 +552,9 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
                 headers["Authorization"] = f"Bearer {api_key}"
             async with httpx.AsyncClient() as client:
                 response = await client.get(
-                    f"{base_url.rstrip('/')}/models", headers=headers, timeout=30.0,
+                    models_endpoint(base_url),
+                    headers=headers,
+                    timeout=30.0,
                 )
                 response.raise_for_status()
                 data = response.json()
@@ -618,6 +626,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
 
     # Standard OpenAI-style API discovery
     discovery_url = url_map.get(provider)
+    if provider == "openai" and base_url:
+        discovery_url = models_endpoint(base_url)
     if not discovery_url or not api_key:
         return []
 

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -2,8 +2,11 @@
 
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
+
+from api import credentials_service
 
 
 @pytest.fixture
@@ -94,6 +97,95 @@ class TestCredentialCascadeDelete:
         mock_model.save.assert_awaited_once()
         assert mock_model.credential == "cred:456"
         mock_cred.delete.assert_awaited_once()
+
+
+class TestCredentialModelDiscovery:
+    """Tests for credential-backed model discovery."""
+
+    @pytest.mark.asyncio
+    async def test_openai_discovery_respects_base_url(self, monkeypatch):
+        """OpenAI model discovery should call the configured API base URL."""
+
+        requests = []
+
+        class FakeAsyncClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def get(self, url, headers=None, timeout=None):
+                requests.append(
+                    {
+                        "url": url,
+                        "headers": headers,
+                        "timeout": timeout,
+                    }
+                )
+                return httpx.Response(
+                    200,
+                    json={"data": [{"id": "custom-openai-model"}]},
+                    request=httpx.Request("GET", url, headers=headers or {}),
+                )
+
+        monkeypatch.setattr(credentials_service.httpx, "AsyncClient", FakeAsyncClient)
+
+        models = await credentials_service.discover_with_config(
+            "openai",
+            {
+                "api_key": "sk-test",
+                "base_url": "https://llm-gateway.example.com/v1",
+            },
+        )
+
+        assert models == [
+            {
+                "name": "custom-openai-model",
+                "provider": "openai",
+                "description": None,
+            }
+        ]
+        assert requests == [
+            {
+                "url": "https://llm-gateway.example.com/v1/models",
+                "headers": {"Authorization": "Bearer sk-test"},
+                "timeout": 30.0,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_model_discovery_base_url_can_include_models_path(self, monkeypatch):
+        """Model discovery should not append /models twice."""
+
+        requests = []
+
+        class FakeAsyncClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def get(self, url, headers=None, timeout=None):
+                requests.append(url)
+                return httpx.Response(
+                    200,
+                    json={"data": [{"id": "model-a"}]},
+                    request=httpx.Request("GET", url, headers=headers or {}),
+                )
+
+        monkeypatch.setattr(credentials_service.httpx, "AsyncClient", FakeAsyncClient)
+
+        await credentials_service.discover_with_config(
+            "openai_compatible",
+            {
+                "api_key": "sk-test",
+                "base_url": "https://llm-gateway.example.com/v1/models/",
+            },
+        )
+
+        assert requests == ["https://llm-gateway.example.com/v1/models"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use the configured OpenAI `base_url` for model discovery instead of always calling `https://api.openai.com/v1/models`
- avoid appending `/models` twice when an OpenAI-compatible endpoint already includes that path
- add regression coverage for OpenAI and OpenAI-compatible discovery URLs

## Validation
- `uv run pytest tests/test_credentials_api.py -q`
- `uv run ruff check api/credentials_service.py tests/test_credentials_api.py`

Fixes #676