### PR TITLE
fix(providers): expose OpenRouter embedding modality (closes #717)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Thanks to the [Esperanto](https://github.com/lfnovo/esperanto) library, we suppo
 | DeepSeek     | ✅          | ❌               | ❌             | ❌             |
 | Voyage       | ❌          | ✅               | ❌             | ❌             |
 | xAI          | ✅          | ❌               | ❌             | ✅             |
-| OpenRouter   | ✅          | ❌               | ❌             | ❌             |
+| OpenRouter   | ✅          | ✅               | ❌             | ❌             |
 | DashScope (Qwen) | ✅          | ❌               | ❌             | ❌             |
 | MiniMax      | ✅          | ❌               | ❌             | ❌             |
 | OpenAI Compatible* | ✅          | ✅               | ✅             | ✅             |

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -71,7 +71,7 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "mistral": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "deepseek": ["language"],
     "xai": ["language", "text_to_speech"],
-    "openrouter": ["language"],
+    "openrouter": ["language", "embedding"],
     "voyage": ["embedding"],
     "elevenlabs": ["text_to_speech", "speech_to_text"],
     "deepgram": ["text_to_speech"],


### PR DESCRIPTION
## What

Aligns the backend with reality: **OpenRouter embeddings work end-to-end as of v1.9.0.**

- Esperanto 2.22 (shipped in 1.9.0) fixed the malformed OpenRouter embedding request body (`json=` vs `data=`), so the embedding call actually works.
- The frontend already offers the `embedding` modality for OpenRouter.
- Only the backend `PROVIDER_MODALITIES` still said `openrouter: [language]`, which fed `get_default_modalities()` — so **env/legacy credential migration** created OpenRouter credentials without the embedding modality. This fixes that.

## Changes
- `api/credentials_service.py`: `openrouter` → `["language", "embedding"]`
- `README.md`: OpenRouter embedding column → ✅

## Verification
- `uv run pytest tests/test_credentials_api.py` — 12 passed
- `get_default_modalities("openrouter")` → `['language', 'embedding']`

Closes #717