### PR TITLE
docs: fix local quickstart (Ollama env + nav) and document worker step

### DIFF
--- a/docs/0-START-HERE/quick-start-local.md
+++ b/docs/0-START-HERE/quick-start-local.md
@@ -56,6 +56,9 @@ services:
       - SURREAL_PASSWORD=password
       - SURREAL_NAMESPACE=open_notebook
       - SURREAL_DATABASE=open_notebook
+
+      # Ollama (required when running Ollama via Docker, as in this compose file)
+      - OLLAMA_BASE_URL=http://ollama:11434
     volumes:
       - ./notebook_data:/app/data
     depends_on:
@@ -129,7 +132,7 @@ You should see the Open Notebook interface.
 
 ## Step 6: Configure Ollama Provider (1 min)
 
-1. Go to **Settings** → **API Keys**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Ollama**
 4. Give it a name (e.g., "Local Ollama")
@@ -142,7 +145,7 @@ You should see the Open Notebook interface.
 
 ## Step 7: Configure Local Model (1 min)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Set:
    - **Language Model**: `ollama/mistral` (or whichever model you downloaded)
    - **Embedding Model**: `ollama/nomic-embed-text` (auto-downloads if missing)

--- a/docs/1-INSTALLATION/from-source.md
+++ b/docs/1-INSTALLATION/from-source.md
@@ -66,7 +66,7 @@ cp .env.example .env
 # OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
 ```
 
-After starting the app, configure AI providers via the **Settings → API Keys** UI in the browser.
+After starting the app, configure AI providers via the **Manage → Models** UI in the browser.
 
 ### 5. Start API
 
@@ -76,23 +76,38 @@ make api
 # or: uv run --env-file .env uvicorn api.main:app --host 0.0.0.0 --port 5055
 ```
 
-### 6. Start Frontend
+### 6. Start Worker
+
+Source and note processing (content extraction, embedding, insights) is dispatched
+as background jobs that a **separate worker** process consumes. Without it, every
+source stays stuck at `Source processing status: CommandStatus.NEW` forever.
 
 ```bash
 # Terminal 3
+make worker
+# or: uv run --env-file .env surreal-commands-worker --import-modules commands
+```
+
+> `make start-all` starts Database + API + Worker + Frontend together; the steps
+> above run them individually so you can see each process's logs.
+
+### 7. Start Frontend
+
+```bash
+# Terminal 4
 cd frontend && npm install && npm run dev
 ```
 
-### 7. Access
+### 8. Access
 
 - **Frontend**: http://localhost:3000
 - **API Docs**: http://localhost:5055/docs
 - **Database**: http://localhost:8000
 
-### 8. Configure AI Provider
+### 9. Configure AI Provider
 
 1. Open http://localhost:3000
-2. Go to **Settings** → **API Keys**
+2. Go to **Manage** → **Models**
 3. Click **Add Credential** → Select your provider → Paste API key
 4. Click **Save**, then **Test Connection**
 5. Click **Discover Models** → **Register Models**


### PR DESCRIPTION
## Summary

Two documentation fixes for the installation guides.

### #781 — Update Quickstart documentation (`docs/0-START-HERE/quick-start-local.md`)
- Add the `OLLAMA_BASE_URL=http://ollama:11434` env var to the `open_notebook` service. It's required to reach the Dockerized Ollama and is already present in `examples/docker-compose-ollama.yml`, but was missing from the quickstart compose file.
- Fix the provider/model setup navigation: the UI has no "Settings → API Keys"; credentials and models are configured under **Manage → Models** (Steps 6 and 7).

### #779 — Sources stuck at `CommandStatus.NEW` (`docs/1-INSTALLATION/from-source.md`)
Root cause (per maintainer triage): source/note processing runs as surreal-commands jobs consumed by a **separate worker**; the from-source guide never told you to start it, so following it literally left every source stuck at `CommandStatus.NEW`.
- Add a "Start Worker" step between API and Frontend (`make worker`), mirroring `make start-all`, and renumber the following steps.
- Fix the same outdated "Settings → API Keys" navigation reference here too.

Docs-only; no code or CHANGELOG changes.

Closes #781
Closes #779

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

