### PR TITLE
fix: cascade delete commands and insights when deleting source

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -951,16 +951,16 @@ async def delete_source(source_id: str):
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")
 
-    # Clean up associated commands to prevent zombie processes
-    command_id = getattr(source, 'command_id', None)
-    if command_id:
-        try:
-            command_id_str = str(command_id)
-            from surreal_commands import cancel_command
-            await cancel_command(command_id_str)
-            logger.info(f"Cancelled command {command_id_str} for source {source_id}")
-        except Exception as e:
-            logger.warning(f"Failed to cancel command {command_id}: {e}")
+        # Clean up associated commands to prevent zombie processes
+        command_id = getattr(source, 'command_id', None)
+        if command_id:
+            try:
+                command_id_str = str(command_id)
+                from surreal_commands import cancel_command
+                await cancel_command(command_id_str)
+                logger.info(f"Cancelled command {command_id_str} for source {source_id}")
+            except Exception as e:
+                logger.warning(f"Failed to cancel command {command_id}: {e}")
 
         # Delete all associated insights
         try:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -951,15 +951,16 @@ async def delete_source(source_id: str):
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")
 
-        # Clean up associated commands to prevent zombie processes
-        if source.command_id:
-            try:
-                command_id = str(source.command_id)
-                from surreal_commands import cancel_command
-                await cancel_command(command_id)
-                logger.info(f"Cancelled command {command_id} for source {source_id}")
-            except Exception as e:
-                logger.warning(f"Failed to cancel command {source.command_id}: {e}")
+    # Clean up associated commands to prevent zombie processes
+    command_id = getattr(source, 'command_id', None)
+    if command_id:
+        try:
+            command_id_str = str(command_id)
+            from surreal_commands import cancel_command
+            await cancel_command(command_id_str)
+            logger.info(f"Cancelled command {command_id_str} for source {source_id}")
+        except Exception as e:
+            logger.warning(f"Failed to cancel command {command_id}: {e}")
 
         # Delete all associated insights
         try:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -945,15 +945,34 @@ async def retry_source_processing(source_id: str):
 
 @router.delete("/sources/{source_id}")
 async def delete_source(source_id: str):
-    """Delete a source."""
+    """Delete a source and all associated commands/insights."""
     try:
         source = await Source.get(source_id)
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")
 
-        await source.delete()
+        # Clean up associated commands to prevent zombie processes
+        if source.command_id:
+            try:
+                command_id = str(source.command_id)
+                from surreal_commands import cancel_command
+                await cancel_command(command_id)
+                logger.info(f"Cancelled command {command_id} for source {source_id}")
+            except Exception as e:
+                logger.warning(f"Failed to cancel command {source.command_id}: {e}")
 
-        return {"message": "Source deleted successfully"}
+        # Delete all associated insights
+        try:
+            insights = await source.get_insights()
+            for insight in insights:
+                await insight.delete()
+            logger.info(f"Deleted {len(insights)} insights for source {source_id}")
+        except Exception as e:
+            logger.warning(f"Failed to delete insights for source {source_id}: {e}")
+
+        # Finally delete the source
+        await source.delete()
+        return {"message": "Source and associated resources deleted successfully"}
     except HTTPException:
         raise
     except Exception as e:


### PR DESCRIPTION
## Problem

When deleting a source in the UI, the associated commands in SurrealDB are not cleaned up. This causes zombie processes that block the worker from processing new sources.

## Symptoms

- Worker continuously tries to process non-existent sources
- Error logs show: `NotFoundError: source with id source:xxx not found`
- New sources get stuck in "new" status and never start processing
- After deleting stuck sources, the problem gets worse

## Root Cause

The `delete_source` endpoint in `api/routers/sources.py` only deletes the source record, but does not:
1. Cancel associated commands
2. Delete associated insights
3. Clean up any related database records

## Solution

Added cascade delete logic to:
- Cancel associated commands before deleting source
- Delete all associated insights
- Log cleanup actions for debugging

## Testing

- Manually tested by deleting sources and verifying no zombie commands remain
- Verified worker can process new sources after deleting stuck ones

## Related

Fixes #886

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

