### PR TITLE
feat: expose new audio providers (Mistral STT/TTS, Deepgram TTS, xAI TTS)

### DIFF
--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -41,6 +41,7 @@ PROVIDER_ENV_CONFIG: Dict[str, dict] = {
     "openrouter": {"required": ["OPENROUTER_API_KEY"]},
     "voyage": {"required": ["VOYAGE_API_KEY"]},
     "elevenlabs": {"required": ["ELEVENLABS_API_KEY"]},
+    "deepgram": {"required": ["DEEPGRAM_API_KEY"]},
     "ollama": {"required": ["OLLAMA_API_BASE"]},
     "vertex": {
         "required": ["VERTEX_PROJECT", "VERTEX_LOCATION"],
@@ -67,12 +68,13 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "anthropic": ["language"],
     "google": ["language", "embedding"],
     "groq": ["language", "speech_to_text"],
-    "mistral": ["language", "embedding"],
+    "mistral": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "deepseek": ["language"],
-    "xai": ["language"],
+    "xai": ["language", "text_to_speech"],
     "openrouter": ["language"],
     "voyage": ["embedding"],
     "elevenlabs": ["text_to_speech"],
+    "deepgram": ["text_to_speech"],
     "ollama": ["language", "embedding"],
     "vertex": ["language", "embedding"],
     "azure": ["language", "embedding", "speech_to_text", "text_to_speech"],
@@ -506,6 +508,12 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         "elevenlabs": [
             "eleven_multilingual_v2", "eleven_turbo_v2_5",
             "eleven_turbo_v2", "eleven_monolingual_v1",
+        ],
+        "deepgram": [
+            "aura-2-thalia-en", "aura-2-andromeda-en", "aura-2-helena-en",
+            "aura-2-apollo-en", "aura-2-arcas-en", "aura-2-asteria-en",
+            "aura-2-athena-en", "aura-2-hera-en", "aura-2-hermes-en",
+            "aura-2-atlas-en",
         ],
     }
 

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -13,7 +13,6 @@ from api.models import (
     ModelResponse,
     ProviderAvailabilityResponse,
 )
-from open_notebook.domain.credential import Credential
 from open_notebook.ai.connection_tester import test_individual_model
 from open_notebook.ai.key_provider import provision_provider_keys
 from open_notebook.ai.model_discovery import (
@@ -23,6 +22,7 @@ from open_notebook.ai.model_discovery import (
     sync_provider_models,
 )
 from open_notebook.ai.models import DefaultModels, Model
+from open_notebook.domain.credential import Credential
 from open_notebook.exceptions import InvalidInputError
 
 router = APIRouter()
@@ -381,6 +381,7 @@ async def get_provider_availability():
             "openrouter": "OPENROUTER_API_KEY",
             "voyage": "VOYAGE_API_KEY",
             "elevenlabs": "ELEVENLABS_API_KEY",
+            "deepgram": "DEEPGRAM_API_KEY",
             "ollama": "OLLAMA_API_BASE",
             "dashscope": "DASHSCOPE_API_KEY",
             "minimax": "MINIMAX_API_KEY",

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -72,6 +72,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   openrouter: 'OpenRouter',
   voyage: 'Voyage AI',
   elevenlabs: 'ElevenLabs',
+  deepgram: 'Deepgram',
   ollama: 'Ollama',
   azure: 'Azure OpenAI',
   vertex: 'Google Vertex AI',
@@ -83,7 +84,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 // All providers in display order
 const ALL_PROVIDERS = [
   'openai', 'anthropic', 'google', 'groq', 'mistral', 'deepseek',
-  'xai', 'openrouter', 'dashscope', 'minimax', 'voyage', 'elevenlabs', 'ollama',
+  'xai', 'openrouter', 'dashscope', 'minimax', 'voyage', 'elevenlabs', 'deepgram', 'ollama',
   'azure', 'vertex', 'openai_compatible',
 ]
 
@@ -93,12 +94,13 @@ const PROVIDER_MODALITIES: Record<string, ModelType[]> = {
   anthropic: ['language'],
   google: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
   groq: ['language', 'speech_to_text'],
-  mistral: ['language', 'embedding'],
+  mistral: ['language', 'embedding', 'speech_to_text', 'text_to_speech'],
   deepseek: ['language'],
-  xai: ['language'],
+  xai: ['language', 'text_to_speech'],
   openrouter: ['language', 'embedding'],
   voyage: ['embedding'],
   elevenlabs: ['text_to_speech', 'speech_to_text'],
+  deepgram: ['text_to_speech'],
   ollama: ['language', 'embedding'],
   azure: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
   vertex: ['language', 'embedding', 'text_to_speech'],
@@ -119,6 +121,7 @@ const PROVIDER_DOCS: Record<string, string> = {
   openrouter: 'https://openrouter.ai/keys',
   voyage: 'https://dash.voyageai.com/api-keys',
   elevenlabs: 'https://elevenlabs.io/app/settings/api-keys',
+  deepgram: 'https://console.deepgram.com/',
   azure: 'https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI',
   vertex: 'https://cloud.google.com/vertex-ai/docs/start/cloud-environment',
   openai_compatible: 'https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/openai-compatible.md',

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -8,13 +8,10 @@ configurations end-to-end.
 import io
 import os
 import struct
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import httpx
-from esperanto.factory import AIFactory
 from loguru import logger
-
-from open_notebook.domain.credential import Credential
 
 # Test models for each provider - uses minimal/cheapest models for testing
 # Format: (model_name, model_type)
@@ -29,6 +26,7 @@ TEST_MODELS = {
     "openrouter": ("openai/gpt-3.5-turbo", "language"),
     "voyage": ("voyage-3-lite", "embedding"),
     "elevenlabs": ("eleven_multilingual_v2", "text_to_speech"),
+    "deepgram": ("aura-2-thalia-en", "text_to_speech"),
     "ollama": (None, "language"),  # Dynamic - will use first available model
     # Complex providers with additional configuration
     "vertex": ("gemini-2.0-flash", "language"),  # Uses Google Vertex AI
@@ -169,148 +167,16 @@ async def _test_openai_compatible_connection(base_url: str, api_key: Optional[st
     except Exception as e:
         return False, f"Connection error: {str(e)[:100]}"
 
-async def test_provider_connection(
-    provider: str, model_type: str = "language", config_id: Optional[str] = None
-) -> Tuple[bool, str]:
-    """
-    Test if a provider's API key is valid by making a minimal API call.
-
-    Args:
-        provider: Provider name (openai, anthropic, etc.)
-        model_type: Type of model to test (language, embedding, etc.)
-                   Note: This is overridden by TEST_MODELS if provider is in that dict.
-        config_id: Optional specific configuration ID to test (format: configId)
-                   If provided, uses the configuration from ProviderConfig for this specific config.
-
-    Returns:
-        Tuple of (success: bool, message: str)
-    """
-    try:
-        # Get configuration - either specific config or default
-        api_key: Optional[str] = None
-        base_url: Optional[str] = None
-        endpoint: Optional[str] = None
-        api_version: Optional[str] = None
-        model_name: Optional[str] = None
-
-        if config_id:
-            # Load specific credential from database
-            try:
-                cred = await Credential.get(config_id)
-                config = cred.to_esperanto_config()
-                api_key = config.get("api_key")
-                base_url = config.get("base_url")
-                endpoint = config.get("endpoint")
-                api_version = config.get("api_version")
-            except Exception:
-                return False, f"Credential not found: {config_id}"
-
-        # Normalize provider name (handle hyphenated aliases)
-        normalized_provider = provider.replace("-", "_")
-
-        # Special handling for URL-based providers (no API key, just connectivity)
-        if normalized_provider == "ollama":
-            # Use base_url from specific config, or environment variable
-            test_base_url = base_url or os.environ.get("OLLAMA_API_BASE", "http://localhost:11434")
-            return await _test_ollama_connection(test_base_url)
-
-        if normalized_provider == "openai_compatible":
-            # Use base_url from specific config, or environment variable
-            test_base_url = base_url or os.environ.get("OPENAI_COMPATIBLE_BASE_URL")
-            test_api_key = api_key or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
-            if not test_base_url:
-                return False, "No base URL configured for OpenAI-compatible provider"
-            return await _test_openai_compatible_connection(test_base_url, test_api_key)
-
-        if normalized_provider == "azure":
-            # For Azure, base_url from the UI form maps to endpoint
-            azure_endpoint = endpoint or base_url
-            return await _test_azure_connection(azure_endpoint, api_key, api_version)
-
-        # Get test model for provider
-        if normalized_provider not in TEST_MODELS:
-            return False, f"Unknown provider: {provider}"
-
-        test_model, test_model_type = TEST_MODELS[normalized_provider]
-
-        # Use model from config if provided, otherwise use TEST_MODELS default
-        model_to_use = model_name if model_name else test_model
-
-        # For providers with dynamic model detection
-        if model_to_use is None:
-            if normalized_provider == "openai_compatible":
-                # OpenAI-compatible servers should already be tested via _test_openai_compatible_connection
-                test_base_url = base_url or os.environ.get("OPENAI_COMPATIBLE_BASE_URL", "")
-                test_api_key = api_key or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
-                return await _test_openai_compatible_connection(test_base_url, test_api_key)
-            else:
-                return False, f"No test model configured for {provider}"
-
-        # If we have a specific API key, set it in environment for this test
-        if api_key:
-            os.environ[f"{provider.upper()}_API_KEY"] = api_key
-
-        # Try to create the model and make a minimal call
-        if test_model_type == "language":
-            model = AIFactory.create_language(model_name=model_to_use, provider=provider)
-            # Convert to LangChain and make a minimal call
-            lc_model = model.to_langchain()
-            await lc_model.ainvoke("Hi")
-            return True, "Connection successful"
-
-        elif test_model_type == "embedding":
-            model = AIFactory.create_embedding(model_name=model_to_use, provider=provider)
-            # Embed a single short test string
-            await model.aembed(["test"])
-            return True, "Connection successful"
-
-        elif test_model_type == "text_to_speech":
-            # For TTS, we just verify the model can be created
-            # Making an actual TTS call would be more expensive
-            # Most TTS providers validate the key on model creation
-            AIFactory.create_text_to_speech(
-                model_name=model_to_use, provider=provider
-            )
-            return True, "Connection successful (key format valid)"
-
-        else:
-            return False, f"Unsupported model type for testing: {test_model_type}"
-
-    except Exception as e:
-        error_msg = str(e)
-
-        # Clean up common error messages for user-friendly display
-        if "401" in error_msg or "unauthorized" in error_msg.lower():
-            return False, "Invalid API key"
-        elif "403" in error_msg or "forbidden" in error_msg.lower():
-            return False, "API key lacks required permissions"
-        elif "rate" in error_msg.lower() and "limit" in error_msg.lower():
-            # Rate limit means the key is valid but we hit limits
-            return True, "Rate limited - but connection works"
-        elif "connection" in error_msg.lower() or "network" in error_msg.lower():
-            return False, "Connection error - check network/endpoint"
-        elif "timeout" in error_msg.lower():
-            return False, "Connection timed out - check network/endpoint"
-        elif "not found" in error_msg.lower() and "model" in error_msg.lower():
-            # Model not found but auth worked - this is actually a success for connectivity
-            return True, "API key valid (test model not available)"
-        elif provider == "ollama" and "connection refused" in error_msg.lower():
-            return False, "Ollama not running - check if Ollama server is started"
-        else:
-            logger.debug(f"Test connection error for {provider}: {e}")
-            # Truncate long error messages
-            truncated = error_msg[:100] + "..." if len(error_msg) > 100 else error_msg
-            return False, f"Error: {truncated}"
-
-
 # Default voices for TTS testing per provider
-# ElevenLabs excluded: uses voice_id (not name), looked up dynamically
+# ElevenLabs and Mistral excluded: voices looked up dynamically via available_voices
 DEFAULT_TEST_VOICES = {
     "openai": "alloy",
     "azure": "alloy",
     "google": "Kore",
     "vertex": "Kore",
     "openai_compatible": "alloy",
+    "deepgram": "aura-2-thalia-en",
+    "xai": "eve",
 }
 
 

--- a/open_notebook/ai/key_provider.py
+++ b/open_notebook/ai/key_provider.py
@@ -19,7 +19,6 @@ from loguru import logger
 
 from open_notebook.domain.credential import Credential
 
-
 # =============================================================================
 # Provider Configuration Mapping
 # =============================================================================
@@ -57,6 +56,9 @@ PROVIDER_CONFIG = {
     },
     "elevenlabs": {
         "env_var": "ELEVENLABS_API_KEY",
+    },
+    "deepgram": {
+        "env_var": "DEEPGRAM_API_KEY",
     },
     # URL-based providers
     "ollama": {

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -14,8 +14,8 @@ import httpx
 from loguru import logger
 
 from open_notebook.ai.models import Model
-from open_notebook.domain.credential import Credential
 from open_notebook.database.repository import repo_query
+from open_notebook.domain.credential import Credential
 
 
 @dataclass
@@ -108,6 +108,11 @@ MISTRAL_MODEL_TYPES = {
         "open-mixtral",
     ],
     "embedding": ["mistral-embed"],
+    # Voxtral. TTS first by specificity: the "-tts" model must not be caught by
+    # the broader STT names. classify_model_type checks speech_to_text before
+    # text_to_speech, so STT patterns are the explicit non-tts model names.
+    "text_to_speech": ["voxtral-mini-tts", "voxtral-tts"],
+    "speech_to_text": ["voxtral-mini-latest", "voxtral-small-latest"],
 }
 
 GROQ_MODEL_TYPES = {
@@ -129,6 +134,10 @@ VOYAGE_MODEL_TYPES = {
 
 ELEVENLABS_MODEL_TYPES = {
     "text_to_speech": ["eleven"],
+}
+
+DEEPGRAM_MODEL_TYPES = {
+    "text_to_speech": ["aura"],
 }
 
 DASHSCOPE_MODEL_TYPES = {
@@ -158,6 +167,7 @@ def classify_model_type(model_name: str, provider: str) -> str:
         "xai": XAI_MODEL_TYPES,
         "voyage": VOYAGE_MODEL_TYPES,
         "elevenlabs": ELEVENLABS_MODEL_TYPES,
+        "deepgram": DEEPGRAM_MODEL_TYPES,
         "dashscope": DASHSCOPE_MODEL_TYPES,
         "minimax": MINIMAX_MODEL_TYPES,
     }
@@ -528,6 +538,36 @@ async def discover_elevenlabs_models() -> List[DiscoveredModel]:
     ]
 
 
+async def discover_deepgram_models() -> List[DiscoveredModel]:
+    """Return a curated static list of Deepgram Aura TTS voices.
+
+    Deepgram has no model-listing API and treats each voice as a model id.
+    This is a representative subset of the Aura-2 English catalog; users can
+    add any other voice manually via the custom-model input.
+    """
+    api_key = os.environ.get("DEEPGRAM_API_KEY")
+    if not api_key:
+        return []
+
+    deepgram_voices = [
+        "aura-2-thalia-en",
+        "aura-2-andromeda-en",
+        "aura-2-helena-en",
+        "aura-2-apollo-en",
+        "aura-2-arcas-en",
+        "aura-2-asteria-en",
+        "aura-2-athena-en",
+        "aura-2-hera-en",
+        "aura-2-hermes-en",
+        "aura-2-atlas-en",
+    ]
+
+    return [
+        DiscoveredModel(name=m, provider="deepgram", model_type="text_to_speech")
+        for m in deepgram_voices
+    ]
+
+
 async def discover_dashscope_models() -> List[DiscoveredModel]:
     """Fetch available models from DashScope (Qwen) API."""
     api_key = os.environ.get("DASHSCOPE_API_KEY")
@@ -677,6 +717,7 @@ PROVIDER_DISCOVERY_FUNCTIONS = {
     "openrouter": discover_openrouter_models,
     "voyage": discover_voyage_models,
     "elevenlabs": discover_elevenlabs_models,
+    "deepgram": discover_deepgram_models,
     "openai_compatible": discover_openai_compatible_models,
     "dashscope": discover_dashscope_models,
     "minimax": discover_minimax_models,

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -216,5 +216,37 @@ class TestCredentialNumCtx:
         assert "num_ctx" not in cred.to_esperanto_config()
 
 
+class TestAudioProviderWiring:
+    """Tests for the new audio providers (Mistral STT/TTS, Deepgram TTS, xAI TTS)."""
+
+    def test_classify_voxtral_and_aura(self):
+        from open_notebook.ai.model_discovery import classify_model_type
+
+        # Mistral Voxtral: TTS model must not be mis-detected as STT
+        assert classify_model_type("voxtral-mini-tts-2603", "mistral") == "text_to_speech"
+        assert classify_model_type("voxtral-mini-latest", "mistral") == "speech_to_text"
+        assert classify_model_type("voxtral-small-latest", "mistral") == "speech_to_text"
+        # Existing Mistral classification still holds
+        assert classify_model_type("mistral-large-latest", "mistral") == "language"
+        assert classify_model_type("mistral-embed", "mistral") == "embedding"
+        # Deepgram Aura voices
+        assert classify_model_type("aura-2-thalia-en", "deepgram") == "text_to_speech"
+
+    def test_provider_modalities_include_audio(self):
+        from api.credentials_service import PROVIDER_MODALITIES
+
+        assert "speech_to_text" in PROVIDER_MODALITIES["mistral"]
+        assert "text_to_speech" in PROVIDER_MODALITIES["mistral"]
+        assert "text_to_speech" in PROVIDER_MODALITIES["xai"]
+        assert PROVIDER_MODALITIES["deepgram"] == ["text_to_speech"]
+
+    def test_deepgram_has_env_and_test_model(self):
+        from api.credentials_service import PROVIDER_ENV_CONFIG
+        from open_notebook.ai.connection_tester import TEST_MODELS
+
+        assert PROVIDER_ENV_CONFIG["deepgram"]["required"] == ["DEEPGRAM_API_KEY"]
+        assert TEST_MODELS["deepgram"][1] == "text_to_speech"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Surfaces the audio providers added in esperanto 2.21/2.22 so they can be configured in Open Notebook:

- **Mistral Voxtral** — STT (`voxtral-*-latest`) and TTS (`voxtral-mini-tts`). Reuses `MISTRAL_API_KEY`; discovered via the existing `/v1/models` endpoint.
- **Deepgram TTS (Aura)** — **new provider**: `DEEPGRAM_API_KEY` env config + key_provider mapping, a static Aura voice catalog for discovery, and modality/display-name/docs-link in the UI.
- **xAI TTS** — adds `text_to_speech` to the existing `xai` provider.

## Also (closes #826)

The `#826` re-key turned out unnecessary: the function that would have benefited — `test_provider_connection()` — has **no callers** (the UI uses `test_credential` / `test_individual_model`). So instead of a pointless refactor, this **removes the dead function** and its now-unused imports, and adds the one entry actually needed (`deepgram` in `TEST_MODELS`).

## Notes / caveats

- **xAI TTS is voice-based and sends no model id** — the registered model name is cosmetic (esperanto ignores it; only the voice matters at generation). There's no discovery entry for it; users add a model via the custom-model input. Verified against the esperanto source.
- `classify_model_type` distinguishes Voxtral **TTS vs STT** (the `-tts` model must not be caught by the broader STT names, since STT is checked first) and Aura voices — covered by tests.
- Provider display names are **frontend constants, not i18n**, so this PR needs **no locale changes**.
- Reconciled with esperanto's `AIFactory.get_available_providers()`: verified it reports `deepgram`/`mistral`/`xai` under TTS and `mistral` under STT, matching the modalities added here.

## Verification

- ✅ Backend `uv run pytest tests/` — 153 passed (incl. new classify + wiring tests)
- ✅ `ruff check` clean on changed files
- ✅ Frontend `npm run lint` (0 errors), `npm test` (32), `npm run build`
- ⚠️ Could not exercise live TTS/STT calls for Deepgram/Mistral/xAI (no API keys) — wiring matches the esperanto API; recommend a real-key smoke test before release.

Stacked on #833 (base branch `feat/esperanto-2.22-bump`); GitHub will retarget to `main` once #833 merges.

Closes #826
Closes #827