### PR TITLE
Add provider-agnostic video understanding for video sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ Thanks to the [Esperanto](https://github.com/lfnovo/esperanto) library, we suppo
 
 *Supports LM Studio and any OpenAI-compatible endpoint
 
+### Video Understanding
+
+Open Notebook now includes a first-class `video_understanding` model slot for enriching video sources with visual-semantic analysis during ingestion.
+
+- The current adapter is provider-neutral at the architecture level and currently targets **OpenAI-compatible** video-understanding endpoints as the first implementation.
+- Structured analysis is stored separately and rendered back into Markdown so existing search, embeddings, and chat flows remain compatible.
+- If no video-understanding model is configured, video sources continue to use the existing transcript-first flow.
+
+See [docs/5-CONFIGURATION/video-understanding.md](docs/5-CONFIGURATION/video-understanding.md) for setup details.
+
 ## ✨ Key Features
 
 ### Core Capabilities

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -75,7 +75,13 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "ollama": ["language", "embedding"],
     "vertex": ["language", "embedding"],
     "azure": ["language", "embedding", "speech_to_text", "text_to_speech"],
-    "openai_compatible": ["language", "embedding", "speech_to_text", "text_to_speech"],
+    "openai_compatible": [
+        "language",
+        "embedding",
+        "speech_to_text",
+        "text_to_speech",
+        "video_understanding",
+    ],
     "dashscope": ["language"],
     "minimax": ["language"],
 }

--- a/api/models.py
+++ b/api/models.py
@@ -66,7 +66,7 @@ class ModelCreate(BaseModel):
     )
     type: str = Field(
         ...,
-        description="Model type (language, embedding, text_to_speech, speech_to_text)",
+        description="Model type (language, embedding, text_to_speech, speech_to_text, video_understanding)",
     )
     credential: Optional[str] = Field(
         None, description="Credential ID to link this model to"
@@ -89,6 +89,7 @@ class DefaultModelsResponse(BaseModel):
     large_context_model: Optional[str] = None
     default_text_to_speech_model: Optional[str] = None
     default_speech_to_text_model: Optional[str] = None
+    default_video_understanding_model: Optional[str] = None
     default_embedding_model: Optional[str] = None
     default_tools_model: Optional[str] = None
 

--- a/api/models_service.py
+++ b/api/models_service.py
@@ -70,6 +70,9 @@ class ModelsService:
         defaults.default_speech_to_text_model = defaults_data.get(
             "default_speech_to_text_model"
         )
+        defaults.default_video_understanding_model = defaults_data.get(
+            "default_video_understanding_model"
+        )
         defaults.default_embedding_model = defaults_data.get("default_embedding_model")
         defaults.default_tools_model = defaults_data.get("default_tools_model")
 
@@ -83,6 +86,7 @@ class ModelsService:
             "large_context_model": defaults.large_context_model,
             "default_text_to_speech_model": defaults.default_text_to_speech_model,
             "default_speech_to_text_model": defaults.default_speech_to_text_model,
+            "default_video_understanding_model": defaults.default_video_understanding_model,
             "default_embedding_model": defaults.default_embedding_model,
             "default_tools_model": defaults.default_tools_model,
         }
@@ -101,6 +105,9 @@ class ModelsService:
         )
         defaults.default_speech_to_text_model = defaults_data.get(
             "default_speech_to_text_model"
+        )
+        defaults.default_video_understanding_model = defaults_data.get(
+            "default_video_understanding_model"
         )
         defaults.default_embedding_model = defaults_data.get("default_embedding_model")
         defaults.default_tools_model = defaults_data.get("default_tools_model")

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -13,7 +13,6 @@ from api.models import (
     ModelResponse,
     ProviderAvailabilityResponse,
 )
-from open_notebook.domain.credential import Credential
 from open_notebook.ai.connection_tester import test_individual_model
 from open_notebook.ai.key_provider import provision_provider_keys
 from open_notebook.ai.model_discovery import (
@@ -23,6 +22,7 @@ from open_notebook.ai.model_discovery import (
     sync_provider_models,
 )
 from open_notebook.ai.models import DefaultModels, Model
+from open_notebook.domain.credential import Credential
 from open_notebook.exceptions import InvalidInputError
 
 router = APIRouter()
@@ -199,7 +199,13 @@ async def create_model(model_data: ModelCreate):
     """Create a new model configuration."""
     try:
         # Validate model type
-        valid_types = ["language", "embedding", "text_to_speech", "speech_to_text"]
+        valid_types = [
+            "language",
+            "embedding",
+            "text_to_speech",
+            "speech_to_text",
+            "video_understanding",
+        ]
         if model_data.type not in valid_types:
             raise HTTPException(
                 status_code=400,
@@ -302,6 +308,7 @@ async def get_default_models():
             large_context_model=defaults.large_context_model,  # type: ignore[attr-defined]
             default_text_to_speech_model=defaults.default_text_to_speech_model,  # type: ignore[attr-defined]
             default_speech_to_text_model=defaults.default_speech_to_text_model,  # type: ignore[attr-defined]
+            default_video_understanding_model=defaults.default_video_understanding_model,  # type: ignore[attr-defined]
             default_embedding_model=defaults.default_embedding_model,  # type: ignore[attr-defined]
             default_tools_model=defaults.default_tools_model,  # type: ignore[attr-defined]
         )
@@ -335,6 +342,10 @@ async def update_default_models(defaults_data: DefaultModelsResponse):
             defaults.default_speech_to_text_model = (
                 defaults_data.default_speech_to_text_model
             )  # type: ignore[attr-defined]
+        if defaults_data.default_video_understanding_model is not None:
+            defaults.default_video_understanding_model = (
+                defaults_data.default_video_understanding_model
+            )  # type: ignore[attr-defined]
         if defaults_data.default_embedding_model is not None:
             defaults.default_embedding_model = defaults_data.default_embedding_model  # type: ignore[attr-defined]
         if defaults_data.default_tools_model is not None:
@@ -350,6 +361,7 @@ async def update_default_models(defaults_data: DefaultModelsResponse):
             large_context_model=defaults.large_context_model,  # type: ignore[attr-defined]
             default_text_to_speech_model=defaults.default_text_to_speech_model,  # type: ignore[attr-defined]
             default_speech_to_text_model=defaults.default_speech_to_text_model,  # type: ignore[attr-defined]
+            default_video_understanding_model=defaults.default_video_understanding_model,  # type: ignore[attr-defined]
             default_embedding_model=defaults.default_embedding_model,  # type: ignore[attr-defined]
             default_tools_model=defaults.default_tools_model,  # type: ignore[attr-defined]
         )
@@ -714,6 +726,7 @@ async def auto_assign_defaults():
             "embedding": [],
             "text_to_speech": [],
             "speech_to_text": [],
+            "video_understanding": [],
         }
 
         for model in all_models:
@@ -730,6 +743,7 @@ async def auto_assign_defaults():
             ("default_embedding_model", "embedding", defaults.default_embedding_model),  # type: ignore[attr-defined]
             ("default_text_to_speech_model", "text_to_speech", defaults.default_text_to_speech_model),  # type: ignore[attr-defined]
             ("default_speech_to_text_model", "speech_to_text", defaults.default_speech_to_text_model),  # type: ignore[attr-defined]
+            ("default_video_understanding_model", "video_understanding", defaults.default_video_understanding_model),  # type: ignore[attr-defined]
         ]
 
         assigned: Dict[str, str] = {}

--- a/docs/3-USER-GUIDE/adding-sources.md
+++ b/docs/3-USER-GUIDE/adding-sources.md
@@ -63,6 +63,8 @@ Sources are the raw materials of your research. This guide covers how to add dif
 
 **Automatic transcription**: Audio/video is transcribed to text automatically. This requires enabling speech-to-text in settings.
 
+**Optional video understanding**: If you configure a default `video_understanding` model, supported video URLs can also be enriched with visual-semantic analysis during ingestion.
+
 ### Web Content
 - **Articles**: Blog posts, news articles, Medium
 - **YouTube**: Full videos or playlists
@@ -89,15 +91,19 @@ The system automatically does four things:
    (PDFs get OCR if scanned)
    (Videos get transcribed if enabled)
 
-2. BREAK INTO CHUNKS
+2. OPTIONAL VIDEO ANALYSIS
+   Supported video URLs → Structured visual analysis
+   (Only when a default video-understanding model is configured)
+
+3. BREAK INTO CHUNKS
    Long text → ~500-word pieces
    (So search finds specific parts, not whole document)
 
-3. CREATE EMBEDDINGS
+4. CREATE EMBEDDINGS
    Each chunk → Vector representation
    (Enables semantic/concept search)
 
