### PR TITLE
feat: complete audio matrix (Google/Vertex TTS, Google/ElevenLabs STT)

### DIFF
--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -66,17 +66,17 @@ PROVIDER_ENV_CONFIG: Dict[str, dict] = {
 PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "openai": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "anthropic": ["language"],
-    "google": ["language", "embedding"],
+    "google": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "groq": ["language", "speech_to_text"],
     "mistral": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "deepseek": ["language"],
     "xai": ["language", "text_to_speech"],
     "openrouter": ["language"],
     "voyage": ["embedding"],
-    "elevenlabs": ["text_to_speech"],
+    "elevenlabs": ["text_to_speech", "speech_to_text"],
     "deepgram": ["text_to_speech"],
     "ollama": ["language", "embedding"],
-    "vertex": ["language", "embedding"],
+    "vertex": ["language", "embedding", "text_to_speech"],
     "azure": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "openai_compatible": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "dashscope": ["language"],
@@ -508,6 +508,7 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         "elevenlabs": [
             "eleven_multilingual_v2", "eleven_turbo_v2_5",
             "eleven_turbo_v2", "eleven_monolingual_v1",
+            "scribe_v1",  # speech-to-text
         ],
         "deepgram": [
             "aura-2-thalia-en", "aura-2-andromeda-en", "aura-2-helena-en",

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -67,6 +67,10 @@ ANTHROPIC_MODELS = {
 GOOGLE_MODEL_TYPES = {
     "language": ["gemini", "palm", "bison", "chat"],
     "embedding": ["embedding", "textembedding"],
+    # Gemini TTS preview models carry "tts" in the name (checked before language).
+    # Google STT reuses plain Gemini names and can't be told apart by name, so it
+    # has no pattern here — users assign the speech_to_text type manually.
+    "text_to_speech": ["tts"],
 }
 
 OLLAMA_MODEL_TYPES = {
@@ -134,6 +138,7 @@ VOYAGE_MODEL_TYPES = {
 
 ELEVENLABS_MODEL_TYPES = {
     "text_to_speech": ["eleven"],
+    "speech_to_text": ["scribe"],
 }
 
 DEEPGRAM_MODEL_TYPES = {
@@ -523,7 +528,7 @@ async def discover_elevenlabs_models() -> List[DiscoveredModel]:
     if not api_key:
         return []
 
-    # ElevenLabs specializes in TTS
+    # ElevenLabs TTS models + the Scribe STT model
     elevenlabs_models = [
         "eleven_multilingual_v2",
         "eleven_turbo_v2_5",
@@ -532,10 +537,16 @@ async def discover_elevenlabs_models() -> List[DiscoveredModel]:
         "eleven_multilingual_v1",
     ]
 
-    return [
+    discovered = [
         DiscoveredModel(name=m, provider="elevenlabs", model_type="text_to_speech")
         for m in elevenlabs_models
     ]
+    discovered.append(
+        DiscoveredModel(
+            name="scribe_v1", provider="elevenlabs", model_type="speech_to_text"
+        )
+    )
+    return discovered
 
 
 async def discover_deepgram_models() -> List[DiscoveredModel]:

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -248,5 +248,27 @@ class TestAudioProviderWiring:
         assert TEST_MODELS["deepgram"][1] == "text_to_speech"
 
 
+class TestAudioMatrixWiring:
+    """Tests for completing the audio matrix (Google/Vertex TTS, Google/ElevenLabs STT)."""
+
+    def test_provider_modalities_matrix(self):
+        from api.credentials_service import PROVIDER_MODALITIES
+
+        for m in ("speech_to_text", "text_to_speech"):
+            assert m in PROVIDER_MODALITIES["google"]
+        assert "text_to_speech" in PROVIDER_MODALITIES["vertex"]
+        assert "speech_to_text" in PROVIDER_MODALITIES["elevenlabs"]
+
+    def test_classify_matrix(self):
+        from open_notebook.ai.model_discovery import classify_model_type
+
+        # Gemini TTS preview is classifiable; plain Gemini STT name stays language
+        assert classify_model_type("gemini-3.1-flash-tts-preview", "google") == "text_to_speech"
+        assert classify_model_type("gemini-2.0-flash", "google") == "language"
+        # ElevenLabs Scribe STT must not be caught by the TTS "eleven" pattern
+        assert classify_model_type("scribe_v1", "elevenlabs") == "speech_to_text"
+        assert classify_model_type("eleven_multilingual_v2", "elevenlabs") == "text_to_speech"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Completes the audio provider matrix by enabling the remaining esperanto audio modalities for providers Open Notebook already supports:

| Provider | Added |
|----------|-------|
| google | speech_to_text, text_to_speech |
| vertex | text_to_speech |
| elevenlabs | speech_to_text (Scribe) |

## Details

- `classify_model_type` gains a **Google TTS** pattern (`tts`, matched before the broad `gemini` language pattern) and an **ElevenLabs STT** pattern (`scribe`, matched before the `eleven` TTS pattern) — both covered by tests.
- **Google STT** reuses plain Gemini names (e.g. `gemini-2.5-flash`) that are indistinguishable from language models by name, so it has **no classifier pattern** — users assign the `speech_to_text` type manually when registering. This is intentional and documented in the code.
- ElevenLabs discovery now also returns `scribe_v1` as a `speech_to_text` model.
- The **frontend already exposed these modalities**; this PR aligns the backend `PROVIDER_MODALITIES`, classification, and discovery with esperanto + the UI (closing the existing frontend/backend mismatch).

## Verification

- ✅ `uv run pytest tests/` — 158 passed (incl. new matrix tests)
- ✅ `ruff check` clean on changed files
- ✅ Verified against esperanto `get_available_providers()`: google/vertex under TTS, google/elevenlabs under STT.
- ⚠️ No live API-key smoke for these modalities (no keys) — wiring matches the esperanto API; recommend a real-key check before release.

Stacked on #834 → #833; GitHub retargets to `main` as each merges.

Closes #828