### PR TITLE
feat(sources): make retry prominent on failed source cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Failed source cards now show a prominent "Retry processing" button directly on the card instead of only inside the 3-dot dropdown; clicking it no longer also opens the source (the click was missing `stopPropagation`) (#726)
+
 ### Fixed
 - `POST /sources/{id}/retry` no longer returns `400 "Source is not associated with any notebooks"` for every source; it now queries the `reference` graph edge by its `in`/`out` columns instead of a non-existent `source` column (#861)
 - Text search no longer returns a 500 when SurrealDB's `search::highlight` hits a "position overflow" on large or multi-byte document chunks; it now falls back to vector search and returns results (#648)

--- a/frontend/src/components/sources/SourceCard.tsx
+++ b/frontend/src/components/sources/SourceCard.tsx
@@ -365,24 +365,28 @@ function SourceCardImpl({
           </DropdownMenu>
           </div>
         </div>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        {(isFailed as any) && (
+        {/* Prominent retry action surfaced directly on failed cards so it's
+            discoverable without opening the dropdown menu (#726). */}
+        {isFailed ? (
           <div className="flex gap-2 pt-2 border-t">
             <Button
-              variant="outline"
+              variant="default"
               size="sm"
-              onClick={handleRetry}
+              onClick={(e) => {
+                e.stopPropagation()
+                handleRetry()
+              }}
               disabled={!onRetry}
               className="h-7 text-xs"
             >
               <RefreshCw className="h-3 w-3 mr-1" />
-              {t('sources.retry')}
+              {t('sources.retryProcessing')}
             </Button>
           </div>
-        )}
+        ) : null}
 
         {/* Processing progress indicator */}
-        {isProcessing && statusData?.processing_info?.progress && (
+        {isProcessing && typeof statusData?.processing_info?.progress === 'number' && (
           <div className="mt-3 pt-2 border-t">
             <div className="flex justify-between items-center mb-1">
             <span className="text-xs text-gray-600">{t('common.progress')}</span>


### PR DESCRIPTION
## Summary

The retry action for a failed source was hard to discover — it lived in the 3-dot dropdown, and the inline button that was supposed to appear had two problems (#726):
1. It was gated behind a `(isFailed as any)` cast + `eslint-disable` hack.
2. Its click handler didn't `stopPropagation`, so clicking "Retry" also triggered the card's `onClick` and navigated to the source detail instead of just retrying.

## Changes
- Surface a filled **"Retry processing"** button directly on failed cards (was a subtle `outline` button).
- Add `e.stopPropagation()` to the retry click so it no longer opens the source.
- Remove the `(isFailed as any)` cast and its `eslint-disable` comment.
- Type the progress-indicator guard: `statusData.processing_info.progress` is `unknown` (the `processing_info` map is `Record<string, unknown>`), which previously contaminated the card's children type — the `any` cast on the sibling was masking it. The guard is now `typeof ... === 'number'`.

Frontend `tsc --noEmit` and `eslint` pass. No behavior change for non-failed cards.

Closes #726

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

