### PR TITLE
fix(credentials): persist Ollama num_ctx via a flexible config object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `POST /sources/{id}/retry` no longer returns `400 "Source is not associated with any notebooks"` for every source; it now queries the `reference` graph edge by its `in`/`out` columns instead of a non-existent `source` column (#861)
 - Text search no longer returns a 500 when SurrealDB's `search::highlight` hits a "position overflow" on large or multi-byte document chunks; it now falls back to vector search and returns results (#648)
 - `POST /api/search` now rejects a non-positive `limit` with a `422` instead of passing `LIMIT -1`/`LIMIT 0` to SurrealDB (which caused a 500 or a silently empty result set) (#863)
+- Ollama `num_ctx` credential override is now persisted. The `credential` table gained a flexible `config` object (migration 15) and provider-specific tuning options are stored there instead of being dropped by the SCHEMAFULL table; future per-credential options can be added without a schema migration (#875)
 
 ### Performance
 - Notebook source list no longer re-renders every `SourceCard` on unrelated state changes (layout toggles, context selection), and completed sources no longer each open a status-polling query. Both scaled with the number of sources and caused UI lag on large notebooks (#503)

--- a/open_notebook/database/CLAUDE.md
+++ b/open_notebook/database/CLAUDE.md
@@ -50,7 +50,7 @@ Both leverage connection context manager for lifecycle management and automatic 
   - `run_one_down()`: Rollback latest migration
 
 - `AsyncMigrationManager`: Main orchestrator
-  - Loads 14 up migrations + 14 down migrations (hard-coded in __init__; migrations 11-12 add credential system, 13 adds model-credential link, 14 adds podcast model registry fields)
+  - Loads 15 up migrations + 15 down migrations (hard-coded in __init__; migrations 11-12 add credential system, 13 adds model-credential link, 14 adds podcast model registry fields, 15 adds the flexible `config` object to the credential table)
   - `get_current_version()`: Query max version from _sbl_migrations table
   - `needs_migration()`: Boolean check (current < total migrations available)
   - `run_migration_up()`: Run all pending migrations with logging

--- a/open_notebook/database/async_migrate.py
+++ b/open_notebook/database/async_migrate.py
@@ -118,6 +118,9 @@ class AsyncMigrationManager:
             AsyncMigration.from_file(
                 "open_notebook/database/migrations/14.surrealql"
             ),
+            AsyncMigration.from_file(
+                "open_notebook/database/migrations/15.surrealql"
+            ),
         ]
         self.down_migrations = [
             AsyncMigration.from_file(
@@ -161,6 +164,9 @@ class AsyncMigrationManager:
             ),
             AsyncMigration.from_file(
                 "open_notebook/database/migrations/14_down.surrealql"
+            ),
+            AsyncMigration.from_file(
+                "open_notebook/database/migrations/15_down.surrealql"
             ),
         ]
         self.runner = AsyncMigrationRunner(

--- a/open_notebook/database/migrations/15.surrealql
+++ b/open_notebook/database/migrations/15.surrealql
@@ -1,0 +1,6 @@
+-- Migration 15: Add a flexible config object to the credential table.
+-- Stores provider-specific tuning options (e.g. Ollama num_ctx) without a
+-- schema change per option. FLEXIBLE allows arbitrary keys inside the object
+-- on this SCHEMAFULL table; validation stays in the Pydantic Credential model.
+
+DEFINE FIELD config ON credential FLEXIBLE TYPE option<object>;

--- a/open_notebook/database/migrations/15_down.surrealql
+++ b/open_notebook/database/migrations/15_down.surrealql
@@ -1,0 +1,3 @@
+-- Migration 15 rollback: remove the flexible config field from credential
+
+REMOVE FIELD IF EXISTS config ON TABLE credential;

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -70,29 +70,28 @@ class Credential(ObjectModel):
     project: Optional[str] = None
     location: Optional[str] = None
     credentials_path: Optional[str] = None
+    # Flexible provider config bag, persisted as-is to the credential table's
+    # `config` FLEXIBLE object (migration 15). This is the source of truth on
+    # disk and holds both the keys this version maps (see CONFIG_EXTRAS) and any
+    # keys written by a newer version, so a load/save round-trip never clobbers
+    # options this version doesn't know about.
+    config: Optional[Dict[str, Any]] = None
+
     # Ollama-only: overrides the context window (num_ctx). Esperanto defaults to
     # 8192; raise this if your hardware can handle a larger context window.
+    # Exposed as a top-level field (and on the API) for convenience; it mirrors
+    # config["num_ctx"].
     num_ctx: Optional[int] = None
 
-    @model_validator(mode="before")
-    @classmethod
-    def _lift_config(cls, data: Any) -> Any:
-        """Lift provider-specific extras out of the persisted `config` object.
-
-        On read, the DB row carries a flexible `config` object holding options
-        like `num_ctx`. Spread those back onto the corresponding top-level model
-        fields so the model's public shape is unchanged, then drop `config`.
-        """
-        if isinstance(data, dict) and isinstance(data.get("config"), dict):
-            data = dict(data)
-            config = data.pop("config")
-            for key in cls.CONFIG_EXTRAS:
-                if key in config and data.get(key) is None:
-                    data[key] = config[key]
-        elif isinstance(data, dict) and "config" in data and data["config"] is None:
-            # Drop a null `config` so it isn't stored as an extra attribute.
-            data = {k: v for k, v in data.items() if k != "config"}
-        return data
+    @model_validator(mode="after")
+    def _mirror_config_to_fields(self) -> "Credential":
+        """Mirror known keys from the persisted `config` bag onto their
+        convenience fields on load, without losing unmapped keys."""
+        if isinstance(self.config, dict):
+            for key in self.CONFIG_EXTRAS:
+                if self.config.get(key) is not None and getattr(self, key, None) is None:
+                    object.__setattr__(self, key, self.config[key])
+        return self
 
     def to_esperanto_config(self) -> Dict[str, Any]:
         """
@@ -220,10 +219,11 @@ class Credential(ObjectModel):
         return [Model(**row) for row in results]
 
     def _prepare_save_data(self) -> Dict[str, Any]:
-        """Override to encrypt api_key and pack provider extras into `config`."""
+        """Override to encrypt api_key and sync provider extras into `config`."""
         data = {}
         for key, value in self.model_dump().items():
-            if key == "decryption_error":
+            if key in ("decryption_error", "config"):
+                # `config` is rebuilt below from the existing bag + convenience fields.
                 continue
             if key == "api_key":
                 # Handle SecretStr: extract, encrypt, store
@@ -235,14 +235,19 @@ class Credential(ObjectModel):
             elif value is not None or key in self.__class__.nullable_fields:
                 data[key] = value
 
-        # Pack provider-specific extras into the flexible `config` object so the
-        # SCHEMAFULL credential table doesn't drop them (migration 15). Only
-        # non-null values are stored; `config` is None when there are none.
-        config: Dict[str, Any] = {}
+        # Sync the convenience fields (num_ctx, ...) into the flexible `config`
+        # object so the SCHEMAFULL credential table doesn't drop them (migration
+        # 15). Starting from the existing bag preserves any keys written by a
+        # newer version, since repo_update MERGE replaces the whole object.
+        # `config` is None only when the merged result is genuinely empty.
+        config: Dict[str, Any] = dict(self.config or {})
         for key in self.__class__.CONFIG_EXTRAS:
-            value = data.pop(key, None)
+            data.pop(key, None)  # not a top-level column; lives in `config`
+            value = getattr(self, key, None)
             if value is not None:
                 config[key] = value
+            else:
+                config.pop(key, None)
         data["config"] = config or None
 
         return data

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -83,15 +83,21 @@ class Credential(ObjectModel):
     # config["num_ctx"].
     num_ctx: Optional[int] = None
 
-    @model_validator(mode="after")
-    def _mirror_config_to_fields(self) -> "Credential":
+    @model_validator(mode="before")
+    @classmethod
+    def _mirror_config_to_fields(cls, data: Any) -> Any:
         """Mirror known keys from the persisted `config` bag onto their
-        convenience fields on load, without losing unmapped keys."""
-        if isinstance(self.config, dict):
-            for key in self.CONFIG_EXTRAS:
-                if self.config.get(key) is not None and getattr(self, key, None) is None:
-                    object.__setattr__(self, key, self.config[key])
-        return self
+        convenience fields on load. Done in `before` so the values flow through
+        normal Pydantic field validation (e.g. `num_ctx` is coerced/validated as
+        an int) instead of being set raw. Unknown keys stay in `config` untouched
+        and are preserved on save."""
+        if isinstance(data, dict) and isinstance(data.get("config"), dict):
+            config = data["config"]
+            data = dict(data)
+            for key in cls.CONFIG_EXTRAS:
+                if data.get(key) is None and config.get(key) is not None:
+                    data[key] = config[key]
+        return data
 
     def to_esperanto_config(self) -> Dict[str, Any]:
         """

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional
 
 from loguru import logger
-from pydantic import SecretStr
+from pydantic import SecretStr, model_validator
 
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.base import ObjectModel
@@ -47,8 +47,13 @@ class Credential(ObjectModel):
         "project",
         "location",
         "credentials_path",
-        "num_ctx",
     }
+
+    # Provider-specific tuning options that are exposed as top-level fields on
+    # this model but persisted inside the flexible `config` object on the
+    # `credential` table (migration 15). Adding a new such option only requires
+    # declaring the Pydantic field below and listing it here — no DB migration.
+    CONFIG_EXTRAS: ClassVar[set[str]] = {"num_ctx"}
 
     name: str
     provider: str
@@ -68,6 +73,26 @@ class Credential(ObjectModel):
     # Ollama-only: overrides the context window (num_ctx). Esperanto defaults to
     # 8192; raise this if your hardware can handle a larger context window.
     num_ctx: Optional[int] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_config(cls, data: Any) -> Any:
+        """Lift provider-specific extras out of the persisted `config` object.
+
+        On read, the DB row carries a flexible `config` object holding options
+        like `num_ctx`. Spread those back onto the corresponding top-level model
+        fields so the model's public shape is unchanged, then drop `config`.
+        """
+        if isinstance(data, dict) and isinstance(data.get("config"), dict):
+            data = dict(data)
+            config = data.pop("config")
+            for key in cls.CONFIG_EXTRAS:
+                if key in config and data.get(key) is None:
+                    data[key] = config[key]
+        elif isinstance(data, dict) and "config" in data and data["config"] is None:
+            # Drop a null `config` so it isn't stored as an extra attribute.
+            data = {k: v for k, v in data.items() if k != "config"}
+        return data
 
     def to_esperanto_config(self) -> Dict[str, Any]:
         """
@@ -195,7 +220,7 @@ class Credential(ObjectModel):
         return [Model(**row) for row in results]
 
     def _prepare_save_data(self) -> Dict[str, Any]:
-        """Override to encrypt api_key before storage."""
+        """Override to encrypt api_key and pack provider extras into `config`."""
         data = {}
         for key, value in self.model_dump().items():
             if key == "decryption_error":
@@ -209,6 +234,16 @@ class Credential(ObjectModel):
                     data["api_key"] = None
             elif value is not None or key in self.__class__.nullable_fields:
                 data[key] = value
+
+        # Pack provider-specific extras into the flexible `config` object so the
+        # SCHEMAFULL credential table doesn't drop them (migration 15). Only
+        # non-null values are stored; `config` is None when there are none.
+        config: Dict[str, Any] = {}
+        for key in self.__class__.CONFIG_EXTRAS:
+            value = data.pop(key, None)
+            if value is not None:
+                config[key] = value
+        data["config"] = config or None
 
         return data
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -616,5 +616,69 @@ class TestEpisodeProfile:
         assert profile.num_segments == 5
 
 
+# ============================================================================
+# TEST SUITE: Credential flexible config bag (#875)
+# ============================================================================
+
+
+class TestCredentialConfigBag:
+    """Provider-specific extras (num_ctx) round-trip through the flexible
+    `config` object instead of a dedicated SCHEMAFULL column."""
+
+    def test_prepare_save_data_packs_num_ctx_into_config(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(name="Local Ollama", provider="ollama", num_ctx=16384)
+        data = cred._prepare_save_data()
+
+        assert data["config"] == {"num_ctx": 16384}
+        assert "num_ctx" not in data  # not a top-level column anymore
+
+    def test_prepare_save_data_config_none_when_no_extras(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(name="OpenAI", provider="openai")
+        data = cred._prepare_save_data()
+
+        assert data["config"] is None
+        assert "num_ctx" not in data
+
+    def test_db_row_with_config_lifts_num_ctx_to_top_level(self):
+        from open_notebook.domain.credential import Credential
+
+        # Simulates a row read back from the DB
+        cred = Credential(
+            name="Local Ollama",
+            provider="ollama",
+            config={"num_ctx": 8192},
+        )
+
+        assert cred.num_ctx == 8192
+        assert "config" not in cred.model_dump()  # not kept as a stray attribute
+
+    def test_num_ctx_round_trips_through_save_and_load(self):
+        from open_notebook.domain.credential import Credential
+
+        original = Credential(name="Local Ollama", provider="ollama", num_ctx=4096)
+        persisted = original._prepare_save_data()
+        # Rebuild from the persisted shape (as the DB would return it)
+        reloaded = Credential(
+            name=persisted["name"],
+            provider=persisted["provider"],
+            config=persisted["config"],
+        )
+
+        assert reloaded.num_ctx == 4096
+        assert reloaded.to_esperanto_config()["num_ctx"] == 4096
+
+    def test_null_config_is_dropped_on_load(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(name="OpenAI", provider="openai", config=None)
+
+        assert cred.num_ctx is None
+        assert "config" not in cred.model_dump()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -708,6 +708,23 @@ class TestCredentialConfigBag:
         data = cred._prepare_save_data()
         assert data["config"] == {"future_option": "keep-me"}
 
+    def test_mirrored_num_ctx_is_validated_as_int(self):
+        from open_notebook.domain.credential import Credential
+
+        # A value coming from the flexible config bag is routed through normal
+        # Pydantic field validation, not set raw.
+        cred = Credential(
+            name="Local Ollama", provider="ollama", config={"num_ctx": "8192"}
+        )
+        assert cred.num_ctx == 8192
+        assert isinstance(cred.num_ctx, int)
+
+        # A non-coercible value is rejected rather than silently flowing through.
+        with pytest.raises(ValidationError):
+            Credential(
+                name="Local Ollama", provider="ollama", config={"num_ctx": "not-an-int"}
+            )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -653,8 +653,7 @@ class TestCredentialConfigBag:
             config={"num_ctx": 8192},
         )
 
-        assert cred.num_ctx == 8192
-        assert "config" not in cred.model_dump()  # not kept as a stray attribute
+        assert cred.num_ctx == 8192  # mirrored from config onto the convenience field
 
     def test_num_ctx_round_trips_through_save_and_load(self):
         from open_notebook.domain.credential import Credential
@@ -671,13 +670,43 @@ class TestCredentialConfigBag:
         assert reloaded.num_ctx == 4096
         assert reloaded.to_esperanto_config()["num_ctx"] == 4096
 
-    def test_null_config_is_dropped_on_load(self):
+    def test_null_config_loads_without_extras(self):
         from open_notebook.domain.credential import Credential
 
         cred = Credential(name="OpenAI", provider="openai", config=None)
 
         assert cred.num_ctx is None
-        assert "config" not in cred.model_dump()
+        assert cred.config is None
+        assert cred._prepare_save_data()["config"] is None
+
+    def test_unmapped_config_keys_are_preserved_on_save(self):
+        from open_notebook.domain.credential import Credential
+
+        # A newer version may have written config keys this model doesn't map.
+        # They must survive a load/save round-trip rather than be clobbered
+        # (repo_update MERGE replaces the whole config object).
+        cred = Credential(
+            name="Local Ollama",
+            provider="ollama",
+            config={"num_ctx": 8192, "future_option": "keep-me"},
+        )
+        assert cred.num_ctx == 8192
+
+        data = cred._prepare_save_data()
+        assert data["config"] == {"num_ctx": 8192, "future_option": "keep-me"}
+
+    def test_clearing_num_ctx_keeps_other_config_keys(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(
+            name="Local Ollama",
+            provider="ollama",
+            config={"num_ctx": 8192, "future_option": "keep-me"},
+        )
+        cred.num_ctx = None  # user clears the override
+
+        data = cred._prepare_save_data()
+        assert data["config"] == {"future_option": "keep-me"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The Ollama `num_ctx` credential override was never persisted (#875). The `credential` table is `SCHEMAFULL`, and there was no `num_ctx` field defined on it, so SurrealDB silently dropped the value on write and the override never took effect.

## Approach

Instead of adding a typed column per provider option (which would mean a migration for every future knob — e.g. temperature/top_p, extra_body), this adds a single **flexible `config` object** to the `credential` table:

```surql
DEFINE FIELD config ON credential FLEXIBLE TYPE option<object>;
```

`FLEXIBLE` allows arbitrary keys inside the object on a SCHEMAFULL table (the same pattern already used by the `episode` and `source` tables). Validation stays in the Pydantic `Credential` model.

The model's public shape is **unchanged**: `num_ctx` remains a top-level field on `Credential` and on the API request/response models. The mapping happens only at the persistence boundary:
- `_prepare_save_data()` packs `CONFIG_EXTRAS` (currently `{"num_ctx"}`) into `config`.
- a `model_validator(mode="before")` lifts them back out of `config` on every read path (`get`, `get_all`, `get_by_provider`, `_from_db_row`).

Adding a future per-credential option now only needs a Pydantic field + an entry in `CONFIG_EXTRAS` — **no DB migration**.

## Changes
- `migrations/15.surrealql` (+ `15_down`): define/remove the `config` field; registered in `AsyncMigrationManager`.
- `Credential`: `CONFIG_EXTRAS`, `_lift_config` before-validator, config packing in `_prepare_save_data`; `num_ctx` dropped from `nullable_fields` (no longer a top-level column).
- API layer unchanged (`num_ctx` still top-level).

## Tests
- `tests/test_domain.py::TestCredentialConfigBag`: pack into `config`, `config` is `None` with no extras, lift back on load, full round-trip incl. `to_esperanto_config()`, and null-config handling.

Closes #875

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

