### PR TITLE
fix(search): page-level scroll for results + configurable API timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `NEXT_PUBLIC_API_TIMEOUT_MS` environment variable to configure the frontend API request timeout (default `600000` = 10 minutes; set `0` to disable). Lets slow/long-running chat models finish without editing source (#880)
+
 ### Fixed
+- Search and Ask results now use page-level scrolling instead of being confined to a cramped, height-capped (`60vh`) bottom container, so the full result set is readable (#882)
 - `POST /sources/{id}/retry` no longer returns `400 "Source is not associated with any notebooks"` for every source; it now queries the `reference` graph edge by its `in`/`out` columns instead of a non-existent `source` column (#861)
 - Text search no longer returns a 500 when SurrealDB's `search::highlight` hits a "position overflow" on large or multi-byte document chunks; it now falls back to vector search and returns results (#648)
 - `POST /api/search` now rejects a non-positive `limit` with a `422` instead of passing `LIMIT -1`/`LIMIT 0` to SurrealDB (which caused a 500 or a silently empty result set) (#863)

--- a/frontend/src/CLAUDE.md
+++ b/frontend/src/CLAUDE.md
@@ -40,7 +40,7 @@ User interactions trigger mutations/queries via hooks, which communicate with th
 ### Lib (`src/lib/`) — Data & State Layer
 
 #### `lib/api/` — Backend Communication
-- **`client.ts`**: Central Axios instance with auth interceptor, FormData handling, 10-min timeout
+- **`client.ts`**: Central Axios instance with auth interceptor, FormData handling, configurable request timeout (`NEXT_PUBLIC_API_TIMEOUT_MS`, default 10 min; `0` disables)
 - **`query-client.ts`**: TanStack Query configuration
 - **Resource modules** (`sources.ts`, `chat.ts`, `notebooks.ts`, etc.): Endpoint-specific functions returning typed responses
 - **Pattern**: All requests go through `apiClient`; auth token auto-added from localStorage

--- a/frontend/src/app/(dashboard)/search/page.tsx
+++ b/frontend/src/app/(dashboard)/search/page.tsx
@@ -158,7 +158,7 @@ export default function SearchPage() {
 
   return (
     <AppShell>
-      <div className="p-4 md:p-6">
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
         <h1 className="text-xl md:text-2xl font-bold mb-4 md:mb-6">{t('searchPage.askAndSearch')}</h1>
 
         <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'ask' | 'search')} className="w-full space-y-6">
@@ -440,7 +440,7 @@ export default function SearchPage() {
                         </CardContent>
                       </Card>
                     ) : (
-                      <div className="space-y-2 max-h-[60vh] overflow-y-auto pr-2">
+                      <div className="space-y-2">
                         {searchMutation.data.results.map((result, index) => {
                           // Parse type from parent_id (format: "source:id" or "note:id" or "source_insight:id")
                           // Handle null parent_id gracefully (orphaned records)

--- a/frontend/src/components/search/StreamingResponse.tsx
+++ b/frontend/src/components/search/StreamingResponse.tsx
@@ -56,7 +56,7 @@ export function StreamingResponse({
 
   return (
     <div
-      className="space-y-4 mt-6 max-h-[60vh] overflow-y-auto pr-2"
+      className="space-y-4 mt-6"
       role="region"
       aria-label={t('common.accessibility.askResponse')}
       aria-live="polite"

--- a/frontend/src/lib/api/CLAUDE.md
+++ b/frontend/src/lib/api/CLAUDE.md
@@ -11,7 +11,7 @@ Axios-based client and resource-specific API modules for backend communication w
 
 ## Important Patterns
 
-- **Single axios instance**: `apiClient` with 10-minute timeout (for slow LLM operations)
+- **Single axios instance**: `apiClient` with a configurable request timeout for slow LLM operations — `NEXT_PUBLIC_API_TIMEOUT_MS` (default `600000` = 10 min; an explicit `0` disables it, empty/invalid falls back to the default)
 - **Request interceptor**: Auto-fetches base URL from config, adds Bearer auth from localStorage `auth-storage`
 - **FormData handling**: Auto-removes Content-Type header for FormData to let browser set multipart boundary
 - **Response interceptor**: 401 clears auth and redirects to `/login`
@@ -41,7 +41,7 @@ Axios-based client and resource-specific API modules for backend communication w
 
 - **Base URL delay**: First request waits for `getApiUrl()` to resolve; can be slow on startup
 - **FormData fields as JSON strings**: Nested objects (arrays, objects) must be JSON stringified in FormData (e.g., `notebooks`, `transformations`)
-- **Timeout for streaming**: 10-minute timeout may not cover very long-running LLM operations; consider extending if needed
+- **Timeout for streaming**: the default 10-minute timeout may not cover very long-running LLM operations; raise it via `NEXT_PUBLIC_API_TIMEOUT_MS` (or set `0` to disable)
 - **Auth token management**: Token stored in localStorage `auth-storage` key; uses Zustand persist middleware
 - **Headers mutation in interceptor**: Mutating `config.headers` directly; be careful with middleware order
 - **No automatic retry logic**: Failed requests not automatically retried; must be handled in consuming code. Podcast episodes have explicit retry via `retryEpisode()` in `podcasts.ts` and `useRetryPodcastEpisode()` hook

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -8,9 +8,12 @@ import { getApiUrl } from '@/lib/config'
 // operations (transformations, insights, synchronous chat) on slower hardware
 // (Ollama, LM Studio). Configure it via NEXT_PUBLIC_API_TIMEOUT_MS for models
 // that can take longer than 10 minutes to respond (#880).
-// Note: value is in milliseconds; 0 disables the timeout entirely.
+// Note: value is in milliseconds; an explicit 0 disables the timeout entirely.
+// An empty or invalid value falls back to the default (so a present-but-empty
+// env var doesn't accidentally disable timeouts).
 const DEFAULT_API_TIMEOUT_MS = 600000 // 600 seconds = 10 minutes
-const parsedTimeout = Number(process.env.NEXT_PUBLIC_API_TIMEOUT_MS)
+const rawTimeout = process.env.NEXT_PUBLIC_API_TIMEOUT_MS
+const parsedTimeout = rawTimeout && rawTimeout.trim() !== '' ? Number(rawTimeout) : NaN
 const apiTimeout = Number.isFinite(parsedTimeout) && parsedTimeout >= 0
   ? parsedTimeout
   : DEFAULT_API_TIMEOUT_MS

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3,12 +3,20 @@ import { getApiUrl } from '@/lib/config'
 
 // API client with runtime-configurable base URL
 // The base URL is fetched from the API config endpoint on first request
-// Timeout increased to 10 minutes (600000ms = 600s) to accommodate slow LLM operations
-// (transformations, insights generation, chat) especially on slower hardware (Ollama, LM Studio)
-// Note: Frontend uses milliseconds, backend uses seconds
-// Local LLMs can take several minutes for complex questions with large contexts
+//
+// Request timeout defaults to 10 minutes (600000ms) to accommodate slow LLM
+// operations (transformations, insights, synchronous chat) on slower hardware
+// (Ollama, LM Studio). Configure it via NEXT_PUBLIC_API_TIMEOUT_MS for models
+// that can take longer than 10 minutes to respond (#880).
+// Note: value is in milliseconds; 0 disables the timeout entirely.
+const DEFAULT_API_TIMEOUT_MS = 600000 // 600 seconds = 10 minutes
+const parsedTimeout = Number(process.env.NEXT_PUBLIC_API_TIMEOUT_MS)
+const apiTimeout = Number.isFinite(parsedTimeout) && parsedTimeout >= 0
+  ? parsedTimeout
+  : DEFAULT_API_TIMEOUT_MS
+
 export const apiClient = axios.create({
-  timeout: 600000, // 600 seconds = 10 minutes
+  timeout: apiTimeout,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
Two small frontend fixes.

## #882 — Search results render in a cramped, hard-to-scroll bottom container
The search page content wrapper (`<div className="p-4 md:p-6">`) wasn't a scroll region, while the AppShell `<main>` is `overflow-hidden`. The only scrollable areas were inner `max-h-[60vh] overflow-y-auto` containers, producing the cramped bottom box.

- Give the search page the same `flex-1 overflow-y-auto` content wrapper used by the notebooks / podcasts / transformations pages → natural page-level scroll.
- Drop the `max-h-[60vh] overflow-y-auto pr-2` caps on both the Search results list and the shared `StreamingResponse` (Ask).

Verified against both surfaces (Search + Ask share `StreamingResponse`, which is only used on this page) and short viewports (page scrolls; no double scrollbars since the inner caps are gone).

## #880 — Chat sendMessage axios timeout hardcoded at 600000ms
The shared axios client had a hardcoded 10-minute timeout, so slow/long-running chat models aborted at exactly 600000ms with no way to raise it.

- Timeout now reads `NEXT_PUBLIC_API_TIMEOUT_MS` (default `600000`; `0` disables the timeout). Documented in the CHANGELOG and inline.

Frontend `tsc --noEmit` and `eslint` pass.

Closes #882
Closes #880

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

