### PR TITLE
Fix legacy embedding jobs after command rename

### DIFF
--- a/commands/embedding_commands.py
+++ b/commands/embedding_commands.py
@@ -7,8 +7,8 @@ from surreal_commands import CommandInput, CommandOutput, command, submit_comman
 
 from open_notebook.ai.models import model_manager
 from open_notebook.database.repository import ensure_record_id, repo_insert, repo_query
-from open_notebook.exceptions import ConfigurationError
 from open_notebook.domain.notebook import Note, Source, SourceInsight
+from open_notebook.exceptions import ConfigurationError
 from open_notebook.utils.chunking import ContentType, chunk_text, detect_content_type
 from open_notebook.utils.embedding import generate_embedding, generate_embeddings
 
@@ -118,6 +118,58 @@ class EmbedSourceOutput(CommandOutput):
     error_message: Optional[str] = None
 
 
+class LegacyEmbedSingleItemInput(CommandInput):
+    """Input for the pre-1.6 embed_single_item command kept for queued jobs."""
+
+    item_id: str
+    item_type: Literal["source", "note", "insight"]
+
+
+class LegacyEmbedSingleItemOutput(CommandOutput):
+    """Output matching the pre-1.6 embed_single_item command shape."""
+
+    success: bool
+    item_id: str
+    item_type: str
+    chunks_created: int = 0
+    processing_time: float
+    error_message: Optional[str] = None
+
+
+class LegacyEmbedChunkInput(CommandInput):
+    """Input for the pre-1.6 per-chunk embedding command kept for queued jobs."""
+
+    source_id: str
+    chunk_index: int
+    chunk_text: str
+
+
+class LegacyEmbedChunkOutput(CommandOutput):
+    """Output matching the pre-1.6 embed_chunk command shape."""
+
+    success: bool
+    source_id: str
+    chunk_index: int
+    error_message: Optional[str] = None
+
+
+class LegacyVectorizeSourceInput(CommandInput):
+    """Input for the pre-1.6 vectorize_source command kept for queued jobs."""
+
+    source_id: str
+
+
+class LegacyVectorizeSourceOutput(CommandOutput):
+    """Output matching the pre-1.6 vectorize_source command shape."""
+
+    success: bool
+    source_id: str
+    total_chunks: int
+    jobs_submitted: int
+    processing_time: float
+    error_message: Optional[str] = None
+
+
 @command(
     "embed_note",
     app="open_notebook",
@@ -126,7 +178,10 @@ class EmbedSourceOutput(CommandOutput):
         "wait_strategy": "exponential_jitter",
         "wait_min": 1,
         "wait_max": 60,
-        "stop_on": [ValueError, ConfigurationError],  # Don't retry validation/config errors
+        "stop_on": [
+            ValueError,
+            ConfigurationError,
+        ],  # Don't retry validation/config errors
         "retry_log_level": "debug",
     },
 )
@@ -218,7 +273,10 @@ async def embed_note_command(input_data: EmbedNoteInput) -> EmbedNoteOutput:
         "wait_strategy": "exponential_jitter",
         "wait_min": 1,
         "wait_max": 60,
-        "stop_on": [ValueError, ConfigurationError],  # Don't retry validation/config errors
+        "stop_on": [
+            ValueError,
+            ConfigurationError,
+        ],  # Don't retry validation/config errors
         "retry_log_level": "debug",
     },
 )
@@ -312,7 +370,10 @@ async def embed_insight_command(input_data: EmbedInsightInput) -> EmbedInsightOu
         "wait_strategy": "exponential_jitter",
         "wait_min": 1,
         "wait_max": 60,
-        "stop_on": [ValueError, ConfigurationError],  # Don't retry validation/config errors
+        "stop_on": [
+            ValueError,
+            ConfigurationError,
+        ],  # Don't retry validation/config errors
         "retry_log_level": "debug",
     },
 )
@@ -371,7 +432,7 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
             f"Created {total_chunks} chunks for source {input_data.source_id} "
             f"(sizes: min={min(chunk_sizes) if chunk_sizes else 0}, "
             f"max={max(chunk_sizes) if chunk_sizes else 0}, "
