### PR TITLE
docs: sync README provider matrix with 1.9.0 audio providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,20 +202,21 @@ Thanks to the [Esperanto](https://github.com/lfnovo/esperanto) library, we suppo
 | OpenAI       | ✅          | ✅               | ✅             | ✅             |
 | Anthropic    | ✅          | ❌               | ❌             | ❌             |
 | Groq         | ✅          | ❌               | ✅             | ❌             |
-| Google (GenAI) | ✅          | ✅               | ❌             | ✅             |
+| Google (GenAI) | ✅          | ✅               | ✅             | ✅             |
 | Vertex AI    | ✅          | ✅               | ❌             | ✅             |
 | Ollama       | ✅          | ✅               | ❌             | ❌             |
 | Perplexity   | ✅          | ❌               | ❌             | ❌             |
 | ElevenLabs   | ❌          | ❌               | ✅             | ✅             |
-| Azure OpenAI | ✅          | ✅               | ❌             | ❌             |
-| Mistral      | ✅          | ✅               | ❌             | ❌             |
+| Deepgram     | ❌          | ❌               | ❌             | ✅             |
+| Azure OpenAI | ✅          | ✅               | ✅             | ✅             |
+| Mistral      | ✅          | ✅               | ✅             | ✅             |
 | DeepSeek     | ✅          | ❌               | ❌             | ❌             |
 | Voyage       | ❌          | ✅               | ❌             | ❌             |
-| xAI          | ✅          | ❌               | ❌             | ❌             |
+| xAI          | ✅          | ❌               | ❌             | ✅             |
 | OpenRouter   | ✅          | ❌               | ❌             | ❌             |
 | DashScope (Qwen) | ✅          | ❌               | ❌             | ❌             |
 | MiniMax      | ✅          | ❌               | ❌             | ❌             |
-| OpenAI Compatible* | ✅          | ❌               | ❌             | ❌             |
+| OpenAI Compatible* | ✅          | ✅               | ✅             | ✅             |
 
 *Supports LM Studio and any OpenAI-compatible endpoint
 


### PR DESCRIPTION
## Problem (flagged in review)

The release notes for 1.9.0 added major provider/audio capabilities, but the **Provider Support Matrix** in the README was not updated — user-facing documentation drift.

## Root cause

The matrix is hand-maintained and wasn't touched when the audio providers landed (#834 / #835). The CHANGELOG documented the new capabilities; the README table didn't.

## Fix

Reconciled the STT/TTS (and OpenAI-Compatible embedding) columns against the app's actual source of truth — `PROVIDER_MODALITIES` in `api/credentials_service.py` (verified consistent with esperanto's `get_available_providers()`):

| Provider | Correction |
|----------|-----------|
| Google (GenAI) | + Speech-to-Text |
| Mistral | + Speech-to-Text, + Text-to-Speech (Voxtral) |
| xAI | + Text-to-Speech |
| **Deepgram** | new row — Text-to-Speech (Aura) |
| Azure OpenAI | + STT, + TTS *(pre-existing drift)* |
| OpenAI Compatible | + Embedding, + STT, + TTS *(pre-existing drift)* |

Rows not changed (OpenAI, Anthropic, Groq, Vertex, Ollama, ElevenLabs, DeepSeek, Voyage, OpenRouter, DashScope, MiniMax, Perplexity) already matched.

Doc-only change. Should land before publishing the 1.9.0 release so the matrix matches the release notes.