### PR TITLE
fix(i18n): use t('common.german') for language toggle label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OPEN_NOTEBOOK_EMBEDDING_BATCH_SIZE` environment variable to override the embedding batch size; default remains `50`. Helps with CPU-only local embedding and stricter OpenAI-compatible endpoints (#735)
 - `CORS_ORIGINS` environment variable to configure the API's allowed origins (comma-separated). Default remains `*` for backward compatibility; the API now logs a startup warning prompting users to set it for production deployments. Exception responses honor the configured origins when explicitly set (#585, #597, #730)
 
+### Fixed
+- Language toggle now uses `t('common.german')` instead of a hardcoded "Deutsch" label, matching the pattern used by every other language entry (follow-up to #794)
+
 ## [1.8.5] - 2026-04-14
 
 ### Changed

--- a/frontend/src/components/common/LanguageToggle.tsx
+++ b/frontend/src/components/common/LanguageToggle.tsx
@@ -98,7 +98,7 @@ export function LanguageToggle({ iconOnly = false }: LanguageToggleProps) {
           onClick={() => setLanguage('de-DE')}
           className={currentLang === 'de-DE' || currentLang.startsWith('de') ? 'bg-accent' : ''}
         >
-          <span>Deutsch</span>
+          <span>{t('common.german')}</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -28,6 +28,7 @@ export const bnIN = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "উৎস",
     notebook: "নোটবুক",
     podcast: "পডকাস্ট",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -28,6 +28,7 @@ export const caES = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Font",
     notebook: "Quadern",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -31,6 +31,7 @@ export const deDE = {
     bengali: "বাংলা",
     spanish: "Español",
     catalan: "Català",
+    german: "Deutsch",
     source: "Quelle",
     notebook: "Notebook",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -28,6 +28,7 @@ export const enUS = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Source",
     notebook: "Notebook",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -28,6 +28,7 @@ export const esES = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Fuente",
     notebook: "Cuaderno",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -28,6 +28,7 @@ export const frFR = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Source",
     notebook: "Carnet",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -28,6 +28,7 @@ export const itIT = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Fonte",
     notebook: "Quaderno",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -28,6 +28,7 @@ export const jaJP = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "ソース",
     notebook: "ノートブック",
     podcast: "ポッドキャスト",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -28,6 +28,7 @@ export const ptBR = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Fonte",
     notebook: "Caderno",
     podcast: "Podcast",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -28,6 +28,7 @@ export const ruRU = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "Источник",
     notebook: "Блокнот",
     podcast: "Подкаст",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -28,6 +28,7 @@ export const zhCN = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "来源",
     notebook: "笔记本",
     podcast: "播客",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -28,6 +28,7 @@ export const zhTW = {
     bengali: "বাংলা",
     catalan: "Català",
     spanish: "Español",
+    german: "Deutsch",
     source: "來源",
     notebook: "筆記本",
     podcast: "播客",


### PR DESCRIPTION
## Summary
- Follow-up to #794 — replaces the hardcoded `<span>Deutsch</span>` in the language toggle with `<span>{t('common.german')}</span>`, matching the i18n pattern used by every other language entry
- Adds `german: "Deutsch"` to all 11 locale files (the native name is always "Deutsch", same convention as `spanish: "Español"`, `french: "Français"`, etc.)
- Adds a CHANGELOG entry under `[Unreleased]` → `Fixed`

The visible label remains "Deutsch" everywhere — this change is purely about consistency with the existing i18n pattern.

## Test plan
- [x] `vitest run src/lib/locales/index.test.ts` — all 11 locale parity tests pass; the unused-key detector confirms `common.german` is referenced from source
- [x] `tsc --noEmit` clean
- [ ] Sanity check the language toggle still shows "Deutsch" and switching to German still works