### PR TITLE
fix: add Notebook.get_context() for podcast generation

### DIFF
--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -26,11 +26,12 @@ class Notebook(ObjectModel):
             raise InvalidInputError("Notebook name cannot be empty")
         return v
 
-    async def get_sources(self) -> List["Source"]:
+    async def get_sources(self, include_full_text: bool = False) -> List["Source"]:
         try:
+            source_projection = "" if include_full_text else " omit source.full_text"
             srcs = await repo_query(
-                """
-                select * omit source.full_text from (
+                f"""
+                select *{source_projection} from (
                 select in as source from reference where out=$id
                 fetch source
             ) order by source.updated desc
@@ -43,11 +44,16 @@ class Notebook(ObjectModel):
             logger.exception(e)
             raise DatabaseOperationError(e)
 
-    async def get_notes(self) -> List["Note"]:
+    async def get_notes(self, include_content: bool = False) -> List["Note"]:
         try:
+            note_projection = (
+                " omit note.embedding"
+                if include_content
+                else " omit note.content, note.embedding"
+            )
             srcs = await repo_query(
-                """
-            select * omit note.content, note.embedding from (
+                f"""
+            select *{note_projection} from (
                 select in as note from artifact where out=$id
                 fetch note
             ) order by note.updated desc
@@ -59,6 +65,66 @@ class Notebook(ObjectModel):
             logger.error(f"Error fetching notes for notebook {self.id}: {str(e)}")
             logger.exception(e)
             raise DatabaseOperationError(e)
+
+    async def get_context(self) -> str:
+        """
+        Build long-form notebook context for podcast and LLM workflows.
+
+        Normal list retrieval omits large source/note bodies, so this method uses
+        opt-in full-content fetches and formats only substantive context blocks.
+        """
+        sources = await self.get_sources(include_full_text=True)
+        notes = await self.get_notes(include_content=True)
+        context_blocks = []
+
+        for source in sources:
+            source_context = await source.get_context(context_size="long")
+            if isinstance(source_context, dict):
+                title = source_context.get("title") or source.title or "Untitled source"
+                full_text = source_context.get("full_text")
+                insights = source_context.get("insights") or []
+
+                content_parts = []
+                if full_text:
+                    content_parts.append(str(full_text))
+
+                insight_lines = []
+                for insight in insights:
+                    if not isinstance(insight, dict):
+                        continue
+
+                    insight_content = insight.get("content")
+                    if not insight_content:
+                        continue
+
+                    insight_type = insight.get("insight_type") or "Insight"
+                    insight_lines.append(f"- {insight_type}: {insight_content}")
+
+                if insight_lines:
+                    content_parts.append("Insights:\n" + "\n".join(insight_lines))
+
+                content = "\n\n".join(content_parts).strip()
+            else:
+                title = source.title or "Untitled source"
+                content = str(source_context).strip()
+
+            if content:
+                context_blocks.append(f"## Source: {title}\n\n{content}")
+
+        for note in notes:
+            note_context = note.get_context(context_size="long")
+            if isinstance(note_context, dict):
+                title = note_context.get("title") or note.title or "Untitled note"
+                content = note_context.get("content")
+                content = str(content).strip() if content else ""
+            else:
+                title = note.title or "Untitled note"
+                content = str(note_context).strip()
+
+            if content:
+                context_blocks.append(f"## Note: {title}\n\n{content}")
+
+        return "\n\n".join(context_blocks)
 
     async def get_chat_sessions(self) -> List["ChatSession"]:
         try:

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -5,13 +5,16 @@ This test suite focuses on validation logic, business rules, and data structures
 that can be tested without database mocking.
 """
 
+import sys
 import tempfile
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import ValidationError
 
+from api.podcast_service import PodcastService
 from open_notebook.ai.models import ModelManager
 from open_notebook.domain.base import RecordModel
 from open_notebook.domain.content_settings import ContentSettings
@@ -98,6 +101,118 @@ class TestNotebookDomain:
 
         notebook_archived = Notebook(name="Test", description="Test", archived=True)
         assert notebook_archived.archived is True
+
+    @pytest.mark.asyncio
+    async def test_notebook_get_context_includes_source_full_text(self):
+        """Test notebook context includes full source content for podcasts."""
+        notebook = Notebook(id="notebook:test", name="Test", description="Test")
+        sources = [
+            Source(
+                id="source:first",
+                title="First Source",
+                full_text="First source full text for podcast generation.",
+            ),
+            Source(
+                id="source:second",
+                title="Second Source",
+                full_text="Second source full text for podcast generation.",
+            ),
+        ]
+        get_sources_calls = []
+
+        async def fake_get_sources(self, include_full_text=False):
+            get_sources_calls.append(include_full_text)
+            return sources
+
+        async def fake_get_notes(self, include_content=False):
+            return []
+
+        async def fake_get_insights(self):
+            return []
+
+        with (
+            patch.object(Notebook, "get_sources", new=fake_get_sources),
+            patch.object(Notebook, "get_notes", new=fake_get_notes),
+            patch.object(Source, "get_insights", new=fake_get_insights),
+        ):
+            context = await notebook.get_context()
+
+        assert get_sources_calls == [True]
+        assert "## Source: First Source" in context
+        assert "First source full text for podcast generation." in context
+        assert "## Source: Second Source" in context
+        assert "Second source full text for podcast generation." in context
+        assert "Notebook(id=" not in context
+
+    @pytest.mark.asyncio
+    async def test_notebook_get_context_includes_note_content(self):
+        """Test notebook context includes linked note content."""
+        notebook = Notebook(id="notebook:test", name="Test", description="Test")
+        notes = [
+            Note(
+                id="note:first",
+                title="Research Note",
+                content="Important notebook note for the podcast.",
+            )
+        ]
+        get_notes_calls = []
+
+        async def fake_get_sources(self, include_full_text=False):
+            return []
+
+        async def fake_get_notes(self, include_content=False):
+            get_notes_calls.append(include_content)
+            return notes
+
+        with (
+            patch.object(Notebook, "get_sources", new=fake_get_sources),
+            patch.object(Notebook, "get_notes", new=fake_get_notes),
+        ):
+            context = await notebook.get_context()
+
+        assert get_notes_calls == [True]
+        assert "## Note: Research Note" in context
+        assert "Important notebook note for the podcast." in context
+
+    @pytest.mark.asyncio
+    async def test_notebook_get_context_returns_empty_string_without_content(self):
+        """Test notebooks with no source or note content produce empty context."""
+        notebook = Notebook(id="notebook:test", name="Test", description="Test")
+
+        async def fake_get_sources(self, include_full_text=False):
+            return []
+
+        async def fake_get_notes(self, include_content=False):
+            return []
+
+        with (
+            patch.object(Notebook, "get_sources", new=fake_get_sources),
+            patch.object(Notebook, "get_notes", new=fake_get_notes),
+        ):
+            assert await notebook.get_context() == ""
+
+    @pytest.mark.asyncio
+    async def test_notebook_get_context_propagates_source_errors(self):
+        """Test source context failures are not swallowed by notebook context."""
+        notebook = Notebook(id="notebook:test", name="Test", description="Test")
+        source = Source(id="source:first", title="First Source")
+
+        async def fake_get_sources(self, include_full_text=False):
+            return [source]
+
+        async def fake_get_notes(self, include_content=False):
+            return []
+
+        async def fake_get_context(self, context_size="short"):
+            raise RuntimeError("source context failed")
+
+        with (
+            patch.object(Notebook, "get_sources", new=fake_get_sources),
+            patch.object(Notebook, "get_notes", new=fake_get_notes),
+            patch.object(Source, "get_context", new=fake_get_context),
+        ):
+            with pytest.raises(RuntimeError, match="source context failed"):
+                await notebook.get_context()
 
 
 # ============================================================================
@@ -200,7 +315,6 @@ class TestSourceDomain:
             result = await source.delete()
             assert result is True
             mock_delete.assert_called_once()
-
 
     @pytest.mark.asyncio
     async def test_vectorize_raises_valueerror_when_no_text(self):
@@ -334,6 +448,77 @@ class TestPodcastDomain:
         )
         assert len(profile.speakers) == 1
         assert profile.speakers[0]["name"] == "Host"
+
+
+class TestPodcastService:
+    """Test suite for podcast service notebook content resolution."""
+
+    @pytest.mark.asyncio
+    async def test_submit_generation_job_uses_notebook_context_content(self):
+        """Test notebook podcast jobs submit real source content, not model repr."""
+        notebook = Notebook(id="notebook:test", name="Test", description="Test")
+        sources = [
+            Source(
+                id="source:first",
+                title="First Source",
+                full_text="First source full text for submitted podcast content.",
+            ),
+            Source(
+                id="source:second",
+                title="Second Source",
+                full_text="Second source full text for submitted podcast content.",
+            ),
+        ]
+        submitted_args = {}
+
+        async def fake_get_sources(self, include_full_text=False):
+            return sources
+
+        async def fake_get_notes(self, include_content=False):
+            return []
+
+        async def fake_get_insights(self):
+            return []
+
+        def fake_submit_command(app_name, command_name, command_args):
+            submitted_args.update(command_args)
+            return "command:podcast"
+
+        fake_commands_module = ModuleType("commands.podcast_commands")
+        # The real commands/__init__.py runs `from .podcast_commands import
+        # generate_podcast_command` when the package is imported, so the fake
+        # submodule must expose that name or the package import fails before the
+        # patched submit_command is reached.
+        fake_commands_module.generate_podcast_command = lambda *a, **k: None
+
+        with (
+            patch.object(
+                EpisodeProfile, "get_by_name", new=AsyncMock(return_value=object())
+            ),
+            patch.object(
+                SpeakerProfile, "get_by_name", new=AsyncMock(return_value=object())
+            ),
+            patch.object(Notebook, "get", new=AsyncMock(return_value=notebook)),
+            patch.object(Notebook, "get_sources", new=fake_get_sources),
+            patch.object(Notebook, "get_notes", new=fake_get_notes),
+            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch("api.podcast_service.submit_command", new=fake_submit_command),
+            patch.dict(
+                sys.modules, {"commands.podcast_commands": fake_commands_module}
+            ),
+        ):
+            job_id = await PodcastService.submit_generation_job(
+                episode_profile_name="Episode",
+                speaker_profile_name="Speakers",
+                episode_name="Episode Name",
+                notebook_id="notebook:test",
+            )
+
+        assert job_id == "command:podcast"
+        content = submitted_args["content"]
+        assert "First source full text for submitted podcast content." in content
+        assert "Second source full text for submitted podcast content." in content
+        assert "Notebook(id=" not in content
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

Podcast generation from a notebook produced useless content because `PodcastService` expected `Notebook.get_context()` to assemble the source/note bodies, but that method did not exist on the model. As a result the podcast command received empty/placeholder context (and `Notebook(id=...)` repr leakage), so the generated audio had nothing real to work from.

This adds `Notebook.get_context()` and the opt-in retrieval it needs:

- `get_sources(include_full_text=False)` and `get_notes(include_content=False)` now take a flag that controls whether the large `full_text` / `content` fields are fetched. The default still omits them (so existing list views stay cheap); the new context path opts in.
- `get_context()` fetches full sources and notes, calls each object's `get_context(context_size="long")`, and formats only substantive blocks (`## Source: <title>` / `## Note: <title>`), skipping empties and folding insights into a readable list. The notebook repr no longer leaks into podcast content.

## Related Issue

Fixes #808

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Existing tests pass (`uv run pytest`)
- [x] Added new unit tests

**Test Details:** `uv run pytest tests/test_domain.py` — 23 passed. New `TestPodcastService` case asserts the submitted podcast content contains each source's full text and does not contain the `Notebook(id=...)` repr. `uv run ruff check open_notebook/domain/notebook.py tests/test_domain.py` passes.

## Design Alignment

- [x] API-First Architecture
- [x] Async-First for Performance

**Explanation:** `get_context()` is an async domain method that the API/podcast service consumes; full-body retrieval stays opt-in so default queries remain lightweight.

## Checklist

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [x] I have added type hints to my code (Python)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran linting: `ruff check .`

### Documentation
- [x] I have added/updated docstrings for new/modified functions

### Database Changes
- [ ] No database schema changes

### Breaking Changes
- [ ] No breaking changes (new param defaults preserve existing behavior)

## Additional Context

The two retrieval flags default to the previous omit-large-fields behavior, so callers other than `get_context()` are unaffected.

AI was used for assistance.
