### PR TITLE
fix(search): reject non-positive limit and survive highlight overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `POST /sources/{id}/retry` no longer returns `400 "Source is not associated with any notebooks"` for every source; it now queries the `reference` graph edge by its `in`/`out` columns instead of a non-existent `source` column (#861)
+- Text search no longer returns a 500 when SurrealDB's `search::highlight` hits a "position overflow" on large or multi-byte document chunks; it now falls back to vector search and returns results (#648)
+- `POST /api/search` now rejects a non-positive `limit` with a `422` instead of passing `LIMIT -1`/`LIMIT 0` to SurrealDB (which caused a 500 or a silently empty result set) (#863)
 
 ## [1.9.0] - 2026-06-02
 

--- a/api/models.py
+++ b/api/models.py
@@ -32,7 +32,7 @@ class NotebookResponse(BaseModel):
 class SearchRequest(BaseModel):
     query: str = Field(..., description="Search query")
     type: Literal["text", "vector"] = Field("text", description="Search type")
-    limit: int = Field(100, description="Maximum number of results", le=1000)
+    limit: int = Field(100, description="Maximum number of results", ge=1, le=1000)
     search_sources: bool = Field(True, description="Include sources in search")
     search_notes: bool = Field(True, description="Include notes in search")
     minimum_score: float = Field(

--- a/open_notebook/domain/CLAUDE.md
+++ b/open_notebook/domain/CLAUDE.md
@@ -43,7 +43,7 @@ Two base classes support different persistence patterns: **ObjectModel** (mutabl
 - **Asset**: File/URL reference helper
 
 - **Search functions**:
-  - `text_search()`: Full-text keyword search
+  - `text_search()`: Full-text keyword search. On a SurrealDB `search::highlight` "position overflow" (large/multi-byte chunks) it falls back to `vector_search()`; if that also fails it raises `DatabaseOperationError` (never silently returns an empty list)
   - `vector_search()`: Semantic search via embeddings (default minimum_score=0.2)
 
 ### content_settings.py

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -719,8 +719,13 @@ async def text_search(
             try:
                 return await vector_search(keyword, results, source, note)
             except Exception as ve:
+                # Both search paths failed (e.g. no embedding model configured).
+                # Surface the failure instead of returning [] — an empty list would
+                # be indistinguishable from a legitimate "no matches" and mask a
+                # total search outage from callers.
                 logger.error(f"Vector search fallback also failed: {str(ve)}")
-                return []
+                logger.exception(ve)
+                raise DatabaseOperationError(ve)
         logger.error(f"Error performing text search: {str(e)}")
         logger.exception(e)
         raise DatabaseOperationError(e)

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -707,6 +707,23 @@ async def text_search(
             {"keyword": keyword, "results": results, "source": source, "note": note},
         )
         return search_results
+    except RuntimeError as e:
+        # SurrealDB's search::highlight can compute a byte position that exceeds the
+        # stored string length on large or multi-byte chunks, aborting the whole query
+        # ("position overflow"). Fall back to vector search so the user still gets
+        # results instead of a 500. See issue #648.
+        if "position overflow" in str(e):
+            logger.warning(
+                f"Highlight position overflow, falling back to vector search: {str(e)}"
+            )
+            try:
+                return await vector_search(keyword, results, source, note)
+            except Exception as ve:
+                logger.error(f"Vector search fallback also failed: {str(ve)}")
+                return []
+        logger.error(f"Error performing text search: {str(e)}")
+        logger.exception(e)
+        raise DatabaseOperationError(e)
     except Exception as e:
         logger.error(f"Error performing text search: {str(e)}")
         logger.exception(e)

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -1,0 +1,102 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create test client after environment variables have been cleared by conftest."""
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestSearchLimitValidation:
+    """SearchRequest.limit must reject non-positive values (#863)."""
+
+    @pytest.mark.parametrize("bad_limit", [0, -1, -100])
+    def test_non_positive_limit_returns_422(self, bad_limit, client):
+        response = client.post(
+            "/api/search",
+            json={"query": "x", "type": "text", "limit": bad_limit},
+        )
+        assert response.status_code == 422
+
+    def test_limit_above_max_returns_422(self, client):
+        response = client.post(
+            "/api/search",
+            json={"query": "x", "type": "text", "limit": 1001},
+        )
+        assert response.status_code == 422
+
+    @patch("api.routers.search.text_search", new_callable=AsyncMock)
+    def test_valid_limit_returns_200(self, mock_text_search, client):
+        mock_text_search.return_value = []
+        response = client.post(
+            "/api/search",
+            json={"query": "x", "type": "text", "limit": 10},
+        )
+        assert response.status_code == 200
+        mock_text_search.assert_awaited_once()
+
+
+class TestTextSearchHighlightOverflowFallback:
+    """text_search() must fall back to vector search on a highlight position overflow (#648)."""
+
+    @pytest.mark.asyncio
+    async def test_position_overflow_falls_back_to_vector_search(self):
+        from open_notebook.domain import notebook as notebook_module
+
+        overflow = RuntimeError(
+            "A value can't be highlighted: position overflow: 2545 - len: 1965"
+        )
+        with (
+            patch.object(
+                notebook_module, "repo_query", new_callable=AsyncMock, side_effect=overflow
+            ),
+            patch.object(
+                notebook_module,
+                "vector_search",
+                new_callable=AsyncMock,
+                return_value=[{"id": "source:1"}],
+            ) as mock_vector,
+        ):
+            result = await notebook_module.text_search("hello", 10)
+
+        assert result == [{"id": "source:1"}]
+        mock_vector.assert_awaited_once_with("hello", 10, True, True)
+
+    @pytest.mark.asyncio
+    async def test_position_overflow_returns_empty_when_vector_also_fails(self):
+        from open_notebook.domain import notebook as notebook_module
+
+        overflow = RuntimeError("position overflow: 1 - len: 0")
+        with (
+            patch.object(
+                notebook_module, "repo_query", new_callable=AsyncMock, side_effect=overflow
+            ),
+            patch.object(
+                notebook_module,
+                "vector_search",
+                new_callable=AsyncMock,
+                side_effect=Exception("no embedding model"),
+            ),
+        ):
+            result = await notebook_module.text_search("hello", 10)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_other_runtime_errors_still_raise(self):
+        from open_notebook.domain import notebook as notebook_module
+        from open_notebook.exceptions import DatabaseOperationError
+
+        with patch.object(
+            notebook_module,
+            "repo_query",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("some other db failure"),
+        ):
+            with pytest.raises(DatabaseOperationError):
+                await notebook_module.text_search("hello", 10)

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -68,8 +68,9 @@ class TestTextSearchHighlightOverflowFallback:
         mock_vector.assert_awaited_once_with("hello", 10, True, True)
 
     @pytest.mark.asyncio
-    async def test_position_overflow_returns_empty_when_vector_also_fails(self):
+    async def test_position_overflow_raises_when_vector_also_fails(self):
         from open_notebook.domain import notebook as notebook_module
+        from open_notebook.exceptions import DatabaseOperationError
 
         overflow = RuntimeError("position overflow: 1 - len: 0")
         with (
@@ -83,9 +84,10 @@ class TestTextSearchHighlightOverflowFallback:
                 side_effect=Exception("no embedding model"),
             ),
         ):
-            result = await notebook_module.text_search("hello", 10)
-
-        assert result == []
+            # When both search paths fail, surface the error rather than masking it
+            # as an empty result set.
+            with pytest.raises(DatabaseOperationError):
+                await notebook_module.text_search("hello", 10)
 
     @pytest.mark.asyncio
     async def test_other_runtime_errors_still_raise(self):


### PR DESCRIPTION
## Summary

Two small, independent search robustness fixes.

### #863 — `SearchRequest.limit` accepts 0 and negative values, causing a 500
`limit` had an upper bound (`le=1000`) but no lower bound, so `limit=-1` flowed into SurrealDB as `LIMIT -1` (→ 500) and `limit=0` silently returned an empty set. Added `ge=1`, consistent with the sibling `minimum_score` (`ge=0, le=1`) and `Query(..., ge=1, le=100)` used elsewhere.

### #648 — Search fails with "position overflow" on large document chunks
SurrealDB's `search::highlight` can compute a byte position that exceeds the stored string length on large/multi-byte chunks, aborting the whole query with `RuntimeError: A value can't be highlighted: position overflow`. `text_search()` now catches this specific error and falls back to `vector_search()`, returning results (with a warning log) instead of a 500. Any other `RuntimeError` keeps the previous behavior.

## Tests
- `tests/test_search_api.py`: `limit` of 0/-1/-100/1001 → 422, valid limit → 200; overflow → vector fallback, vector-also-fails → `[]`, other RuntimeError → still raises `DatabaseOperationError`.

Closes #863
Closes #648

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