-            f"avg={sum(chunk_sizes)//len(chunk_sizes) if chunk_sizes else 0} chars)"
+            f"avg={sum(chunk_sizes) // len(chunk_sizes) if chunk_sizes else 0} chars)"
         )
 
         if total_chunks == 0:
@@ -441,6 +502,218 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
 
 
 @command(
+    "embed_single_item",
+    app="open_notebook",
+    retry={
+        "max_attempts": 5,
+        "wait_strategy": "exponential_jitter",
+        "wait_min": 1,
+        "wait_max": 60,
+        "stop_on": [ValueError, ConfigurationError],
+        "retry_log_level": "debug",
+    },
+)
+async def legacy_embed_single_item_command(
+    input_data: LegacyEmbedSingleItemInput,
+) -> LegacyEmbedSingleItemOutput:
+    """
+    Compatibility handler for pre-1.6 queued embed_single_item jobs.
+
+    New code submits embed_source, embed_note, or embed_insight directly. This
+    alias lets workers drain older queues after an upgrade.
+    """
+    start_time = time.time()
+
+    try:
+        logger.info(
+            f"Processing legacy embed_single_item for "
+            f"{input_data.item_type}: {input_data.item_id}"
+        )
+
+        if input_data.item_type == "source":
+            result = await embed_source_command(
+                EmbedSourceInput(
+                    source_id=input_data.item_id,
+                    execution_context=input_data.execution_context,
+                )
+            )
+            chunks_created = result.chunks_created
+        elif input_data.item_type == "note":
+            result = await embed_note_command(
+                EmbedNoteInput(
+                    note_id=input_data.item_id,
+                    execution_context=input_data.execution_context,
+                )
+            )
+            chunks_created = 0
+        elif input_data.item_type == "insight":
+            result = await embed_insight_command(
+                EmbedInsightInput(
+                    insight_id=input_data.item_id,
+                    execution_context=input_data.execution_context,
+                )
+            )
+            chunks_created = 0
+        else:
+            raise ValueError(f"Invalid item_type: {input_data.item_type}")
+
+        return LegacyEmbedSingleItemOutput(
+            success=result.success,
+            item_id=input_data.item_id,
+            item_type=input_data.item_type,
+            chunks_created=chunks_created,
+            processing_time=time.time() - start_time,
+            error_message=result.error_message,
+        )
+
+    except ValueError as e:
+        processing_time = time.time() - start_time
+        logger.error(
+            f"Failed legacy embed_single_item for "
+            f"{input_data.item_type} {input_data.item_id}: {e}"
+        )
+        return LegacyEmbedSingleItemOutput(
+            success=False,
+            item_id=input_data.item_id,
+            item_type=input_data.item_type,
+            processing_time=processing_time,
+            error_message=str(e),
+        )
+    except Exception as e:
+        logger.debug(
+            f"Transient error in legacy embed_single_item for "
+            f"{input_data.item_type} {input_data.item_id}: {e}"
+        )
+        raise
+
+
+@command(
+    "embed_chunk",
+    app="open_notebook",
+    retry={
+        "max_attempts": 5,
+        "wait_strategy": "exponential_jitter",
+        "wait_min": 1,
+        "wait_max": 60,
+        "stop_on": [ValueError, ConfigurationError],
+        "retry_log_level": "debug",
+    },
+)
+async def legacy_embed_chunk_command(
+    input_data: LegacyEmbedChunkInput,
+) -> LegacyEmbedChunkOutput:
+    """
+    Compatibility handler for pre-1.6 queued embed_chunk jobs.
+
+    The legacy vectorizer stored the full chunk payload in each job. Keeping this
+    command registered prevents upgraded workers from crashing on stale queues.
+    """
+    try:
+        logger.debug(
+            f"Processing legacy chunk {input_data.chunk_index} "
+            f"for source {input_data.source_id}"
+        )
+
+        cmd_id = get_command_id(input_data)
+        embedding = await generate_embedding(
+            input_data.chunk_text,
+            content_type=ContentType.PLAIN,
+            command_id=cmd_id,
+        )
+
+        await repo_query(
+            """
+            CREATE source_embedding CONTENT {
+                "source": $source_id,
+                "order": $order,
+                "content": $content,
+                "embedding": $embedding,
+            };
+            """,
+            {
+                "source_id": ensure_record_id(input_data.source_id),
+                "order": input_data.chunk_index,
+                "content": input_data.chunk_text,
+                "embedding": embedding,
+            },
+        )
+
+        return LegacyEmbedChunkOutput(
+            success=True,
+            source_id=input_data.source_id,
+            chunk_index=input_data.chunk_index,
+        )
+
+    except ValueError as e:
+        logger.error(
+            f"Failed legacy embed_chunk for source {input_data.source_id} "
+            f"chunk {input_data.chunk_index}: {e}"
+        )
+        return LegacyEmbedChunkOutput(
+            success=False,
+            source_id=input_data.source_id,
+            chunk_index=input_data.chunk_index,
+            error_message=str(e),
+        )
+    except Exception as e:
+        logger.debug(
+            f"Transient error in legacy embed_chunk for source "
+            f"{input_data.source_id} chunk {input_data.chunk_index}: {e}"
+        )
+        raise
+
+
+@command("vectorize_source", app="open_notebook", retry=None)
+async def legacy_vectorize_source_command(
+    input_data: LegacyVectorizeSourceInput,
+) -> LegacyVectorizeSourceOutput:
+    """
+    Compatibility handler for pre-1.6 queued vectorize_source jobs.
+
+    The old command submitted one job per chunk. Current embed_source does the
+    same source embedding work in one batch-aware command.
+    """
+    start_time = time.time()
+
+    try:
+        logger.info(f"Processing legacy vectorize_source for {input_data.source_id}")
+        result = await embed_source_command(
+            EmbedSourceInput(
+                source_id=input_data.source_id,
+                execution_context=input_data.execution_context,
+            )
+        )
+        jobs_submitted = 1 if result.success else 0
+
+        return LegacyVectorizeSourceOutput(
+            success=result.success,
+            source_id=input_data.source_id,
+            total_chunks=result.chunks_created,
+            jobs_submitted=jobs_submitted,
+            processing_time=time.time() - start_time,
+            error_message=result.error_message,
+        )
+
+    except ValueError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Failed legacy vectorize_source for {input_data.source_id}: {e}")
+        return LegacyVectorizeSourceOutput(
+            success=False,
+            source_id=input_data.source_id,
+            total_chunks=0,
+            jobs_submitted=0,
+            processing_time=processing_time,
+            error_message=str(e),
+        )
+    except Exception as e:
+        logger.debug(
+            f"Transient error in legacy vectorize_source for "
+            f"{input_data.source_id}: {e}"
+        )
+        raise
+
+
+@command(
     "create_insight",
     app="open_notebook",
     retry={
@@ -448,7 +721,10 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
         "wait_strategy": "exponential_jitter",
         "wait_min": 1,
         "wait_max": 60,
-        "stop_on": [ValueError, ConfigurationError],  # Don't retry validation/config errors
+        "stop_on": [
+            ValueError,
+            ConfigurationError,
+        ],  # Don't retry validation/config errors
         "retry_log_level": "debug",
     },
 )