-4. INDEX & STORE
+5. INDEX & STORE
    Everything → Database
    (Ready to search and retrieve)
 ```

--- a/docs/5-CONFIGURATION/index.md
+++ b/docs/5-CONFIGURATION/index.md
@@ -218,6 +218,11 @@ OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
 ### [OpenAI-Compatible Providers](openai-compatible.md)
 - LM Studio, vLLM, Text Generation WebUI
 - Connection configuration
+
+### [Video Understanding](video-understanding.md)
+- Configure the `video_understanding` model slot
+- Understand current provider scope and fallbacks
+- Enable visual-semantic enrichment for video sources
 - Docker networking
 - Troubleshooting
 

--- a/docs/5-CONFIGURATION/video-understanding.md
+++ b/docs/5-CONFIGURATION/video-understanding.md
@@ -1,0 +1,84 @@
+# Video Understanding
+
+Open Notebook can now enrich video sources with **provider-configurable visual analysis** in addition to transcript text.
+
+---
+
+## What This Feature Does
+
+When a source is detected as a video and a default `video_understanding` model is configured, Open Notebook will:
+
+1. extract the usual transcript/text content;
+2. call the configured video-understanding provider;
+3. normalize the provider response into a structured analysis artifact;
+4. render that analysis back into Markdown so search, embeddings, and chat continue to work with the existing text-first pipeline.
+
+If no video-understanding model is configured, the existing transcript-first behavior is preserved.
+
+---
+
+## Current Scope
+
+The first implementation is intentionally conservative:
+
+- it adds a new model type: `video_understanding`
+- it adds a new default slot: `default_video_understanding_model`
+- it stores structured video-analysis artifacts in `source_analysis`
+- it currently supports **OpenAI-compatible** video-understanding endpoints as the first adapter
+
+This was designed so provider support can expand without changing the ingestion architecture.
+
+---
+
+## How To Configure
+
+### 1. Add a credential
+
+Go to:
+
+`Settings → API Keys → Add Credential`
+
+For the current implementation, add an **OpenAI-Compatible** credential with:
+
+- `Base URL`: your provider endpoint
+- `API Key`: your provider key, if required
+
+---
+
+### 2. Register a video-understanding model
+
+In the same Settings page:
+
+1. open the provider's **Models** dialog
+2. add or discover the model you want
+3. set its type to `video_understanding`
+
+For providers like Ark / Doubao, this is typically the endpoint or deployment name that exposes the video-understanding capability.
+
+---
+
+### 3. Set the default model
+
+In:
+
+`Settings → API Keys → Default Model Assignments`
+
+choose a model for:
+
+- `Video Understanding Model`
+
+---
+
+## Current Limitations
+
+- The first adapter expects a **directly accessible remote video URL** for video-understanding calls.
+- Local uploaded video files still fall back safely to the existing transcript-first flow if they cannot be sent to the provider directly.
+- This feature enriches **source ingestion**. It does **not** yet add direct raw-video chat sessions or a timeline playback UI.
+
+---
+
+## Recommended Provider Shape
+
+The current adapter targets **OpenAI-compatible Responses-style APIs** for video understanding.
+
+That keeps the architecture provider-neutral while allowing vendors such as Ark / Doubao to be used as the first implementation target.

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -19,7 +19,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
-  RefreshCw,
   Key,
   ShieldAlert,
   AlertTriangle,
@@ -37,6 +36,7 @@ import {
   Mic,
   Volume2,
   Bot,
+  Film,
 } from 'lucide-react'
 import { useTranslation } from '@/lib/hooks/use-translation'
 import { useModels, useDeleteModel, useModelDefaults, useUpdateModelDefaults, useAutoAssignDefaults, useTestModel } from '@/lib/hooks/use-models'
@@ -51,14 +51,13 @@ import {
   useTestCredential,
   useDiscoverModels,
   useRegisterModels,
-  useMigrateFromEnv,
 } from '@/lib/hooks/use-credentials'
 import { Credential, CreateCredentialRequest, UpdateCredentialRequest, DiscoveredModel } from '@/lib/api/credentials'
 import { Model, ModelDefaults } from '@/lib/types/models'
 import { MigrationBanner, ModelTestResultDialog } from '@/components/settings'
 import { EmbeddingModelChangeDialog } from '@/components/settings/EmbeddingModelChangeDialog'
 
-type ModelType = 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text'
+type ModelType = 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text' | 'video_understanding'
 
 // Provider display names
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
@@ -102,7 +101,7 @@ const PROVIDER_MODALITIES: Record<string, ModelType[]> = {
   ollama: ['language', 'embedding'],
   azure: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
   vertex: ['language', 'embedding', 'text_to_speech'],
-  openai_compatible: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
+  openai_compatible: ['language', 'embedding', 'text_to_speech', 'speech_to_text', 'video_understanding'],
   dashscope: ['language'],
   minimax: ['language'],
 }
@@ -131,6 +130,7 @@ const TYPE_ICONS: Record<ModelType, React.ReactNode> = {
   embedding: <Code className="h-3 w-3" />,
   text_to_speech: <Volume2 className="h-3 w-3" />,
   speech_to_text: <Mic className="h-3 w-3" />,
+  video_understanding: <Film className="h-3 w-3" />,
 }
 
 const TYPE_COLORS: Record<ModelType, string> = {
@@ -138,6 +138,7 @@ const TYPE_COLORS: Record<ModelType, string> = {
   embedding: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
   text_to_speech: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
   speech_to_text: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300',
+  video_understanding: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300',
 }
 
 const TYPE_COLOR_INACTIVE = 'bg-muted text-muted-foreground opacity-50'
@@ -147,6 +148,7 @@ const TYPE_LABELS: Record<ModelType, string> = {
   embedding: 'Embedding',
   text_to_speech: 'TTS',
   speech_to_text: 'STT',
+  video_understanding: 'Video',
 }
 
 // =============================================================================
@@ -783,6 +785,7 @@ function CredentialItem({
       'Embedding': defaults.default_embedding_model,
       'TTS': defaults.default_text_to_speech_model,
       'STT': defaults.default_speech_to_text_model,
+      'Video': defaults.default_video_understanding_model,
     }
     for (const [slot, modelId] of Object.entries(slotMap)) {
       if (modelId) defaultSlots[modelId] = slot
@@ -866,7 +869,7 @@ function CredentialItem({
         {/* Linked models grouped by type */}
         {linkedModels.length > 0 && (
           <div className="space-y-1.5 pt-1">
-            {(['language', 'embedding', 'text_to_speech', 'speech_to_text'] as ModelType[])
+            {(['language', 'embedding', 'text_to_speech', 'speech_to_text', 'video_understanding'] as ModelType[])
               .filter(type => linkedModels.some(m => m.type === type))
               .map(type => (
                 <div key={type} className="flex items-start gap-1.5">
@@ -1102,6 +1105,7 @@ function DefaultModelSelectors({
     { key: 'default_embedding_model', label: t('models.embeddingModelLabel'), description: t('models.embeddingModelDesc'), modelType: 'embedding', required: true, id: `${generatedId}-embed` },
     { key: 'default_text_to_speech_model', label: t('models.ttsModelLabel'), description: t('models.ttsModelDesc'), modelType: 'text_to_speech', id: `${generatedId}-tts` },
     { key: 'default_speech_to_text_model', label: t('models.sttModelLabel'), description: t('models.sttModelDesc'), modelType: 'speech_to_text', id: `${generatedId}-stt` },
+    { key: 'default_video_understanding_model', label: t('models.videoModelLabel'), description: t('models.videoModelDesc'), modelType: 'video_understanding', id: `${generatedId}-video` },
   ]
 
   const advancedConfigs: DefaultConfig[] = [

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -856,6 +856,8 @@ export const bnIN = {
     ttsModelDesc: "পডকাস্ট তৈরির জন্য ব্যবহৃত",
     sttModelLabel: "স্পিচ-টু-টেক্সট মডেল",
     sttModelDesc: "অডিও ট্রান্সক্রিপশনের জন্য ব্যবহৃত",
+    videoModelLabel: "ভিডিও আন্ডারস্ট্যান্ডিং মডেল",
+    videoModelDesc: "ভিডিও সোর্সে ভিজ্যুয়াল-সেম্যান্টিক বিশ্লেষণ যোগ করতে ব্যবহৃত হয়",
     embeddingChangeTitle: "এমবেডিং মডেল পরিবর্তন",
     embeddingChangeConfirm: "আপনি আপনার এমবেডিং মডেল {from} থেকে {to} তে পরিবর্তন করতে যাচ্ছেন।",
     rebuildRequired: "গুরুত্বপূর্ণ: পুনর্নির্মাণ প্রয়োজন",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -856,6 +856,8 @@ export const enUS = {
     ttsModelDesc: "Used for podcast generation",
     sttModelLabel: "Speech-to-Text Model",
     sttModelDesc: "Used for audio transcription",
+    videoModelLabel: "Video Understanding Model",
+    videoModelDesc: "Used to enrich video sources with visual-semantic analysis",
     embeddingChangeTitle: "Embedding Model Change",
     embeddingChangeConfirm: "You are about to change your embedding model from {from} to {to}.",
     rebuildRequired: "Important: Rebuild Required",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -856,6 +856,8 @@ export const esES = {
     ttsModelDesc: "Usado para generación de podcasts",
     sttModelLabel: "Modelo de voz a texto",
     sttModelDesc: "Usado para transcripción de audio",
+    videoModelLabel: "Modelo de comprensión de video",
+    videoModelDesc: "Usado para enriquecer fuentes de video con análisis visual y semántico",
     embeddingChangeTitle: "Cambio de modelo de embedding",
     embeddingChangeConfirm: "Estás a punto de cambiar tu modelo de embedding de {from} a {to}.",
     rebuildRequired: "Importante: Reconstrucción requerida",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -855,6 +855,8 @@ export const frFR = {
     ttsModelDesc: "Utilisé pour la génération de podcasts",
     sttModelLabel: "Modèle de Transcription Vocale (STT)",
     sttModelDesc: "Utilisé pour la transcription audio",
+    videoModelLabel: "Modèle de compréhension vidéo",
+    videoModelDesc: "Utilisé pour enrichir les sources vidéo avec une analyse visuelle et sémantique",
     embeddingChangeTitle: "Changement de modèle d'embedding",
     embeddingChangeConfirm: "Vous êtes sur le point de changer votre modèle d'embedding de {from} à {to}.",
     rebuildRequired: "Important : Reconstruction requise",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -855,6 +855,8 @@ export const itIT = {
     ttsModelDesc: "Usato per la generazione podcast",
     sttModelLabel: "Modello Speech-to-Text",
     sttModelDesc: "Usato per la trascrizione audio",
+    videoModelLabel: "Modello di comprensione video",
+    videoModelDesc: "Usato per arricchire le fonti video con analisi visiva e semantica",
     embeddingChangeTitle: "Cambio modello di embedding",
     embeddingChangeConfirm: "Stai per cambiare il modello di embedding da {from} a {to}.",
     rebuildRequired: "Importante: ricostruzione richiesta",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -855,6 +855,8 @@ export const jaJP = {
     ttsModelDesc: "ポッドキャスト生成に使用",
     sttModelLabel: "音声認識モデル",
     sttModelDesc: "音声の書き起こしに使用",
+    videoModelLabel: "動画理解モデル",
+    videoModelDesc: "動画ソースに視覚的・意味的分析を追加するために使用",
     embeddingChangeTitle: "Embeddingモデルの変更",
     embeddingChangeConfirm: "Embeddingモデルを{from}から{to}に変更しようとしています。",
     rebuildRequired: "重要：再構築が必要",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -855,6 +855,8 @@ export const ptBR = {
     ttsModelDesc: "Usado para geração de podcast",
     sttModelLabel: "Modelo Speech-to-Text",
     sttModelDesc: "Usado para transcrição de áudio",
+    videoModelLabel: "Modelo de entendimento de vídeo",
+    videoModelDesc: "Usado para enriquecer fontes de vídeo com análise visual e semântica",
     embeddingChangeTitle: "Alteração de Modelo de Embedding",
     embeddingChangeConfirm: "Você está prestes a alterar seu modelo de embedding de {from} para {to}.",
     rebuildRequired: "Importante: Reconstrução Necessária",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -855,6 +855,8 @@ export const ruRU = {
     ttsModelDesc: "Используется для генерации подкастов",
     sttModelLabel: "Модель распознавания речи",
     sttModelDesc: "Используется для транскрибации аудио",
+    videoModelLabel: "Модель понимания видео",
+    videoModelDesc: "Используется для обогащения видеоисточников визуально-семантическим анализом",
     embeddingChangeTitle: "Изменение модели эмбеддинга",
     embeddingChangeConfirm: "Вы собираетесь изменить модель эмбеддинга с {from} на {to}.",
     rebuildRequired: "Важно: Требуется пересоздание",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -855,6 +855,8 @@ export const zhCN = {
     ttsModelDesc: "用于生成播客",
     sttModelLabel: "语音转文字模型",
     sttModelDesc: "用于音频转录",
+    videoModelLabel: "视频理解模型",
+    videoModelDesc: "用于为视频来源增加视觉语义分析",
     embeddingChangeTitle: "嵌入模型变更",
     embeddingChangeConfirm: "您即将将嵌入模型从 {from} 更改为 {to}。",
     rebuildRequired: "重要提示：需要重建索引",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -855,6 +855,8 @@ export const zhTW = {
     ttsModelDesc: "用於生成播客",
     sttModelLabel: "語音轉文字模型",
     sttModelDesc: "用於音訊轉錄",
+    videoModelLabel: "影片理解模型",
+    videoModelDesc: "用於為影片來源增加視覺語義分析",
     embeddingChangeTitle: "嵌入模型變更",
     embeddingChangeConfirm: "您即將將嵌入模型從 {from} 更改為 {to}。",
     rebuildRequired: "重要提示：需要重建索引",

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -2,7 +2,7 @@ export interface Model {
   id: string
   name: string
   provider: string
-  type: 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text'
+  type: 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text' | 'video_understanding'
   credential?: string | null
   created: string
   updated: string
@@ -11,7 +11,7 @@ export interface Model {
 export interface CreateModelRequest {
   name: string
   provider: string
-  type: 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text'
+  type: 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text' | 'video_understanding'
   credential?: string
 }
 
@@ -21,6 +21,7 @@ export interface ModelDefaults {
   large_context_model?: string | null
   default_text_to_speech_model?: string | null
   default_speech_to_text_model?: string | null
+  default_video_understanding_model?: string | null
   default_embedding_model?: string | null
   default_tools_model?: string | null
 }
@@ -35,7 +36,7 @@ export interface ProviderAvailability {
 export interface DiscoveredModel {
   name: string
   provider: string
-  model_type: 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text'
+  model_type: 'language' | 'embedding' | 'text_to_speech' | 'speech_to_text' | 'video_understanding'
   description?: string
 }
 

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -387,8 +387,10 @@ async def test_individual_model(model) -> Tuple[bool, str]:
             )
 
             provider = await get_video_understanding_provider(model)
-            provider_name = getattr(provider, "__class__", type(provider)).__name__
-            return True, f"Video understanding adapter ready: {provider_name}"
+            success, message = await provider.test_connection()
+            if success:
+                return True, message
+            return False, message
 
         manager = ModelManager()
         esp_model = await manager.get_model(model.id)

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -381,6 +381,15 @@ async def test_individual_model(model) -> Tuple[bool, str]:
     from open_notebook.ai.models import ModelManager
 
     try:
+        if model.type == "video_understanding":
+            from open_notebook.multimodal.registry import (
+                get_video_understanding_provider,
+            )
+
+            provider = await get_video_understanding_provider(model)
+            provider_name = getattr(provider, "__class__", type(provider)).__name__
+            return True, f"Video understanding adapter ready: {provider_name}"
+
         manager = ModelManager()
         esp_model = await manager.get_model(model.id)
 

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -66,6 +66,7 @@ class DefaultModels(RecordModel):
     large_context_model: Optional[str] = None
     default_text_to_speech_model: Optional[str] = None
     default_speech_to_text_model: Optional[str] = None
+    default_video_understanding_model: Optional[str] = None
     # default_vision_model: Optional[str]
     default_embedding_model: Optional[str] = None
     default_tools_model: Optional[str] = None
@@ -217,6 +218,18 @@ class ModelManager:
             f"Expected EmbeddingModel but got {type(model)}"
         )
         return model
+
+    async def get_video_understanding_model_config(self) -> Optional[Model]:
+        """Get the configured default video understanding model record."""
+        defaults = await self.get_defaults()
+        model_id = defaults.default_video_understanding_model
+        if not model_id:
+            return None
+        try:
+            return await Model.get(model_id)
+        except Exception as e:
+            logger.error(f"Failed to load video understanding model '{model_id}': {e}")
+            return None
 
     async def get_default_model(self, model_type: str, **kwargs) -> Optional[ModelType]:
         """

--- a/open_notebook/database/migrations/15.surrealql
+++ b/open_notebook/database/migrations/15.surrealql
@@ -1,0 +1,11 @@
+-- Migration 15: structured source analyses for multimodal capabilities
+
+DEFINE TABLE IF NOT EXISTS source_analysis SCHEMALESS;
+DEFINE FIELD IF NOT EXISTS source ON TABLE source_analysis TYPE record<source>;
+DEFINE FIELD IF NOT EXISTS capability ON TABLE source_analysis TYPE string;
+DEFINE FIELD IF NOT EXISTS provider ON TABLE source_analysis TYPE string;
+DEFINE FIELD IF NOT EXISTS model ON TABLE source_analysis TYPE string;
+DEFINE FIELD IF NOT EXISTS status ON TABLE source_analysis TYPE string;
+DEFINE FIELD IF NOT EXISTS raw_output ON TABLE source_analysis TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS normalized_output ON TABLE source_analysis TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS rendered_markdown ON TABLE source_analysis TYPE option<string>;

--- a/open_notebook/database/migrations/15_down.surrealql
+++ b/open_notebook/database/migrations/15_down.surrealql
@@ -1,0 +1,3 @@
+-- Migration 15 rollback: remove structured source analyses
+
+REMOVE TABLE IF EXISTS source_analysis;

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -10,6 +10,7 @@ from surrealdb import RecordID
 
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.base import ObjectModel
+from open_notebook.domain.source_analysis import SourceAnalysis
 from open_notebook.exceptions import DatabaseOperationError, InvalidInputError
 
 
@@ -403,6 +404,45 @@ class Source(ObjectModel):
             logger.exception(e)
             raise DatabaseOperationError("Failed to fetch insights for source")
 
+    async def get_analyses(self, capability: Optional[str] = None) -> List[SourceAnalysis]:
+        try:
+            query = "SELECT * FROM source_analysis WHERE source=$id"
+            params = {"id": ensure_record_id(self.id)}
+            if capability:
+                query += " AND capability=$capability"
+                params["capability"] = capability
+            query += " ORDER BY updated DESC"
+            result = await repo_query(query, params)
+            return [SourceAnalysis(**analysis) for analysis in result]
+        except Exception as e:
+            logger.error(f"Error fetching analyses for source {self.id}: {str(e)}")
+            logger.exception(e)
+            raise DatabaseOperationError("Failed to fetch analyses for source")
+
+    async def save_analysis(
+        self,
+        *,
+        capability: str,
+        provider: str,
+        model: str,
+        status: str,
+        normalized_output: Optional[Dict[str, Any]] = None,
+        raw_output: Optional[Dict[str, Any]] = None,
+        rendered_markdown: Optional[str] = None,
+    ) -> SourceAnalysis:
+        analysis = SourceAnalysis(
+            source=str(self.id),
+            capability=capability,
+            provider=provider,
+            model=model,
+            status=status,
+            normalized_output=normalized_output,
+            raw_output=raw_output,
+            rendered_markdown=rendered_markdown,
+        )
+        await analysis.save()
+        return analysis
+
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
@@ -541,6 +581,10 @@ class Source(ObjectModel):
             )
             await repo_query(
                 "DELETE source_insight WHERE source = $source_id",
+                {"source_id": source_id},
+            )
+            await repo_query(
+                "DELETE source_analysis WHERE source = $source_id",
                 {"source_id": source_id},
             )
             logger.debug(f"Deleted embeddings and insights for source {self.id}")

--- a/open_notebook/domain/source_analysis.py
+++ b/open_notebook/domain/source_analysis.py
@@ -1,0 +1,37 @@
+from typing import Any, ClassVar, Dict, Optional
+
+from open_notebook.database.repository import ensure_record_id, repo_query
+from open_notebook.domain.base import ObjectModel
+from open_notebook.exceptions import DatabaseOperationError
+
+
+class SourceAnalysis(ObjectModel):
+    table_name: ClassVar[str] = "source_analysis"
+    nullable_fields: ClassVar[set[str]] = {
+        "raw_output",
+        "normalized_output",
+        "rendered_markdown",
+    }
+
+    source: str
+    capability: str
+    provider: str
+    model: str
+    status: str
+    raw_output: Optional[Dict[str, Any]] = None
+    normalized_output: Optional[Dict[str, Any]] = None
+    rendered_markdown: Optional[str] = None
+
+    def _prepare_save_data(self) -> Dict[str, Any]:
+        data = super()._prepare_save_data()
+        data["source"] = ensure_record_id(self.source)
+        return data
+
+    async def get_source(self):
+        try:
+            from open_notebook.domain.notebook import Source
+
+            source = await repo_query("SELECT * FROM $id", {"id": ensure_record_id(self.source)})
+            return Source(**source[0]) if source else None
+        except Exception as e:
+            raise DatabaseOperationError(e)

--- a/open_notebook/graphs/source.py
+++ b/open_notebook/graphs/source.py
@@ -86,26 +86,13 @@ async def content_process(state: SourceState) -> dict:
         # Continue without custom audio model (content-core will use its default)
 
     processed_state = await extract_content(content_state)
-
-    if not processed_state.content or not processed_state.content.strip():
-        url = processed_state.url or ""
-        if url and ("youtube.com" in url or "youtu.be" in url):
-            raise ValueError(
-                "Could not extract content from this YouTube video. "
-                "No transcript or subtitles are available. "
-                "Try configuring a Speech-to-Text model in Settings "
-                "to transcribe the audio instead."
-            )
-        raise ValueError(
-            "Could not extract any text content from this source. "
-            "The content may be empty, inaccessible, or in an unsupported format."
-        )
-
     response: dict[str, Any] = {"content_state": processed_state}
-
-    if video_model and is_video_source(
+    is_video = is_video_source(
         url=processed_state.url, file_path=processed_state.file_path
-    ):
+    )
+    has_text_content = bool(processed_state.content and processed_state.content.strip())
+
+    if video_model and is_video:
         try:
             provider = await get_video_understanding_provider(video_model)
             result = await provider.analyze(
@@ -129,6 +116,31 @@ async def content_process(state: SourceState) -> dict:
             logger.warning(
                 f"Video understanding failed for source {state['source_id']}: {e}"
             )
+
+    if not processed_state.content or not processed_state.content.strip():
+        url = processed_state.url or ""
+        if is_video and video_model:
+            raise ValueError(
+                "Could not extract any usable content from this video source. "
+                "Transcript extraction returned no text and video understanding "
+                "did not produce analysis output."
+            )
+        if url and ("youtube.com" in url or "youtu.be" in url):
+            raise ValueError(
+                "Could not extract content from this YouTube video. "
+                "No transcript or subtitles are available. "
+                "Try configuring a Speech-to-Text model in Settings "
+                "to transcribe the audio instead."
+            )
+        if is_video and not has_text_content:
+            raise ValueError(
+                "Could not extract any text content from this video source. "
+                "Configure Speech-to-Text or a Video Understanding model and try again."
+            )
+        raise ValueError(
+            "Could not extract any text content from this source. "
+            "The content may be empty, inaccessible, or in an unsupported format."
+        )
 
     return response
 

--- a/open_notebook/graphs/source.py
+++ b/open_notebook/graphs/source.py
@@ -19,6 +19,7 @@ from open_notebook.multimodal.registry import get_video_understanding_provider
 from open_notebook.multimodal.renderers.video_markdown import (
     render_video_understanding_markdown,
 )
+from open_notebook.multimodal.types import VideoUnderstandingInput
 
 
 class SourceState(TypedDict):
@@ -178,6 +179,18 @@ async def save_source(state: SourceState) -> dict:
     return {"source": source}
 
 
+def dict_to_video_input(
+    processed_state: ProcessSourceState, source_id: str
+) -> VideoUnderstandingInput:
+    return VideoUnderstandingInput(
+        source_id=source_id,
+        title=processed_state.title,
+        url=processed_state.url,
+        file_path=processed_state.file_path,
+        transcript_markdown=processed_state.content,
+    )
+
+
 def trigger_transformations(state: SourceState, config: RunnableConfig) -> List[Send]:
     if len(state["apply_transformations"]) == 0:
         return []
@@ -236,15 +249,3 @@ workflow.add_edge("transform_content", END)
 
 # Compile the graph
 source_graph = workflow.compile()
-
-
-def dict_to_video_input(processed_state: ProcessSourceState, source_id: str):
-    from open_notebook.multimodal.types import VideoUnderstandingInput
-
-    return VideoUnderstandingInput(
-        source_id=source_id,
-        title=processed_state.title,
-        url=processed_state.url,
-        file_path=processed_state.file_path,
-        transcript_markdown=processed_state.content,
-    )

--- a/open_notebook/graphs/source.py
+++ b/open_notebook/graphs/source.py
@@ -14,6 +14,11 @@ from open_notebook.domain.content_settings import ContentSettings
 from open_notebook.domain.notebook import Asset, Source
 from open_notebook.domain.transformation import Transformation
 from open_notebook.graphs.transformation import graph as transform_graph
+from open_notebook.multimodal.detector import is_video_source
+from open_notebook.multimodal.registry import get_video_understanding_provider
+from open_notebook.multimodal.renderers.video_markdown import (
+    render_video_understanding_markdown,
+)
 
 
 class SourceState(TypedDict):
@@ -24,6 +29,7 @@ class SourceState(TypedDict):
     source: Source
     transformation: Annotated[list, operator.add]
     embed: bool
+    video_understanding: Optional[dict]
 
 
 class TransformationState(TypedDict):
@@ -59,6 +65,8 @@ async def content_process(state: SourceState) -> dict:
     )
     content_state["output_format"] = "markdown"
 
+    video_model: Optional[Model] = None
+
     # Add speech-to-text model configuration from Default Models
     try:
         model_manager = ModelManager()
@@ -71,6 +79,7 @@ async def content_process(state: SourceState) -> dict:
                 logger.debug(
                     f"Using speech-to-text model: {stt_model.provider}/{stt_model.name}"
                 )
+        video_model = await model_manager.get_video_understanding_model_config()
     except Exception as e:
         logger.warning(f"Failed to retrieve speech-to-text model configuration: {e}")
         # Continue without custom audio model (content-core will use its default)
@@ -91,7 +100,36 @@ async def content_process(state: SourceState) -> dict:
             "The content may be empty, inaccessible, or in an unsupported format."
         )
 
-    return {"content_state": processed_state}
+    response: dict[str, Any] = {"content_state": processed_state}
+
+    if video_model and is_video_source(
+        url=processed_state.url, file_path=processed_state.file_path
+    ):
+        try:
+            provider = await get_video_understanding_provider(video_model)
+            result = await provider.analyze(
+                dict_to_video_input(processed_state, source_id=state["source_id"])
+            )
+            markdown = render_video_understanding_markdown(result)
+            merged_content = processed_state.content.rstrip()
+            if merged_content:
+                merged_content = f"{merged_content}\n\n{markdown}"
+            else:
+                merged_content = markdown
+            processed_state.content = merged_content
+            response["video_understanding"] = {
+                "normalized": result.model_dump(exclude={"raw_response"}),
+                "raw_output": result.raw_response,
+                "rendered_markdown": markdown,
+            }
+        except ValueError as e:
+            logger.info(f"Video understanding skipped for source {state['source_id']}: {e}")
+        except Exception as e:
+            logger.warning(
+                f"Video understanding failed for source {state['source_id']}: {e}"
+            )
+
+    return response
 
 
 async def save_source(state: SourceState) -> dict:
@@ -111,6 +149,19 @@ async def save_source(state: SourceState) -> dict:
         source.title = content_state.title
 
     await source.save()
+
+    analysis_data = state.get("video_understanding")
+    if analysis_data:
+        normalized_output = analysis_data.get("normalized", {})
+        await source.save_analysis(
+            capability="video_understanding",
+            provider=normalized_output.get("provider", "unknown"),
+            model=normalized_output.get("model", "unknown"),
+            status="completed",
+            normalized_output=normalized_output,
+            raw_output=analysis_data.get("raw_output"),
+            rendered_markdown=analysis_data.get("rendered_markdown"),
+        )
 
     # NOTE: Notebook associations are created by the API immediately for UI responsiveness
     # No need to create them here to avoid duplicate edges
@@ -185,3 +236,15 @@ workflow.add_edge("transform_content", END)
 
 # Compile the graph
 source_graph = workflow.compile()
+
+
+def dict_to_video_input(processed_state: ProcessSourceState, source_id: str):
+    from open_notebook.multimodal.types import VideoUnderstandingInput
+
+    return VideoUnderstandingInput(
+        source_id=source_id,
+        title=processed_state.title,
+        url=processed_state.url,
+        file_path=processed_state.file_path,
+        transcript_markdown=processed_state.content,
+    )

--- a/open_notebook/multimodal/__init__.py
+++ b/open_notebook/multimodal/__init__.py
@@ -1,0 +1,17 @@
+"""Provider-neutral multimodal capability interfaces."""
+
+from open_notebook.multimodal.base import VideoUnderstandingProvider
+from open_notebook.multimodal.types import (
+    VideoEntity,
+    VideoTimelineSegment,
+    VideoUnderstandingInput,
+    VideoUnderstandingResult,
+)
+
+__all__ = [
+    "VideoUnderstandingProvider",
+    "VideoEntity",
+    "VideoTimelineSegment",
+    "VideoUnderstandingInput",
+    "VideoUnderstandingResult",
+]

--- a/open_notebook/multimodal/base.py
+++ b/open_notebook/multimodal/base.py
@@ -14,3 +14,12 @@ class VideoUnderstandingProvider(ABC):
         self, input_data: VideoUnderstandingInput
     ) -> VideoUnderstandingResult:
         """Analyze a video source and return a normalized result."""
+
+    async def test_connection(self) -> tuple[bool, str]:
+        """
+        Validate provider connectivity for Settings model tests.
+
+        Providers should override this when they can perform a lightweight
+        authenticated request without requiring a real video input.
+        """
+        raise NotImplementedError("Connection testing is not implemented")

--- a/open_notebook/multimodal/base.py
+++ b/open_notebook/multimodal/base.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+from open_notebook.multimodal.types import (
+    VideoUnderstandingInput,
+    VideoUnderstandingResult,
+)
+
+
+class VideoUnderstandingProvider(ABC):
+    """Abstract interface for provider-specific video understanding adapters."""
+
+    @abstractmethod
+    async def analyze(
+        self, input_data: VideoUnderstandingInput
+    ) -> VideoUnderstandingResult:
+        """Analyze a video source and return a normalized result."""

--- a/open_notebook/multimodal/detector.py
+++ b/open_notebook/multimodal/detector.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mpeg", ".mpg"}
+VIDEO_HOST_HINTS = ("youtube.com", "youtu.be", "vimeo.com", "bilibili.com")
+
+
+def _has_video_extension(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    suffix = Path(urlparse(value).path).suffix.lower()
+    return suffix in VIDEO_EXTENSIONS
+
+
+def is_video_source(url: Optional[str] = None, file_path: Optional[str] = None) -> bool:
+    if _has_video_extension(file_path) or _has_video_extension(url):
+        return True
+    if not url:
+        return False
+    hostname = (urlparse(url).hostname or "").lower()
+    return any(hint in hostname for hint in VIDEO_HOST_HINTS)

--- a/open_notebook/multimodal/detector.py
+++ b/open_notebook/multimodal/detector.py
@@ -19,4 +19,8 @@ def is_video_source(url: Optional[str] = None, file_path: Optional[str] = None) 
     if not url:
         return False
     hostname = (urlparse(url).hostname or "").lower()
-    return any(hint in hostname for hint in VIDEO_HOST_HINTS)
+    return any(_hostname_matches_hint(hostname, hint) for hint in VIDEO_HOST_HINTS)
+
+
+def _hostname_matches_hint(hostname: str, hint: str) -> bool:
+    return hostname == hint or hostname.endswith(f".{hint}")

--- a/open_notebook/multimodal/providers/__init__.py
+++ b/open_notebook/multimodal/providers/__init__.py
@@ -1,0 +1,7 @@
+"""Provider implementations for multimodal analysis."""
+
+from open_notebook.multimodal.providers.openai_compatible_video import (
+    OpenAICompatibleVideoProvider,
+)
+
+__all__ = ["OpenAICompatibleVideoProvider"]

--- a/open_notebook/multimodal/providers/openai_compatible_video.py
+++ b/open_notebook/multimodal/providers/openai_compatible_video.py
@@ -1,0 +1,203 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from open_notebook.exceptions import ConfigurationError
+from open_notebook.multimodal.base import VideoUnderstandingProvider
+from open_notebook.multimodal.types import (
+    VideoEntity,
+    VideoTimelineSegment,
+    VideoUnderstandingInput,
+    VideoUnderstandingResult,
+)
+
+
+class OpenAICompatibleVideoProvider(VideoUnderstandingProvider):
+    """
+    Video understanding adapter for OpenAI-compatible Responses-style APIs.
+
+    The first target is Ark/Doubao's video understanding capability, but the
+    adapter is intentionally written against a generic OpenAI-compatible
+    request/response shape so it can support other providers later.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        base_url: Optional[str],
+        api_key: Optional[str] = None,
+        timeout: float = 180.0,
+    ):
+        if not base_url:
+            raise ConfigurationError(
+                "OpenAI-compatible video understanding requires a base_url"
+            )
+        self.model_name = model_name
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+
+    async def analyze(
+        self, input_data: VideoUnderstandingInput
+    ) -> VideoUnderstandingResult:
+        if not input_data.url:
+            raise ValueError(
+                "Video understanding currently requires a directly accessible video URL"
+            )
+
+        payload = self._build_payload(input_data)
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.base_url}/responses",
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
+            body = response.json()
+
+        return self._normalize_response(body, transcript_used=bool(input_data.transcript_markdown))
+
+    def _build_payload(self, input_data: VideoUnderstandingInput) -> Dict[str, Any]:
+        transcript = input_data.transcript_markdown or ""
+        prompt = (
+            "Analyze this video as research source material. "
+            "Return strict JSON with keys summary, key_events, entities, and timeline. "
+            "Each timeline item should include start_seconds, end_seconds, title, description. "
+            "Each entity should include name, entity_type, description. "
+            "Focus on visual events, scene changes, on-screen text, and actions."
+        )
+        if transcript:
+            prompt += (
+                "\n\nA transcript is available. Use it only as supporting context and "
+                "prioritize visual evidence when they differ.\n\nTranscript:\n"
+                f"{transcript[:12000]}"
+            )
+
+        return {
+            "model": self.model_name,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": prompt},
+                        {"type": "input_video", "video_url": input_data.url},
+                    ],
+                }
+            ],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "video_understanding",
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "summary": {"type": "string"},
+                            "key_events": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "entities": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "entity_type": {
+                                            "type": ["string", "null"]
+                                        },
+                                        "description": {
+                                            "type": ["string", "null"]
+                                        },
+                                    },
+                                    "required": ["name", "entity_type", "description"],
+                                },
+                            },
+                            "timeline": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "start_seconds": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "end_seconds": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "title": {"type": ["string", "null"]},
+                                        "description": {"type": "string"},
+                                    },
+                                    "required": [
+                                        "start_seconds",
+                                        "end_seconds",
+                                        "title",
+                                        "description",
+                                    ],
+                                },
+                            },
+                        },
+                        "required": ["summary", "key_events", "entities", "timeline"],
+                    },
+                }
+            },
+        }
+
+    def _normalize_response(
+        self, body: Dict[str, Any], *, transcript_used: bool
+    ) -> VideoUnderstandingResult:
+        payload = self._extract_json_payload(body)
+        entities = [
+            VideoEntity(
+                name=item.get("name", "Unknown"),
+                entity_type=item.get("entity_type"),
+                description=item.get("description"),
+            )
+            for item in payload.get("entities", [])
+        ]
+        timeline = [
+            VideoTimelineSegment(
+                start_seconds=item.get("start_seconds"),
+                end_seconds=item.get("end_seconds"),
+                title=item.get("title"),
+                description=item.get("description", ""),
+            )
+            for item in payload.get("timeline", [])
+        ]
+        return VideoUnderstandingResult(
+            summary=payload.get("summary", "").strip() or "No summary returned.",
+            key_events=_coerce_list(payload.get("key_events")),
+            entities=entities,
+            timeline=timeline,
+            transcript_used=transcript_used,
+            provider="openai_compatible",
+            model=self.model_name,
+            raw_response=body,
+        )
+
+    def _extract_json_payload(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        output = body.get("output", [])
+        for item in output:
+            for content in item.get("content", []):
+                if content.get("type") == "output_text":
+                    text = content.get("text")
+                    if isinstance(text, str):
+                        import json
+
+                        return json.loads(text)
+        raise ValueError("Provider response did not contain structured output_text")
+
+
+def _coerce_list(value: Any) -> List[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if value is None:
+        return []
+    return [str(value)]

--- a/open_notebook/multimodal/providers/openai_compatible_video.py
+++ b/open_notebook/multimodal/providers/openai_compatible_video.py
@@ -76,7 +76,15 @@ class OpenAICompatibleVideoProvider(VideoUnderstandingProvider):
                 data = response.json()
                 models = data.get("data", [])
                 if models:
-                    return True, f"Connected. {len(models)} models available."
+                    if any(
+                        model.get("id") == self.model_name
+                        for model in models
+                        if isinstance(model, dict)
+                    ):
+                        return True, f"Connected. {len(models)} models available."
+                    return False, (
+                        f"Connected but model '{self.model_name}' was not found on this provider."
+                    )
                 return True, "Connected successfully (no models listed)"
             if response.status_code == 401:
                 return False, "Invalid API key"

--- a/open_notebook/multimodal/providers/openai_compatible_video.py
+++ b/open_notebook/multimodal/providers/openai_compatible_video.py
@@ -1,4 +1,4 @@
-import os
+import json
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -62,6 +62,33 @@ class OpenAICompatibleVideoProvider(VideoUnderstandingProvider):
             body = response.json()
 
         return self._normalize_response(body, transcript_used=bool(input_data.transcript_markdown))
+
+    async def test_connection(self) -> tuple[bool, str]:
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            async with httpx.AsyncClient(timeout=min(self.timeout, 10.0)) as client:
+                response = await client.get(f"{self.base_url}/models", headers=headers)
+
+            if response.status_code == 200:
+                data = response.json()
+                models = data.get("data", [])
+                if models:
+                    return True, f"Connected. {len(models)} models available."
+                return True, "Connected successfully (no models listed)"
+            if response.status_code == 401:
+                return False, "Invalid API key"
+            if response.status_code == 403:
+                return False, "API key lacks required permissions"
+            return False, f"Server returned status {response.status_code}"
+        except httpx.ConnectError:
+            return False, "Cannot connect to server. Check the URL is correct."
+        except httpx.TimeoutException:
+            return False, "Connection timed out. Check if server is accessible."
+        except Exception as e:
+            return False, f"Connection error: {str(e)[:100]}"
 
     def _build_payload(self, input_data: VideoUnderstandingInput) -> Dict[str, Any]:
         transcript = input_data.transcript_markdown or ""
@@ -189,8 +216,6 @@ class OpenAICompatibleVideoProvider(VideoUnderstandingProvider):
                 if content.get("type") == "output_text":
                     text = content.get("text")
                     if isinstance(text, str):
-                        import json
-
                         return json.loads(text)
         raise ValueError("Provider response did not contain structured output_text")
 

--- a/open_notebook/multimodal/registry.py
+++ b/open_notebook/multimodal/registry.py
@@ -1,0 +1,34 @@
+import os
+
+from open_notebook.ai.key_provider import provision_provider_keys
+from open_notebook.ai.models import Model
+from open_notebook.exceptions import ConfigurationError
+from open_notebook.multimodal.base import VideoUnderstandingProvider
+from open_notebook.multimodal.providers.openai_compatible_video import (
+    OpenAICompatibleVideoProvider,
+)
+
+
+async def get_video_understanding_provider(
+    model: Model,
+) -> VideoUnderstandingProvider:
+    provider = model.provider.replace("-", "_").lower()
+
+    config: dict = {}
+    if model.credential:
+        credential = await model.get_credential_obj()
+        if credential:
+            config = credential.to_esperanto_config()
+    else:
+        await provision_provider_keys(provider)
+
+    if provider == "openai_compatible":
+        return OpenAICompatibleVideoProvider(
+            model_name=model.name,
+            base_url=config.get("base_url") or os.environ.get("OPENAI_COMPATIBLE_BASE_URL"),
+            api_key=config.get("api_key") or os.environ.get("OPENAI_COMPATIBLE_API_KEY"),
+        )
+
+    raise ConfigurationError(
+        f"Provider '{model.provider}' does not support video_understanding yet"
+    )

--- a/open_notebook/multimodal/renderers/video_markdown.py
+++ b/open_notebook/multimodal/renderers/video_markdown.py
@@ -1,0 +1,54 @@
+from open_notebook.multimodal.types import VideoUnderstandingResult
+
+
+def _format_timestamp(seconds: float | None) -> str:
+    if seconds is None:
+        return ""
+    total = int(seconds)
+    minutes, secs = divmod(total, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def render_video_understanding_markdown(result: VideoUnderstandingResult) -> str:
+    lines = [
+        "# Video Understanding",
+        "",
+        "## Overview",
+        result.summary.strip(),
+        "",
+        "## Analysis Metadata",
+        f"- Provider: {result.provider}",
+        f"- Model: {result.model}",
+        f"- Transcript used: {'yes' if result.transcript_used else 'no'}",
+        "",
+    ]
+
+    if result.key_events:
+        lines.extend(["## Key Events"])
+        lines.extend(f"- {event}" for event in result.key_events)
+        lines.append("")
+
+    if result.timeline:
+        lines.extend(["## Timeline"])
+        for segment in result.timeline:
+            start = _format_timestamp(segment.start_seconds)
+            end = _format_timestamp(segment.end_seconds)
+            prefix = ""
+            if start or end:
+                prefix = f"[{start or '--'} - {end or '--'}] "
+            title = f"{segment.title}: " if segment.title else ""
+            lines.append(f"- {prefix}{title}{segment.description}")
+        lines.append("")
+
+    if result.entities:
+        lines.extend(["## Entities"])
+        for entity in result.entities:
+            detail = f" ({entity.entity_type})" if entity.entity_type else ""
+            description = f": {entity.description}" if entity.description else ""
+            lines.append(f"- {entity.name}{detail}{description}")
+        lines.append("")
+
+    return "\n".join(lines).strip()

--- a/open_notebook/multimodal/types.py
+++ b/open_notebook/multimodal/types.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VideoUnderstandingInput(BaseModel):
+    source_id: Optional[str] = None
+    title: Optional[str] = None
+    url: Optional[str] = None
+    file_path: Optional[str] = None
+    transcript_markdown: Optional[str] = None
+
+
+class VideoTimelineSegment(BaseModel):
+    start_seconds: Optional[float] = None
+    end_seconds: Optional[float] = None
+    title: Optional[str] = None
+    description: str
+
+
+class VideoEntity(BaseModel):
+    name: str
+    entity_type: Optional[str] = None
+    description: Optional[str] = None
+
+
+class VideoUnderstandingResult(BaseModel):
+    summary: str
+    timeline: List[VideoTimelineSegment] = Field(default_factory=list)
+    entities: List[VideoEntity] = Field(default_factory=list)
+    key_events: List[str] = Field(default_factory=list)
+    transcript_used: bool = False
+    provider: str
+    model: str
+    raw_response: Optional[Dict[str, Any]] = None

--- a/tests/test_connection_tester_video.py
+++ b/tests/test_connection_tester_video.py
@@ -1,0 +1,29 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_notebook.ai.connection_tester import (
+    test_individual_model as run_individual_model_test,
+)
+
+
+@pytest.mark.asyncio
+@patch("open_notebook.multimodal.registry.get_video_understanding_provider", new_callable=AsyncMock)
+async def test_test_individual_model_uses_real_video_provider_connection(
+    mock_get_provider,
+):
+    provider = AsyncMock()
+    provider.test_connection.return_value = (True, "Connected. 1 models available.")
+    mock_get_provider.return_value = provider
+
+    model = type(
+        "ModelStub",
+        (),
+        {"type": "video_understanding", "id": "model:1", "provider": "openai_compatible"},
+    )()
+
+    success, message = await run_individual_model_test(model)
+
+    assert success is True
+    assert "Connected." in message
+    provider.test_connection.assert_awaited_once()

--- a/tests/test_models_api.py
+++ b/tests/test_models_api.py
@@ -115,6 +115,26 @@ class TestModelCreation:
             # Should succeed because type is different
             assert response.status_code == 200
 
+    @pytest.mark.asyncio
+    @patch("open_notebook.database.repository.repo_query")
+    async def test_create_video_understanding_model(self, mock_repo_query, client):
+        """Test that video_understanding is accepted as a model type."""
+        from open_notebook.ai.models import Model
+
+        mock_repo_query.return_value = []
+
+        with patch.object(Model, "save", new_callable=AsyncMock):
+            response = client.post(
+                "/api/models",
+                json={
+                    "name": "ep-video",
+                    "provider": "openai_compatible",
+                    "type": "video_understanding",
+                },
+            )
+
+            assert response.status_code == 200
+
 
 class TestModelsProviderAvailability:
     """Test suite for Models Provider Availability endpoint."""

--- a/tests/test_multimodal_detector.py
+++ b/tests/test_multimodal_detector.py
@@ -1,0 +1,15 @@
+from open_notebook.multimodal.detector import is_video_source
+
+
+def test_detects_video_by_extension():
+    assert is_video_source(url="https://example.com/demo.mp4")
+    assert is_video_source(file_path="/tmp/video.MOV")
+
+
+def test_detects_video_by_known_host():
+    assert is_video_source(url="https://www.youtube.com/watch?v=abc123")
+
+
+def test_ignores_non_video_sources():
+    assert not is_video_source(url="https://example.com/doc.pdf")
+    assert not is_video_source(file_path="/tmp/notes.txt")

--- a/tests/test_multimodal_detector.py
+++ b/tests/test_multimodal_detector.py
@@ -8,8 +8,12 @@ def test_detects_video_by_extension():
 
 def test_detects_video_by_known_host():
     assert is_video_source(url="https://www.youtube.com/watch?v=abc123")
+    assert is_video_source(url="https://m.youtube.com/watch?v=abc123")
 
 
 def test_ignores_non_video_sources():
     assert not is_video_source(url="https://example.com/doc.pdf")
     assert not is_video_source(file_path="/tmp/notes.txt")
+    assert not is_video_source(url="https://notyoutube.com/watch?v=abc123")
+    assert not is_video_source(url="https://youtube.com.evil.org/watch?v=abc123")
+    assert not is_video_source(url="https://vimeo.com.cn/clip")

--- a/tests/test_openai_compatible_video_provider.py
+++ b/tests/test_openai_compatible_video_provider.py
@@ -1,0 +1,81 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_notebook.multimodal.providers.openai_compatible_video import (
+    OpenAICompatibleVideoProvider,
+)
+from open_notebook.multimodal.types import VideoUnderstandingInput
+
+
+@pytest.mark.asyncio
+@patch("open_notebook.multimodal.providers.openai_compatible_video.httpx.AsyncClient")
+async def test_openai_compatible_video_provider_normalizes_response(mock_client_cls):
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "output": [
+            {
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": json.dumps(
+                            {
+                                "summary": "Video summary",
+                                "key_events": ["Event A"],
+                                "entities": [
+                                    {
+                                        "name": "Object A",
+                                        "entity_type": "object",
+                                        "description": "Detected object",
+                                    }
+                                ],
+                                "timeline": [
+                                    {
+                                        "start_seconds": 1,
+                                        "end_seconds": 5,
+                                        "title": "Segment",
+                                        "description": "What happens",
+                                    }
+                                ],
+                            }
+                        ),
+                    }
+                ]
+            }
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+    provider = OpenAICompatibleVideoProvider(
+        model_name="video-model",
+        base_url="https://example.com/v1",
+        api_key="secret",
+    )
+    result = await provider.analyze(
+        VideoUnderstandingInput(
+            url="https://cdn.example.com/video.mp4",
+            transcript_markdown="Transcript",
+        )
+    )
+
+    assert result.summary == "Video summary"
+    assert result.provider == "openai_compatible"
+    assert result.transcript_used is True
+    assert result.timeline[0].title == "Segment"
+    assert result.entities[0].name == "Object A"
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_video_provider_requires_url():
+    provider = OpenAICompatibleVideoProvider(
+        model_name="video-model",
+        base_url="https://example.com/v1",
+    )
+
+    with pytest.raises(ValueError, match="directly accessible video URL"):
+        await provider.analyze(VideoUnderstandingInput(file_path="/tmp/local.mp4"))

--- a/tests/test_openai_compatible_video_provider.py
+++ b/tests/test_openai_compatible_video_provider.py
@@ -79,3 +79,24 @@ async def test_openai_compatible_video_provider_requires_url():
 
     with pytest.raises(ValueError, match="directly accessible video URL"):
         await provider.analyze(VideoUnderstandingInput(file_path="/tmp/local.mp4"))
+
+
+@pytest.mark.asyncio
+@patch("open_notebook.multimodal.providers.openai_compatible_video.httpx.AsyncClient")
+async def test_openai_compatible_video_provider_test_connection(mock_client_cls):
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"data": [{"id": "video-model"}]}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+    provider = OpenAICompatibleVideoProvider(
+        model_name="video-model",
+        base_url="https://example.com/v1",
+        api_key="secret",
+    )
+    success, message = await provider.test_connection()
+
+    assert success is True
+    assert "Connected." in message

--- a/tests/test_openai_compatible_video_provider.py
+++ b/tests/test_openai_compatible_video_provider.py
@@ -100,3 +100,26 @@ async def test_openai_compatible_video_provider_test_connection(mock_client_cls)
 
     assert success is True
     assert "Connected." in message
+
+
+@pytest.mark.asyncio
+@patch("open_notebook.multimodal.providers.openai_compatible_video.httpx.AsyncClient")
+async def test_openai_compatible_video_provider_test_connection_fails_when_model_missing(
+    mock_client_cls,
+):
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"data": [{"id": "other-model"}]}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+    provider = OpenAICompatibleVideoProvider(
+        model_name="video-model",
+        base_url="https://example.com/v1",
+        api_key="secret",
+    )
+    success, message = await provider.test_connection()
+
+    assert success is False
+    assert "video-model" in message

--- a/tests/test_source_analysis_domain.py
+++ b/tests/test_source_analysis_domain.py
@@ -1,0 +1,28 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_notebook.domain.notebook import Source
+
+
+@pytest.mark.asyncio
+async def test_source_save_analysis_creates_source_analysis():
+    source = Source(id="source:123", title="Video source")
+
+    with patch(
+        "open_notebook.domain.source_analysis.SourceAnalysis.save",
+        new_callable=AsyncMock,
+    ) as mock_save:
+        analysis = await source.save_analysis(
+            capability="video_understanding",
+            provider="openai_compatible",
+            model="video-model",
+            status="completed",
+            normalized_output={"summary": "Done"},
+            raw_output={"raw": True},
+            rendered_markdown="# Video Understanding",
+        )
+
+    mock_save.assert_awaited_once()
+    assert analysis.source == "source:123"
+    assert analysis.capability == "video_understanding"

--- a/tests/test_video_markdown_renderer.py
+++ b/tests/test_video_markdown_renderer.py
@@ -1,0 +1,37 @@
+from open_notebook.multimodal.renderers.video_markdown import (
+    render_video_understanding_markdown,
+)
+from open_notebook.multimodal.types import (
+    VideoEntity,
+    VideoTimelineSegment,
+    VideoUnderstandingResult,
+)
+
+
+def test_render_video_understanding_markdown():
+    result = VideoUnderstandingResult(
+        summary="A short overview.",
+        key_events=["Opening scene", "Key demonstration"],
+        entities=[
+            VideoEntity(name="Laser", entity_type="object", description="Bright beam")
+        ],
+        timeline=[
+            VideoTimelineSegment(
+                start_seconds=0,
+                end_seconds=12,
+                title="Intro",
+                description="Presenter introduces the experiment.",
+            )
+        ],
+        transcript_used=True,
+        provider="openai_compatible",
+        model="ep-demo",
+    )
+
+    markdown = render_video_understanding_markdown(result)
+
+    assert "# Video Understanding" in markdown
+    assert "## Overview" in markdown
+    assert "Opening scene" in markdown
+    assert "[00:00 - 00:12] Intro: Presenter introduces the experiment." in markdown
+    assert "Laser (object): Bright beam" in markdown

--- a/tests/test_video_understanding_ingestion.py
+++ b/tests/test_video_understanding_ingestion.py
@@ -60,6 +60,58 @@ async def test_content_process_merges_video_understanding_markdown(
 
 
 @pytest.mark.asyncio
+@patch("open_notebook.graphs.source.get_video_understanding_provider", new_callable=AsyncMock)
+@patch("open_notebook.graphs.source.ModelManager.get_video_understanding_model_config", new_callable=AsyncMock)
+@patch("open_notebook.graphs.source.ModelManager.get_defaults", new_callable=AsyncMock)
+@patch("open_notebook.graphs.source.extract_content", new_callable=AsyncMock)
+async def test_content_process_allows_video_understanding_without_transcript(
+    mock_extract_content,
+    mock_get_defaults,
+    mock_get_video_model,
+    mock_get_provider,
+):
+    mock_get_defaults.return_value = SimpleNamespace(
+        default_speech_to_text_model=None
+    )
+    mock_extract_content.return_value = SimpleNamespace(
+        content="",
+        url="https://cdn.example.com/video.mp4",
+        file_path=None,
+        title="Demo",
+    )
+    mock_get_video_model.return_value = SimpleNamespace(
+        id="model:123",
+        name="video-model",
+        provider="openai_compatible",
+        credential=None,
+    )
+    mock_provider = AsyncMock()
+    mock_provider.analyze.return_value = VideoUnderstandingResult(
+        summary="Video-only summary",
+        key_events=["Important scene"],
+        provider="openai_compatible",
+        model="video-model",
+    )
+    mock_get_provider.return_value = mock_provider
+
+    result = await content_process(
+        {
+            "content_state": {"url": "https://cdn.example.com/video.mp4"},
+            "apply_transformations": [],
+            "source_id": "source:1",
+            "notebook_ids": [],
+            "source": None,
+            "transformation": [],
+            "embed": False,
+            "video_understanding": None,
+        }
+    )
+
+    assert "Video-only summary" in result["content_state"].content
+    mock_provider.analyze.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @patch("open_notebook.graphs.source.Source.get", new_callable=AsyncMock)
 async def test_save_source_persists_video_analysis(mock_source_get):
     source = SimpleNamespace(

--- a/tests/test_video_understanding_ingestion.py
+++ b/tests/test_video_understanding_ingestion.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_notebook.graphs.source import content_process, save_source
+from open_notebook.multimodal.types import VideoUnderstandingResult
+
+
+@pytest.mark.asyncio
+@patch("open_notebook.graphs.source.get_video_understanding_provider", new_callable=AsyncMock)
+@patch("open_notebook.graphs.source.ModelManager.get_video_understanding_model_config", new_callable=AsyncMock)
+@patch("open_notebook.graphs.source.extract_content", new_callable=AsyncMock)
+async def test_content_process_merges_video_understanding_markdown(
+    mock_extract_content,
+    mock_get_video_model,
+    mock_get_provider,
+):
+    mock_extract_content.return_value = SimpleNamespace(
+        content="Transcript body",
+        url="https://cdn.example.com/video.mp4",
+        file_path=None,
+        title="Demo",
+    )
+    mock_get_video_model.return_value = SimpleNamespace(
+        id="model:123",
+        name="video-model",
+        provider="openai_compatible",
+        credential=None,
+    )
+    mock_provider = AsyncMock()
+    mock_provider.analyze.return_value = VideoUnderstandingResult(
+        summary="Video summary",
+        key_events=["Important scene"],
+        provider="openai_compatible",
+        model="video-model",
+    )
+    mock_get_provider.return_value = mock_provider
+
+    result = await content_process(
+        {
+            "content_state": {"url": "https://cdn.example.com/video.mp4"},
+            "apply_transformations": [],
+            "source_id": "source:1",
+            "notebook_ids": [],
+            "source": None,
+            "transformation": [],
+            "embed": False,
+            "video_understanding": None,
+        }
+    )
+
+    assert "Video summary" in result["content_state"].content
+    assert result["video_understanding"]["normalized"]["provider"] == "openai_compatible"
+
+
+@pytest.mark.asyncio
+@patch("open_notebook.graphs.source.Source.get", new_callable=AsyncMock)
+async def test_save_source_persists_video_analysis(mock_source_get):
+    source = SimpleNamespace(
+        id="source:1",
+        title="Processing...",
+        asset=None,
+        full_text=None,
+        save=AsyncMock(),
+        save_analysis=AsyncMock(),
+        vectorize=AsyncMock(),
+    )
+    mock_source_get.return_value = source
+    content_state = SimpleNamespace(
+        url="https://cdn.example.com/video.mp4",
+        file_path=None,
+        content="Transcript\n\n# Video Understanding",
+        title="Demo title",
+    )
+
+    await save_source(
+        {
+            "content_state": content_state,
+            "apply_transformations": [],
+            "source_id": "source:1",
+            "notebook_ids": [],
+            "source": source,
+            "transformation": [],
+            "embed": False,
+            "video_understanding": {
+                "normalized": {
+                    "provider": "openai_compatible",
+                    "model": "video-model",
+                },
+                "raw_output": {"ok": True},
+                "rendered_markdown": "# Video Understanding",
+            },
+        }
+    )
+
+    source.save.assert_awaited_once()
+    source.save_analysis.assert_awaited_once()
+    assert source.title == "Demo title"

--- a/tests/test_video_understanding_ingestion.py
+++ b/tests/test_video_understanding_ingestion.py
@@ -10,12 +10,17 @@ from open_notebook.multimodal.types import VideoUnderstandingResult
 @pytest.mark.asyncio
 @patch("open_notebook.graphs.source.get_video_understanding_provider", new_callable=AsyncMock)
 @patch("open_notebook.graphs.source.ModelManager.get_video_understanding_model_config", new_callable=AsyncMock)
+@patch("open_notebook.graphs.source.ModelManager.get_defaults", new_callable=AsyncMock)
 @patch("open_notebook.graphs.source.extract_content", new_callable=AsyncMock)
 async def test_content_process_merges_video_understanding_markdown(
     mock_extract_content,
+    mock_get_defaults,
     mock_get_video_model,
     mock_get_provider,
 ):
+    mock_get_defaults.return_value = SimpleNamespace(
+        default_speech_to_text_model=None
+    )
     mock_extract_content.return_value = SimpleNamespace(
         content="Transcript body",
         url="https://cdn.example.com/video.mp4",


### PR DESCRIPTION
## Summary
- add a first-class `video_understanding` model slot and default assignment
- introduce a provider-neutral multimodal capability layer plus structured `source_analysis` persistence
- enrich video ingestion with OpenAI-compatible video understanding while preserving transcript-first fallback behavior
- expose the new model type in Settings and document configuration for upstream contributors/users

## Implementation Notes
- adds `open_notebook.multimodal` with detector, registry, renderer, normalized types, and the first OpenAI-compatible video adapter
- stores structured video analysis separately in `source_analysis`, then renders it back into Markdown so existing embeddings/search/chat flows continue to work
- keeps non-video sources unchanged and safely skips provider analysis when no compatible video model is configured
- first adapter currently expects a directly accessible remote video URL; local uploaded files still fall back to the existing transcript path

## Verification
- `uv run pytest tests -q`
- `uv run ruff check api/models.py api/models_service.py api/credentials_service.py api/routers/models.py open_notebook/ai/models.py open_notebook/ai/connection_tester.py open_notebook/domain/notebook.py open_notebook/domain/source_analysis.py open_notebook/graphs/source.py open_notebook/multimodal tests/test_models_api.py tests/test_multimodal_detector.py tests/test_video_markdown_renderer.py tests/test_openai_compatible_video_provider.py tests/test_source_analysis_domain.py tests/test_video_understanding_ingestion.py`
- `npm run lint`
- `npm run build`

## Issue
Refs #804
