### PR TITLE
fix(frontend): keep "Chat with source" navigation in-app

### DIFF
--- a/frontend/src/components/source/SourceDialog.tsx
+++ b/frontend/src/components/source/SourceDialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { SourceDetailContent } from './SourceDetailContent'
 import { useTranslation } from '@/lib/hooks/use-translation'
@@ -14,10 +15,11 @@ interface SourceDialogProps {
  * Source Dialog Component
  *
  * Displays source details in a modal dialog.
- * Includes a "Chat with source" button that opens the full source page in a new tab.
+ * Includes a "Chat with source" button that navigates to the full source page in-app.
  */
 export function SourceDialog({ open, onOpenChange, sourceId }: SourceDialogProps) {
   const { t } = useTranslation()
+  const router = useRouter()
   // Ensure source ID has 'source:' prefix for API calls and routing
   const sourceIdWithPrefix = sourceId
     ? (sourceId.includes(':') ? sourceId : `source:${sourceId}`)
@@ -25,8 +27,8 @@ export function SourceDialog({ open, onOpenChange, sourceId }: SourceDialogProps
 
   const handleChatClick = () => {
     if (sourceIdWithPrefix) {
-      window.open(`/sources/${sourceIdWithPrefix}`, '_blank')
-      // Modal stays open after opening chat
+      onOpenChange(false)
+      router.push(`/sources/${sourceIdWithPrefix}`)
     }
   }
 


### PR DESCRIPTION
The "Chat with source" button in SourceDialog opened an internal app route (`/sources/...`) in a new browser tab via `window.open(..., "_blank")`. This switches it to Next.js router navigation so it stays within the app (closing the dialog first).

External links (a source's original URL, links inside source content) are unchanged — they still open in new tabs as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)