--- a/tests/test_embedding_commands.py
+++ b/tests/test_embedding_commands.py
@@ -1,0 +1,102 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from surreal_commands import registry
+
+import commands
+import commands.embedding_commands as embedding_commands
+
+
+def test_legacy_embedding_commands_are_registered():
+    app_commands = registry.list_commands()["open_notebook"]
+
+    assert "embed_chunk" in app_commands
+    assert "embed_single_item" in app_commands
+    assert "vectorize_source" in app_commands
+
+
+@pytest.mark.asyncio
+async def test_legacy_embed_chunk_processes_stale_queue_payload(monkeypatch):
+    mock_generate_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    mock_repo_query = AsyncMock()
+
+    monkeypatch.setattr(
+        embedding_commands, "generate_embedding", mock_generate_embedding
+    )
+    monkeypatch.setattr(embedding_commands, "repo_query", mock_repo_query)
+    monkeypatch.setattr(
+        embedding_commands, "ensure_record_id", lambda value: f"record:{value}"
+    )
+
+    result = await embedding_commands.legacy_embed_chunk_command(
+        embedding_commands.LegacyEmbedChunkInput(
+            source_id="source:abc",
+            chunk_index=2,
+            chunk_text="queued legacy chunk",
+        )
+    )
+
+    assert result.success is True
+    assert result.source_id == "source:abc"
+    assert result.chunk_index == 2
+    mock_generate_embedding.assert_awaited_once_with(
+        "queued legacy chunk",
+        content_type=embedding_commands.ContentType.PLAIN,
+        command_id="unknown",
+    )
+    mock_repo_query.assert_awaited_once()
+    assert mock_repo_query.await_args is not None
+    assert mock_repo_query.await_args.args[1] == {
+        "source_id": "record:source:abc",
+        "order": 2,
+        "content": "queued legacy chunk",
+        "embedding": [0.1, 0.2, 0.3],
+    }
+
+
+@pytest.mark.asyncio
+async def test_legacy_vectorize_source_delegates_to_embed_source(monkeypatch):
+    async def fake_embed_source(input_data):
+        assert input_data.source_id == "source:abc"
+        return embedding_commands.EmbedSourceOutput(
+            success=True,
+            source_id=input_data.source_id,
+            chunks_created=3,
+            processing_time=0.1,
+        )
+
+    monkeypatch.setattr(embedding_commands, "embed_source_command", fake_embed_source)
+
+    result = await embedding_commands.legacy_vectorize_source_command(
+        embedding_commands.LegacyVectorizeSourceInput(source_id="source:abc")
+    )
+
+    assert result.success is True
+    assert result.source_id == "source:abc"
+    assert result.total_chunks == 3
+    assert result.jobs_submitted == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_embed_single_item_routes_insights(monkeypatch):
+    async def fake_embed_insight(input_data):
+        assert input_data.insight_id == "source_insight:abc"
+        return embedding_commands.EmbedInsightOutput(
+            success=True,
+            insight_id=input_data.insight_id,
+            processing_time=0.1,
+        )
+
+    monkeypatch.setattr(embedding_commands, "embed_insight_command", fake_embed_insight)
+
+    result = await embedding_commands.legacy_embed_single_item_command(
+        embedding_commands.LegacyEmbedSingleItemInput(
+            item_id="source_insight:abc",
+            item_type="insight",
+        )
+    )
+
+    assert result.success is True
+    assert result.item_id == "source_insight:abc"
+    assert result.item_type == "insight"
+    assert result.chunks_created == 0


### PR DESCRIPTION
## Summary

Fixes #695.

- Register compatibility handlers for the pre-1.6 embedding commands `embed_chunk`, `embed_single_item`, and `vectorize_source`.
- Let upgraded workers drain stale queued jobs instead of raising `Command not found: open_notebook.embed_chunk` before command status can be updated.
- Delegate legacy whole-item/source commands to the current `embed_source`, `embed_note`, and `embed_insight` handlers; process old per-chunk payloads with the current embedding helper.
- Add tests covering registration through the worker import path and legacy payload handling.

## Validation

- `uv run ruff check commands/embedding_commands.py tests/test_embedding_commands.py --fix`
- `uv run ruff format commands/embedding_commands.py tests/test_embedding_commands.py`
- `uv run pytest tests/test_embedding.py tests/test_embedding_commands.py -q` (22 passed)
- `uv run --with mypy python -m mypy commands/embedding_commands.py tests/test_embedding_commands.py` still reports existing type errors in `open_notebook/utils/chunking.py`, `open_notebook/database/repository.py`, `open_notebook/domain/credential.py`, and `commands/source_commands.py`; no errors remain in the new test after fixing its optional `await_args` assertion.

Written by an agent for Federicorao (GPT-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

