### PR TITLE
fix(docker): retry npm ci to survive transient registry ECONNRESETs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,17 @@ COPY . /app
 WORKDIR /app/frontend
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 COPY frontend/package.json frontend/package-lock.json ./
-RUN npm config set registry ${NPM_REGISTRY}
-RUN npm ci
+RUN npm config set registry ${NPM_REGISTRY} \
+ && npm config set fetch-retries 5 \
+ && npm config set fetch-retry-mintimeout 20000 \
+ && npm config set fetch-retry-maxtimeout 120000
+# Retry npm ci to survive transient registry ECONNRESETs, which are common on
+# the QEMU-emulated arm64 leg of the multi-arch build.
+RUN i=0; until npm ci; do \
+      i=$((i+1)); \
+      if [ "$i" -ge 5 ]; then echo "npm ci failed after $i attempts"; exit 1; fi; \
+      echo "npm ci failed (attempt $i); retrying in 15s"; sleep 15; \
+    done
 COPY frontend/ ./
 RUN npm run build
 

--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -5,8 +5,17 @@ WORKDIR /app/frontend
 # Copy dependency files first to leverage cache
 COPY frontend/package.json frontend/package-lock.json ./
 ARG NPM_REGISTRY=https://registry.npmjs.org/
-RUN npm config set registry ${NPM_REGISTRY}
-RUN npm ci
+RUN npm config set registry ${NPM_REGISTRY} \
+ && npm config set fetch-retries 5 \
+ && npm config set fetch-retry-mintimeout 20000 \
+ && npm config set fetch-retry-maxtimeout 120000
+# Retry npm ci to survive transient registry ECONNRESETs, which are common on
+# the QEMU-emulated arm64 leg of the multi-arch build.
+RUN i=0; until npm ci; do \
+      i=$((i+1)); \
+      if [ "$i" -ge 5 ]; then echo "npm ci failed after $i attempts"; exit 1; fi; \
+      echo "npm ci failed (attempt $i); retrying in 15s"; sleep 15; \
+    done
 
 # Copy the rest of the frontend source
 COPY frontend/ ./


### PR DESCRIPTION
## Problem

The **Development Build** failed after a recent merge to main:

```
[linux/arm64 builder 13/16] RUN npm ci
npm error code ECONNRESET / errno -104 / network read ECONNRESET
exit code: 152
```

## Root cause

Not a code regression. The multi-arch build runs `npm ci` for the **arm64** image under **QEMU emulation** (`/dev/.buildkit_qemu_emulator`), which is slow and prone to **transient `ECONNRESET`** errors from the npm registry. The amd64 leg succeeded; only the emulated arm64 leg dropped its connection mid-download. The same `Dockerfile` (and `Dockerfile.single`) is used by the release workflow (`platforms: linux/amd64,linux/arm64`), so the real `v1.9.0` release publish could hit the same flake.

## Fix

In both `Dockerfile` and `Dockerfile.single`:
- Set npm `fetch-retries=5` with longer min/max timeouts (resilient per-request fetches).
- Wrap `npm ci` in an `until` retry loop (up to 5 attempts, 15s backoff) that still fails the build if all attempts fail.

## Notes

- Build-infra only; no app/dependency changes.
- The failed Development Build was also re-run (transient — expected to pass on retry); this PR prevents recurrence, especially on the emulated arm64 release leg.
- Recommend merging **before publishing the v1.9.0 release** (the draft targets `main`, so this fix will be included in the release build).