### PR TITLE
fix: use model_dump(exclude_unset=True) in PUT profile handlers

### DIFF
--- a/api/routers/episode_profiles.py
+++ b/api/routers/episode_profiles.py
@@ -137,18 +137,8 @@ async def update_episode_profile(profile_id: str, profile_data: EpisodeProfileCr
                 status_code=404, detail=f"Episode profile '{profile_id}' not found"
             )
 
-        profile.name = profile_data.name
-        profile.description = profile_data.description
-        profile.speaker_config = profile_data.speaker_config
-        profile.outline_llm = profile_data.outline_llm
-        profile.transcript_llm = profile_data.transcript_llm
-        profile.language = profile_data.language
-        profile.default_briefing = profile_data.default_briefing
-        profile.num_segments = profile_data.num_segments
-        profile.outline_provider = profile_data.outline_provider
-        profile.outline_model = profile_data.outline_model
-        profile.transcript_provider = profile_data.transcript_provider
-        profile.transcript_model = profile_data.transcript_model
+        for field, value in profile_data.model_dump(exclude_unset=True).items():
+            setattr(profile, field, value)
 
         await profile.save()
         return _profile_to_response(profile)

--- a/api/routers/speaker_profiles.py
+++ b/api/routers/speaker_profiles.py
@@ -113,12 +113,8 @@ async def update_speaker_profile(profile_id: str, profile_data: SpeakerProfileCr
                 status_code=404, detail=f"Speaker profile '{profile_id}' not found"
             )
 
-        profile.name = profile_data.name
-        profile.description = profile_data.description
-        profile.voice_model = profile_data.voice_model
-        profile.speakers = profile_data.speakers
-        profile.tts_provider = profile_data.tts_provider
-        profile.tts_model = profile_data.tts_model
+        for field, value in profile_data.model_dump(exclude_unset=True).items():
+            setattr(profile, field, value)
 
         await profile.save()
         return _profile_to_response(profile)


### PR DESCRIPTION
## Summary

Closes #809

`PUT /api/episode-profiles/{id}` and `PUT /api/speaker-profiles/{id}` both blindly assigned **every** field of the Pydantic request model (including `Optional[str] = None` defaults) to the database object. SurrealDB rejects `None` for string-typed fields — so saving a profile from the UI without explicitly re-selecting dropdown values produced HTTP 500:

```
Failed to update record: Found NONE for field `outline_model`, with record `episode_profile:...`, but expected a string
```

## Fix

Replace the per-field blind-assign blocks with:

```python
for field, value in profile_data.model_dump(exclude_unset=True).items():
    setattr(profile, field, value)
```

`exclude_unset=True` means **only fields the client explicitly included** in the request body are written through. Fields absent from the payload keep their current database values, so omitting a dropdown in the UI no longer overwrites a valid string with `None`.

To explicitly clear a field, the client can send `"field": null` — which will still be applied.

## Files changed

- `api/routers/episode_profiles.py` — `update_episode_profile` handler
- `api/routers/speaker_profiles.py` — `update_speaker_profile` handler (same bug, confirmed in issue comments)

## Test plan
- [ ] Edit an existing Episode Profile without changing Outline Model / Transcript Model → save should succeed (HTTP 200)
- [ ] Edit an existing Speaker Profile without changing TTS provider/model → save should succeed
- [ ] Sending `null` for a previously-set field should still clear it
- [ ] Full round-trip: create → fetch → update (partial) → fetch; unchanged fields retain original values