### PR TITLE
fix(api): normalize openai_compatible provider name in models endpoint (fixes #792)

### DIFF
--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -414,7 +414,7 @@ async def get_provider_availability():
         )
 
         # OpenAI-compatible: DB credential or env vars
-        provider_status["openai-compatible"] = (
+        provider_status["openai_compatible"] = (
             await _check_provider_has_credential("openai_compatible")
             or _check_openai_compatible_support("LLM")
             or _check_openai_compatible_support("EMBEDDING")
@@ -442,12 +442,15 @@ async def get_provider_availability():
             }
 
             # Special handling for openai-compatible to check mode-specific availability
-            if provider == "openai-compatible":
+            if provider == "openai_compatible":
+                # Esperanto exposes this provider with a hyphen ("openai-compatible"),
+                # while the rest of the codebase uses the underscore form.
+                esperanto_name = "openai-compatible"
                 has_db_cred = await _check_provider_has_credential("openai_compatible")
                 for model_type, mode in mode_mapping.items():
                     if (
                         model_type in esperanto_available
-                        and provider in esperanto_available[model_type]
+                        and esperanto_name in esperanto_available[model_type]
                     ):
                         if has_db_cred or _check_openai_compatible_support(mode):
                             supported_types[provider].append(model_type)

--- a/tests/test_models_api.py
+++ b/tests/test_models_api.py
@@ -146,11 +146,11 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # openai-compatible should be available
-        assert "openai-compatible" in data["available"]
+        assert "openai_compatible" in data["available"]
 
         # Should support all 4 types
-        assert "openai-compatible" in data["supported_types"]
-        supported = data["supported_types"]["openai-compatible"]
+        assert "openai_compatible" in data["supported_types"]
+        supported = data["supported_types"]["openai_compatible"]
         assert "language" in supported
         assert "embedding" in supported
         assert "speech_to_text" in supported
@@ -188,11 +188,11 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # openai-compatible should be available
-        assert "openai-compatible" in data["available"]
+        assert "openai_compatible" in data["available"]
 
         # Should support only language and embedding
-        assert "openai-compatible" in data["supported_types"]
-        supported = data["supported_types"]["openai-compatible"]
+        assert "openai_compatible" in data["supported_types"]
+        supported = data["supported_types"]["openai_compatible"]
         assert "language" in supported
         assert "embedding" in supported
         assert "speech_to_text" not in supported
@@ -222,11 +222,11 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # openai-compatible should NOT be available
-        assert "openai-compatible" not in data["available"]
-        assert "openai-compatible" in data["unavailable"]
+        assert "openai_compatible" not in data["available"]
+        assert "openai_compatible" in data["unavailable"]
 
         # Should not have supported_types entry
-        assert "openai-compatible" not in data["supported_types"]
+        assert "openai_compatible" not in data["supported_types"]
 
     @patch("api.routers.models.os.environ.get")
     @patch("api.routers.models.AIFactory.get_available_providers")
@@ -259,11 +259,11 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # openai-compatible should be available
-        assert "openai-compatible" in data["available"]
+        assert "openai_compatible" in data["available"]
 
         # Generic var enables all, so all 4 should be supported
-        assert "openai-compatible" in data["supported_types"]
-        supported = data["supported_types"]["openai-compatible"]
+        assert "openai_compatible" in data["supported_types"]
+        supported = data["supported_types"]["openai_compatible"]
         assert "language" in supported
         assert "embedding" in supported
         assert "speech_to_text" in supported
@@ -297,7 +297,7 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # Should support only language
-        supported = data["supported_types"]["openai-compatible"]
+        supported = data["supported_types"]["openai_compatible"]
         assert supported == ["language"]
 
     @patch("api.routers.models.os.environ.get")
@@ -327,7 +327,7 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # Should support only embedding
-        supported = data["supported_types"]["openai-compatible"]
+        supported = data["supported_types"]["openai_compatible"]
         assert supported == ["embedding"]
 
     @patch("api.routers.models.os.environ.get")
@@ -357,7 +357,7 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # Should support only speech_to_text
-        supported = data["supported_types"]["openai-compatible"]
+        supported = data["supported_types"]["openai_compatible"]
         assert supported == ["speech_to_text"]
 
     @patch("api.routers.models.os.environ.get")
@@ -387,5 +387,5 @@ class TestModelsProviderAvailability:
         data = response.json()
 
         # Should support only text_to_speech
-        supported = data["supported_types"]["openai-compatible"]
+        supported = data["supported_types"]["openai_compatible"]
         assert supported == ["text_to_speech"]


### PR DESCRIPTION
## Summary

Fixes #792 — credentials created for the `openai-compatible` provider could not be tested or used because the provider name was spelled with a hyphen in `api/routers/models.py` but with an underscore everywhere else (allow-list, `credentials_service.py`, dispatch / test / discover branches, the frontend `api-keys/page.tsx`).

This PR aligns the two locations in `api/routers/models.py` to the underscore form (`openai_compatible`) used by the rest of the codebase.

## Changes

- `api/routers/models.py` L417: `provider_status["openai-compatible"]` → `provider_status["openai_compatible"]`
- `api/routers/models.py` L445: `if provider == "openai-compatible":` → `if provider == "openai_compatible":`
- Esperanto itself reports the OpenAI-compatible provider with a hyphen in `AIFactory.get_available_providers()` (confirmed against `esperanto==2.21.0`). Added a single `esperanto_name = "openai-compatible"` local at the Esperanto-boundary inside the special-case branch, with a comment, so the lookup against `esperanto_available[model_type]` still succeeds.
- `tests/test_models_api.py`: updated assertions on the API response payload to expect the underscore form. Mocked `esperanto_available` values keep the hyphen form (that's what real Esperanto returns).

## Test plan

- [x] All 8 tests in `tests/test_models_api.py::TestModelsProviderAvailability` pass.
- [x] Verified Esperanto returns `"openai-compatible"` (hyphen) in modality lists, so the normalization at the boundary is needed.
- [ ] Manual end-to-end smoke: create a credential via the UI for an OpenAI-compatible endpoint, click Test — should now succeed (or return the upstream auth/connection error) instead of failing with "Unknown provider: openai-compatible".

🤖 Generated with [Claude Code](https://claude.com/claude-code)