### PR TITLE
fix: classify ollama embedding models correctly

### DIFF
--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -202,6 +202,7 @@ def require_encryption_key() -> None:
             "Set OPEN_NOTEBOOK_ENCRYPTION_KEY to enable storing API keys."
         )
 
+
 def credential_to_response(cred: Credential, model_count: int = 0) -> CredentialResponse:
     """Convert a Credential domain object to API response."""
     return CredentialResponse(

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -18,6 +18,7 @@ from loguru import logger
 from pydantic import SecretStr
 
 from api.models import CredentialResponse
+from open_notebook.ai.model_discovery import classify_model_type
 from open_notebook.domain.credential import Credential
 from open_notebook.utils.encryption import get_secret_from_env
 
@@ -200,7 +201,6 @@ def require_encryption_key() -> None:
             "Encryption key not configured. "
             "Set OPEN_NOTEBOOK_ENCRYPTION_KEY to enable storing API keys."
         )
-
 
 def credential_to_response(cred: Credential, model_count: int = 0) -> CredentialResponse:
     """Convert a Credential domain object to API response."""
@@ -529,7 +529,11 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
                 response.raise_for_status()
                 data = response.json()
                 return [
-                    {"name": m.get("name", ""), "provider": "ollama"}
+                    {
+                        "name": m.get("name", ""),
+                        "provider": "ollama",
+                        "model_type": classify_model_type(m.get("name", ""), "ollama"),
+                    }
                     for m in data.get("models", [])
                     if m.get("name")
                 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     command: start --log info --user root --pass root rocksdb:/mydata/mydatabase.db
     user: root  # Required for bind mounts on Linux
     ports:
-      - "8000:8000"
+      - "127.0.0.1:${SURREAL_HOST_PORT:-8000}:8000"
     volumes:
       - ./surreal_data:/mydata
     environment:
@@ -13,14 +13,17 @@ services:
     pull_policy: always
 
   open_notebook:
-    image: lfnovo/open_notebook:v1-latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: open-notebook-local:dev
     ports:
-      - "8502:8502"  # Web UI
-      - "5055:5055"  # REST API
+      - "127.0.0.1:${OPEN_NOTEBOOK_WEB_PORT:-8502}:8502"  # Web UI
+      - "127.0.0.1:${OPEN_NOTEBOOK_API_PORT:-5055}:5055"  # REST API
     environment:
-      # REQUIRED: Change this to your own secret string
-      # This encrypts your API keys in the database
-      - OPEN_NOTEBOOK_ENCRYPTION_KEY=change-me-to-a-secret-string
+      # REQUIRED: Provide this in .env to encrypt stored API credentials
+      - OPEN_NOTEBOOK_ENCRYPTION_KEY=${OPEN_NOTEBOOK_ENCRYPTION_KEY}
+      - API_URL=http://localhost:${OPEN_NOTEBOOK_API_PORT:-5055}
 
       # Database connection (default values - no need to change)
       - SURREAL_URL=ws://surrealdb:8000/rpc
@@ -33,4 +36,3 @@ services:
     depends_on:
       - surrealdb
     restart: always
-    pull_policy: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     command: start --log info --user root --pass root rocksdb:/mydata/mydatabase.db
     user: root  # Required for bind mounts on Linux
     ports:
-      - "127.0.0.1:${SURREAL_HOST_PORT:-8000}:8000"
+      - "8000:8000"
     volumes:
       - ./surreal_data:/mydata
     environment:
@@ -13,17 +13,14 @@ services:
     pull_policy: always
 
   open_notebook:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: open-notebook-local:dev
+    image: lfnovo/open_notebook:v1-latest
     ports:
-      - "127.0.0.1:${OPEN_NOTEBOOK_WEB_PORT:-8502}:8502"  # Web UI
-      - "127.0.0.1:${OPEN_NOTEBOOK_API_PORT:-5055}:5055"  # REST API
+      - "8502:8502"  # Web UI
+      - "5055:5055"  # REST API
     environment:
-      # REQUIRED: Provide this in .env to encrypt stored API credentials
-      - OPEN_NOTEBOOK_ENCRYPTION_KEY=${OPEN_NOTEBOOK_ENCRYPTION_KEY}
-      - API_URL=http://localhost:${OPEN_NOTEBOOK_API_PORT:-5055}
+      # REQUIRED: Change this to your own secret string
+      # This encrypts your API keys in the database
+      - OPEN_NOTEBOOK_ENCRYPTION_KEY=change-me-to-a-secret-string
 
       # Database connection (default values - no need to change)
       - SURREAL_URL=ws://surrealdb:8000/rpc
@@ -36,3 +33,4 @@ services:
     depends_on:
       - surrealdb
     restart: always
+    pull_policy: always


### PR DESCRIPTION
## Description

This PR fixes Ollama model discovery so embedding models are classified correctly when credentials are added or refreshed.

It also updates the local Docker Compose setup to build from the local source tree instead of always pulling the published image, while keeping services bound to localhost and reading the encryption key from environment configuration.

## Related Issue

Fixes #<issue-number>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [x] Tested locally with Docker
- [ ] Tested locally with development setup
- [ ] Added new unit tests
- [ ] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)

**Test Details:**

- Rebuilt the application container locally with Docker Compose
- Verified the API health endpoint returned a healthy response
- Verified existing stored credentials remained available after rebuild
- Verified the discovered model registry contains:
  - `gemma4:31b-it-q4_K_M` with type `language`
  - `nomic-embed-text:latest` with type `embedding`
- Confirmed the local Docker image is built from the repository source rather than the published image

## Design Alignment

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [x] Simplicity Over Features
- [x] API-First Architecture
- [x] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**

This change keeps the fix minimal and focused on the model discovery path, improves provider compatibility for Ollama embedding models, and preserves the existing API-driven model configuration flow without introducing broader architectural changes.

## Checklist

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [ ] My code follows TypeScript best practices (Frontend)
- [x] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

N/A

## Additional Context

The main user-facing issue was that Ollama embedding models could be treated as language models, which prevented them from appearing in the embedding model selector.

The Docker Compose changes were made to ensure local source changes can be validated in a containerized workflow without replacing persisted credentials, as long as the existing database volume and encryption key are preserved.

## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [ ] This PR addresses an approved issue that was assigned to me
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")