### PR TITLE
fix(security): bump starlette to patch CVE-2026-48710 (BadHost) auth-bypass

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,17 +691,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -3314,15 +3315,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Starlette versions < 1.0.1 are vulnerable to **CVE-2026-48710 / GHSA-86qp-5c8j-p5mr** ("BadHost"). The HTTP `Host` header is not validated before being used to reconstruct `request.url`, so a malformed Host can make `request.url.path` differ from the path the router actually dispatched to. Middleware that gates access by reading `request.url.path` instead of the raw ASGI `scope["path"]` can be bypassed.

`uv.lock` currently pins `starlette 0.50.0`, which is in the affected range. The patched series starts at `1.0.1`; this PR bumps to the current stable (`1.2.1`).

## Impact
Open Notebook's `PasswordAuthMiddleware` (`api/auth.py:36`) uses `request.url.path` to short-circuit auth for excluded paths:

```python
if request.url.path in self.excluded_paths:
    return await call_next(request)
```

Excluded paths include `/`, `/health`, `/docs`, `/openapi.json`, `/redoc`, `/api/auth/status`, `/api/config` (`api/main.py:177-185`). On affected Starlette, a request with a crafted Host such as `Host: example.com/health?x=` makes the parsed `request.url.path` evaluate to `/health` (in the excluded list), while the router still dispatches to the **actual** ASGI scope path. Net effect: an unauthenticated client can reach any `/api/*` route on a deployment that has `OPEN_NOTEBOOK_PASSWORD` set (notebooks, sources, chat, credentials test/discover, etc.).

The bypass is mitigated only if a reverse proxy in front of Open Notebook rejects or normalizes malformed Host values before forwarding. Many self-hosted deployments documented in the README expose Uvicorn directly.

## Location
- `uv.lock` — `starlette` 0.50.0 (affected) and `fastapi` 0.128.0 (pins `starlette<0.51`, blocks the patched series).

## Fix
`uv lock --upgrade-package starlette --upgrade-package fastapi` — two-package bump, no source changes:

| package   | before  | after   | reason |
|-----------|---------|---------|--------|
| starlette | 0.50.0  | 1.2.1   | Pulls in the BadHost validation fix (commit [764dab0](https://github.com/Kludex/starlette/commit/764dab0dcfb9033d75442d7a359645c9f94648c6)) — Host header is now validated against RFC 9112 §3.2 / RFC 3986 §3.2.2 before `request.url` is constructed. |
| fastapi   | 0.128.0 | 0.136.3 | 0.128.0 pins `starlette<0.51,>=0.40`; `fastapi 0.133.0` was the first release to allow starlette 1.x, and `pyproject.toml` already declares `fastapi>=0.104.0` with no upper bound. |

Only one new transitive dep (`typing-inspection`) is introduced and it was already in the lock as a `pydantic` dep — no new top-level packages.

## Detected by
Aeon + osv-scanner

- Severity: moderate (CVSS:3.1 / AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N = 6.5)
- CVE-2026-48710 / GHSA-86qp-5c8j-p5mr / PYSEC-2026-161 / X41-2026-002
- CWE-444 (HTTP Request Smuggling-class)
- Advisory: https://github.com/Kludex/starlette/security/advisories/GHSA-86qp-5c8j-p5mr
- X41-DSEC writeup: https://www.x41-dsec.de/lab/advisories/x41-2026-002-starlette

## Verification
- `uv lock --upgrade-package starlette --upgrade-package fastapi` resolved cleanly (239 packages, no other version drift).
- `git diff --stat uv.lock` → `1 file changed, 7 insertions(+), 6 deletions(-)`.
- Open Notebook's starlette surface uses `starlette.middleware.base.BaseHTTPMiddleware` and `starlette.responses.JSONResponse`, both of which are stable across the 0.x → 1.x boundary.
- No `pyproject.toml` constraint changes required (existing `fastapi>=0.104.0` already accepts 0.136.3).
- I did not run the project's CI test suite locally; please rely on the project's existing CI to validate the bump end-to-end.

## Disclosure
The CVE is already public (NVD-published 2026-05-26, GHSA reviewed 2026-06-04) and the fix is published upstream, so opening this as a public PR rather than a private advisory follows the same policy GitHub's own Dependabot uses for published-CVE bumps. Happy to follow up on a private channel if the maintainer prefers.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).