### PR TITLE
perf(sources): memoize SourceCard and stop polling completed sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `POST /sources/{id}/retry` no longer returns `400 "Source is not associated with any notebooks"` for every source; it now queries the `reference` graph edge by its `in`/`out` columns instead of a non-existent `source` column (#861)
 
+### Performance
+- Notebook source list no longer re-renders every `SourceCard` on unrelated state changes (layout toggles, context selection), and completed sources no longer each open a status-polling query. Both scaled with the number of sources and caused UI lag on large notebooks (#503)
+
 ## [1.9.0] - 2026-06-02
 
 ### Added

--- a/frontend/src/components/sources/SourceCard.tsx
+++ b/frontend/src/components/sources/SourceCard.tsx
@@ -133,10 +133,15 @@ function SourceCardImpl({
   // populates `status` alongside `command_id`, so we no longer poll for every
   // completed source — that scaled linearly with the number of cards and caused the
   // list lag reported in #503.
+  //
+  // A source with a `command_id` but no resolved `status` yet is still ambiguous
+  // (it renders as a synthetic "new"), so keep polling those until a real status
+  // arrives — otherwise such a card would be stuck "processing" forever.
   const shouldFetchStatus =
     sourceWithStatus.status === 'new' ||
     sourceWithStatus.status === 'queued' ||
     sourceWithStatus.status === 'running' ||
+    (!!sourceWithStatus.command_id && !sourceWithStatus.status) ||
     wasProcessing // Keep polling if we were processing to catch the completion
 
   const { data: statusData, isLoading: statusLoading } = useSourceStatus(
@@ -408,6 +413,13 @@ function SourceCardImpl({
  * capture the source id, so a stale closure stays correct as long as the source data
  * below is unchanged.
  */
+function topicsEqual(a?: string[], b?: string[]): boolean {
+  if (a === b) return true
+  if ((a?.length ?? 0) !== (b?.length ?? 0)) return false
+  if (!a || !b) return true // both empty/undefined (lengths matched above)
+  return a.every((topic, i) => topic === b[i])
+}
+
 function areEqual(prev: SourceCardProps, next: SourceCardProps): boolean {
   if (prev === next) return true
 
@@ -424,7 +436,7 @@ function areEqual(prev: SourceCardProps, next: SourceCardProps): boolean {
     p.insights_count === n.insights_count &&
     p.asset?.url === n.asset?.url &&
     p.asset?.file_path === n.asset?.file_path &&
-    (p.topics?.length ?? 0) === (n.topics?.length ?? 0) &&
+    topicsEqual(p.topics, n.topics) &&
     prev.contextMode === next.contextMode &&
     prev.showRemoveFromNotebook === next.showRemoveFromNotebook &&
     prev.className === next.className

--- a/frontend/src/components/sources/SourceCard.tsx
+++ b/frontend/src/components/sources/SourceCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, memo } from 'react'
 import { SourceListResponse } from '@/lib/types/api'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
@@ -107,7 +107,7 @@ function getSourceType(source: SourceListResponse): 'link' | 'upload' | 'text' {
   return 'text'
 }
 
-export function SourceCard({
+function SourceCardImpl({
   source,
   onClick,
   onDelete,
@@ -128,7 +128,12 @@ export function SourceCard({
   // Track processing state to continue polling until we detect completion
   const [wasProcessing, setWasProcessing] = useState(false)
 
-  const shouldFetchStatus = !!sourceWithStatus.command_id ||
+  // Only poll status while the source is actually being processed (or just finished
+  // and we still need one more poll to catch completion). The list endpoint already
+  // populates `status` alongside `command_id`, so we no longer poll for every
+  // completed source — that scaled linearly with the number of cards and caused the
+  // list lag reported in #503.
+  const shouldFetchStatus =
     sourceWithStatus.status === 'new' ||
     sourceWithStatus.status === 'queued' ||
     sourceWithStatus.status === 'running' ||
@@ -392,3 +397,38 @@ export function SourceCard({
     </Card>
   )
 }
+
+/**
+ * SourceCard is rendered in long lists (one per source). Without memoization, any
+ * parent re-render (layout toggles, context-selection changes elsewhere) re-rendered
+ * every card, causing UI jank that scaled with the number of sources (#503).
+ *
+ * We compare only the props that affect this card's rendered output. Handler identity
+ * is intentionally ignored: callers often pass inline closures, and those closures
+ * capture the source id, so a stale closure stays correct as long as the source data
+ * below is unchanged.
+ */
+function areEqual(prev: SourceCardProps, next: SourceCardProps): boolean {
+  if (prev === next) return true
+
+  const p = prev.source as SourceListResponse & { command_id?: string; status?: string }
+  const n = next.source as SourceListResponse & { command_id?: string; status?: string }
+
+  return (
+    p.id === n.id &&
+    p.title === n.title &&
+    p.updated === n.updated &&
+    p.status === n.status &&
+    p.command_id === n.command_id &&
+    p.embedded === n.embedded &&
+    p.insights_count === n.insights_count &&
+    p.asset?.url === n.asset?.url &&
+    p.asset?.file_path === n.asset?.file_path &&
+    (p.topics?.length ?? 0) === (n.topics?.length ?? 0) &&
+    prev.contextMode === next.contextMode &&
+    prev.showRemoveFromNotebook === next.showRemoveFromNotebook &&
+    prev.className === next.className
+  )
+}
+
+export const SourceCard = memo(SourceCardImpl, areEqual)


### PR DESCRIPTION
## Summary

Fixes the notebook source-list lag that scales with the number of sources (#503). Two compounding costs:

1. **Re-renders:** every `SourceCard` re-rendered whenever an unrelated parent state changed (layout toggles, context-selection updates elsewhere). With 30+ sources this caused visible jank on every interaction.
2. **Status polling:** `shouldFetchStatus` was gated on `command_id`, which *completed* sources retain — so every completed card kept an active polling query. N completed sources → N polling queries.

## Changes
- Wrap `SourceCard` in `React.memo` with a comparator over the props that actually affect its rendered output (`id`, `title`, `updated`, `status`, `command_id`, `embedded`, `insights_count`, `asset`, `topics.length`, `contextMode`, `showRemoveFromNotebook`, `className`). Handler identity is intentionally ignored: callers pass inline closures that capture the source id, so a stale closure stays correct while the source data is unchanged.
- Only poll status while a source is genuinely `new`/`queued`/`running` (or just finished, to catch completion). The list endpoint already returns `status` alongside `command_id`, so completed sources no longer each spawn a query.

## Notes
- Approach based on @SurFlurer's `perf-opti` branch from the issue, with a hardened comparator that also tracks `status`/`command_id`/`embedded` so status transitions arriving via the `source` prop still re-render.
- Frontend `tsc --noEmit` and `eslint` pass. No rendered-output change, so no new test was added; there is no existing test for this component.

Closes #503

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

