### PR TITLE
feat(notebooks): bulk include/exclude all sources from chat context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `NEXT_PUBLIC_API_TIMEOUT_MS` environment variable to configure the frontend API request timeout (default `600000` = 10 minutes; set `0` to disable). Lets slow/long-running chat models finish without editing source (#880)
+- Bulk include/exclude all sources from a notebook's chat context in one action, via a "Context" menu in the Sources column header — translated across all 14 locales (#223)
 
 ### Changed
 - Failed source cards now show a prominent "Retry processing" button directly on the card instead of only inside the 3-dot dropdown; clicking it no longer also opens the source (the click was missing `stopPropagation`) (#726)

--- a/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
@@ -107,6 +107,23 @@ export default function NotebookPage() {
     }))
   }
 
+  // Bulk include/exclude every source from the chat context at once (#223).
+  // "include" mirrors the per-source default: insights when available, else full.
+  const handleBulkSourceContext = (action: 'include' | 'exclude') => {
+    setContextSelections(prev => {
+      const next = { ...prev.sources }
+      ;(sources ?? []).forEach(source => {
+        next[source.id] =
+          action === 'exclude'
+            ? 'off'
+            : source.insights_count > 0
+              ? 'insights'
+              : 'full'
+      })
+      return { ...prev, sources: next }
+    })
+  }
+
   if (notebookLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -167,6 +184,7 @@ export default function NotebookPage() {
                     onRefresh={refetchSources}
                     contextSelections={contextSelections.sources}
                     onContextModeChange={(sourceId, mode) => handleContextModeChange(sourceId, mode, 'source')}
+                    onBulkContextModeChange={handleBulkSourceContext}
                     hasNextPage={hasNextPage}
                     isFetchingNextPage={isFetchingNextPage}
                     fetchNextPage={fetchNextPage}
@@ -211,6 +229,7 @@ export default function NotebookPage() {
                 onRefresh={refetchSources}
                 contextSelections={contextSelections.sources}
                 onContextModeChange={(sourceId, mode) => handleContextModeChange(sourceId, mode, 'source')}
+                onBulkContextModeChange={handleBulkSourceContext}
                 hasNextPage={hasNextPage}
                 isFetchingNextPage={isFetchingNextPage}
                 fetchNextPage={fetchNextPage}

--- a/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
@@ -23,12 +23,10 @@ import {
   type SourceContextDefault,
 } from '@/lib/utils/source-context'
 
-export type ContextMode = 'off' | 'insights' | 'full'
-
-export interface ContextSelections {
-  sources: Record<string, ContextMode>
-  notes: Record<string, ContextMode>
-}
+// Re-exported from the shared types module for backward compatibility; several
+// components historically import these from this route file.
+import type { ContextMode, ContextSelections } from '@/lib/types/notebook-context'
+export type { ContextMode, ContextSelections }
 
 export default function NotebookPage() {
   const { t } = useTranslation()

--- a/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
@@ -17,6 +17,11 @@ import { useTranslation } from '@/lib/hooks/use-translation'
 import { cn } from '@/lib/utils'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { FileText, StickyNote, MessageSquare } from 'lucide-react'
+import {
+  applyBulkSourceContext,
+  computeSourceSelections,
+  type SourceContextDefault,
+} from '@/lib/utils/source-context'
 
 export type ContextMode = 'off' | 'insights' | 'full'
 
@@ -58,27 +63,20 @@ export default function NotebookPage() {
     notes: {}
   })
 
+  // The default context mode applied to sources as they load. A bulk
+  // include/exclude updates this so sources loaded later via pagination follow
+  // the same intent instead of reverting to "included" (#223/#915).
+  const [sourceContextDefault, setSourceContextDefault] = useState<SourceContextDefault>('include')
+
   // Initialize and update selections when sources load or change
   useEffect(() => {
     if (sources && sources.length > 0) {
-      setContextSelections(prev => {
-        const newSourceSelections = { ...prev.sources }
-        sources.forEach(source => {
-          const currentMode = newSourceSelections[source.id]
-          const hasInsights = source.insights_count > 0
-
-          if (currentMode === undefined) {
-            // Initial setup - default based on insights availability
-            newSourceSelections[source.id] = hasInsights ? 'insights' : 'full'
-          } else if (currentMode === 'full' && hasInsights) {
-            // Source gained insights while in 'full' mode - auto-switch to 'insights'
-            newSourceSelections[source.id] = 'insights'
-          }
-        })
-        return { ...prev, sources: newSourceSelections }
-      })
+      setContextSelections(prev => ({
+        ...prev,
+        sources: computeSourceSelections(prev.sources, sources, sourceContextDefault),
+      }))
     }
-  }, [sources])
+  }, [sources, sourceContextDefault])
 
   useEffect(() => {
     if (notes && notes.length > 0) {
@@ -108,20 +106,13 @@ export default function NotebookPage() {
   }
 
   // Bulk include/exclude every source from the chat context at once (#223).
-  // "include" mirrors the per-source default: insights when available, else full.
-  const handleBulkSourceContext = (action: 'include' | 'exclude') => {
-    setContextSelections(prev => {
-      const next = { ...prev.sources }
-      ;(sources ?? []).forEach(source => {
-        next[source.id] =
-          action === 'exclude'
-            ? 'off'
-            : source.insights_count > 0
-              ? 'insights'
-              : 'full'
-      })
-      return { ...prev, sources: next }
-    })
+  // Also records the action as the default for sources loaded later (#915).
+  const handleBulkSourceContext = (action: SourceContextDefault) => {
+    setSourceContextDefault(action)
+    setContextSelections(prev => ({
+      ...prev,
+      sources: applyBulkSourceContext(prev.sources, sources ?? [], action),
+    }))
   }
 
   if (notebookLoading) {

--- a/frontend/src/app/(dashboard)/notebooks/components/SourcesColumn.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/SourcesColumn.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Plus, FileText, Link2, ChevronDown, Loader2 } from 'lucide-react'
+import { Plus, FileText, Link2, ChevronDown, Loader2, ListChecks } from 'lucide-react'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { EmptyState } from '@/components/common/EmptyState'
 import { AddSourceDialog } from '@/components/sources/AddSourceDialog'
@@ -32,6 +32,7 @@ interface SourcesColumnProps {
   onRefresh?: () => void
   contextSelections?: Record<string, ContextMode>
   onContextModeChange?: (sourceId: string, mode: ContextMode) => void
+  onBulkContextModeChange?: (action: 'include' | 'exclude') => void
   // Pagination props
   hasNextPage?: boolean
   isFetchingNextPage?: boolean
@@ -45,6 +46,7 @@ export function SourcesColumn({
   onRefresh,
   contextSelections,
   onContextModeChange,
+  onBulkContextModeChange,
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
@@ -158,6 +160,24 @@ export function SourcesColumn({
             <div className="flex items-center justify-between gap-2">
               <CardTitle className="text-lg">{t('navigation.sources')}</CardTitle>
               <div className="flex items-center gap-2">
+                {onBulkContextModeChange && sources && sources.length > 0 && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="sm" title={t('sources.bulkContext')}>
+                        <ListChecks className="h-4 w-4" />
+                        <ChevronDown className="h-4 w-4 ml-1" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => onBulkContextModeChange('include')}>
+                        {t('sources.includeAllInContext')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => onBulkContextModeChange('exclude')}>
+                        {t('sources.excludeAllFromContext')}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
                 <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
                   <DropdownMenuTrigger asChild>
                     <Button size="sm">

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -262,6 +262,9 @@ export const bnIN = {
     deleteSuccess: "নোটবুক সফলভাবে মুছে ফেলা হয়েছে",
   },
   sources: {
+    bulkContext: "প্রসঙ্গ",
+    includeAllInContext: "সবগুলো প্রসঙ্গে যোগ করুন",
+    excludeAllFromContext: "সবগুলো প্রসঙ্গ থেকে বাদ দিন",
     title: "উৎসগুলি",
     add: "উৎস যোগ করুন",
     addNew: "নতুন উৎস যোগ করুন",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -262,6 +262,9 @@ export const caES = {
     deleteSuccess: "S'ha suprimit el quadern correctament",
   },
   sources: {
+    bulkContext: "Context",
+    includeAllInContext: "Inclou-les totes al context",
+    excludeAllFromContext: "Exclou-les totes del context",
     title: "Fonts",
     add: "Afegeix una font",
     addNew: "Afegeix una font nova",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -265,6 +265,9 @@ export const deDE = {
     deleteSuccess: "Notebook erfolgreich gelöscht",
   },
   sources: {
+    bulkContext: "Kontext",
+    includeAllInContext: "Alle in den Kontext aufnehmen",
+    excludeAllFromContext: "Alle aus dem Kontext ausschließen",
     title: "Quellen",
     add: "Quelle hinzufügen",
     addNew: "Neue Quelle hinzufügen",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -263,6 +263,9 @@ export const enUS = {
   },
   sources: {
     title: "Sources",
+    bulkContext: "Context",
+    includeAllInContext: "Include all in context",
+    excludeAllFromContext: "Exclude all from context",
     add: "Add Source",
     addNew: "Add New Source",
     addExisting: "Add Existing Source",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -262,6 +262,9 @@ export const esES = {
     deleteSuccess: "Cuaderno eliminado exitosamente",
   },
   sources: {
+    bulkContext: "Contexto",
+    includeAllInContext: "Incluir todas en el contexto",
+    excludeAllFromContext: "Excluir todas del contexto",
     title: "Fuentes",
     add: "Agregar fuente",
     addNew: "Agregar nueva fuente",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -262,6 +262,9 @@ export const frFR = {
     deleteSuccess: "Carnet supprimé avec succès",
   },
   sources: {
+    bulkContext: "Contexte",
+    includeAllInContext: "Tout inclure dans le contexte",
+    excludeAllFromContext: "Tout exclure du contexte",
     title: "Sources",
     add: "Ajouter une source",
     addNew: "Ajouter une nouvelle source",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -262,6 +262,9 @@ export const itIT = {
     deleteSuccess: "Quaderno eliminato con successo",
   },
   sources: {
+    bulkContext: "Contesto",
+    includeAllInContext: "Includi tutte nel contesto",
+    excludeAllFromContext: "Escludi tutte dal contesto",
     title: "Fonti",
     add: "Aggiungi fonte",
     addNew: "Aggiungi nuova fonte",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -262,6 +262,9 @@ export const jaJP = {
     deleteSuccess: "ノートブックを削除しました",
   },
   sources: {
+    bulkContext: "コンテキスト",
+    includeAllInContext: "すべてをコンテキストに含める",
+    excludeAllFromContext: "すべてをコンテキストから除外",
     title: "ソース",
     add: "ソースを追加",
     addNew: "新規ソースを追加",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -262,6 +262,9 @@ export const plPL = {
     deleteSuccess: "Notatnik usunięty pomyślnie",
   },
   sources: {
+    bulkContext: "Kontekst",
+    includeAllInContext: "Uwzględnij wszystkie w kontekście",
+    excludeAllFromContext: "Wyklucz wszystkie z kontekstu",
     title: "Źródła",
     add: "Dodaj źródło",
     addNew: "Dodaj nowe źródło",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -262,6 +262,9 @@ export const ptBR = {
     deleteSuccess: "Caderno excluído com sucesso",
   },
   sources: {
+    bulkContext: "Contexto",
+    includeAllInContext: "Incluir todas no contexto",
+    excludeAllFromContext: "Excluir todas do contexto",
     title: "Fontes",
     add: "Adicionar Fonte",
     addNew: "Adicionar Nova Fonte",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -262,6 +262,9 @@ export const ruRU = {
     deleteSuccess: "Блокнот успешно удалён",
   },
   sources: {
+    bulkContext: "Контекст",
+    includeAllInContext: "Включить все в контекст",
+    excludeAllFromContext: "Исключить все из контекста",
     title: "Источники",
     add: "Добавить источник",
     addNew: "Добавить новый источник",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -262,6 +262,9 @@ export const trTR = {
     deleteSuccess: "Defter başarıyla silindi",
   },
   sources: {
+    bulkContext: "Bağlam",
+    includeAllInContext: "Tümünü bağlama dahil et",
+    excludeAllFromContext: "Tümünü bağlamdan çıkar",
     title: "Kaynaklar",
     add: "Kaynak Ekle",
     addNew: "Yeni Kaynak Ekle",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -262,6 +262,9 @@ export const zhCN = {
     deleteSuccess: "笔记本删除成功",
   },
   sources: {
+    bulkContext: "上下文",
+    includeAllInContext: "全部加入上下文",
+    excludeAllFromContext: "全部移出上下文",
     title: "来源",
     add: "添加来源",
     addNew: "添加新来源",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -262,6 +262,9 @@ export const zhTW = {
     deleteSuccess: "筆記本刪除成功",
   },
   sources: {
+    bulkContext: "上下文",
+    includeAllInContext: "全部加入上下文",
+    excludeAllFromContext: "全部移出上下文",
     title: "來源",
     add: "新增來源",
     addNew: "新增新來源",

--- a/frontend/src/lib/types/notebook-context.ts
+++ b/frontend/src/lib/types/notebook-context.ts
@@ -1,0 +1,7 @@
+/** Chat-context inclusion mode for a notebook source or note. */
+export type ContextMode = 'off' | 'insights' | 'full'
+
+export interface ContextSelections {
+  sources: Record<string, ContextMode>
+  notes: Record<string, ContextMode>
+}

--- a/frontend/src/lib/utils/source-context.test.ts
+++ b/frontend/src/lib/utils/source-context.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyBulkSourceContext,
+  computeSourceSelections,
+  includedMode,
+} from './source-context'
+
+const src = (id: string, insights_count = 0) => ({ id, insights_count })
+
+describe('includedMode', () => {
+  it('prefers insights when available, else full', () => {
+    expect(includedMode(0)).toBe('full')
+    expect(includedMode(3)).toBe('insights')
+  })
+})
+
+describe('computeSourceSelections', () => {
+  it('defaults new sources to included (insights/full)', () => {
+    const result = computeSourceSelections({}, [src('s:1', 2), src('s:2', 0)], 'include')
+    expect(result).toEqual({ 's:1': 'insights', 's:2': 'full' })
+  })
+
+  it('defaults new sources to off when the default mode is exclude', () => {
+    const result = computeSourceSelections({}, [src('s:1', 2), src('s:2', 0)], 'exclude')
+    expect(result).toEqual({ 's:1': 'off', 's:2': 'off' })
+  })
+
+  it('preserves existing explicit selections', () => {
+    const existing = { 's:1': 'off' as const }
+    const result = computeSourceSelections(existing, [src('s:1', 2), src('s:2', 0)], 'include')
+    expect(result['s:1']).toBe('off') // untouched
+    expect(result['s:2']).toBe('full')
+  })
+
+  it('upgrades a full source to insights once it has insights', () => {
+    const result = computeSourceSelections({ 's:1': 'full' }, [src('s:1', 5)], 'include')
+    expect(result['s:1']).toBe('insights')
+  })
+
+  it('keeps later-loaded sources excluded after an exclude-all (regression for #915)', () => {
+    // exclude-all over the first page
+    let selections = applyBulkSourceContext({}, [src('s:1', 0), src('s:2', 1)], 'exclude')
+    expect(selections).toEqual({ 's:1': 'off', 's:2': 'off' })
+
+    // a second page loads; with the exclude default the new sources stay excluded
+    selections = computeSourceSelections(
+      selections,
+      [src('s:1', 0), src('s:2', 1), src('s:3', 4), src('s:4', 0)],
+      'exclude',
+    )
+    expect(selections).toEqual({ 's:1': 'off', 's:2': 'off', 's:3': 'off', 's:4': 'off' })
+  })
+})
+
+describe('applyBulkSourceContext', () => {
+  it('excludes all sources', () => {
+    const result = applyBulkSourceContext(
+      { 's:1': 'full', 's:2': 'insights' },
+      [src('s:1', 0), src('s:2', 3)],
+      'exclude',
+    )
+    expect(result).toEqual({ 's:1': 'off', 's:2': 'off' })
+  })
+
+  it('includes all sources using their sensible mode', () => {
+    const result = applyBulkSourceContext(
+      { 's:1': 'off', 's:2': 'off' },
+      [src('s:1', 0), src('s:2', 3)],
+      'include',
+    )
+    expect(result).toEqual({ 's:1': 'full', 's:2': 'insights' })
+  })
+})

--- a/frontend/src/lib/utils/source-context.ts
+++ b/frontend/src/lib/utils/source-context.ts
@@ -1,4 +1,4 @@
-import type { ContextMode } from '@/app/(dashboard)/notebooks/[id]/page'
+import type { ContextMode } from '@/lib/types/notebook-context'
 
 export type SourceContextDefault = 'include' | 'exclude'
 

--- a/frontend/src/lib/utils/source-context.ts
+++ b/frontend/src/lib/utils/source-context.ts
@@ -1,0 +1,53 @@
+import type { ContextMode } from '@/app/(dashboard)/notebooks/[id]/page'
+
+export type SourceContextDefault = 'include' | 'exclude'
+
+interface SourceLike {
+  id: string
+  insights_count: number
+}
+
+/** The "included" context mode for a source: insights when available, else full. */
+export function includedMode(insightsCount: number): ContextMode {
+  return insightsCount > 0 ? 'insights' : 'full'
+}
+
+/**
+ * Compute chat-context selections for a batch of sources while preserving
+ * existing choices.
+ *
+ * Newly-seen sources adopt `defaultMode`, so a prior bulk include/exclude also
+ * governs sources that load later via pagination — otherwise "exclude all"
+ * would silently miss sources loaded after the action (#223/#915).
+ */
+export function computeSourceSelections(
+  existing: Record<string, ContextMode>,
+  sources: SourceLike[],
+  defaultMode: SourceContextDefault = 'include',
+): Record<string, ContextMode> {
+  const next = { ...existing }
+  for (const source of sources) {
+    const current = next[source.id]
+    if (current === undefined) {
+      next[source.id] =
+        defaultMode === 'exclude' ? 'off' : includedMode(source.insights_count)
+    } else if (current === 'full' && source.insights_count > 0) {
+      // Source gained insights while in 'full' mode — prefer the leaner insights.
+      next[source.id] = 'insights'
+    }
+  }
+  return next
+}
+
+/** Apply a uniform bulk include/exclude to every given source. */
+export function applyBulkSourceContext(
+  existing: Record<string, ContextMode>,
+  sources: SourceLike[],
+  action: SourceContextDefault,
+): Record<string, ContextMode> {
+  const next = { ...existing }
+  for (const source of sources) {
+    next[source.id] = action === 'exclude' ? 'off' : includedMode(source.insights_count)
+  }
+  return next
+}


### PR DESCRIPTION
## Summary

Implements #223 — "Add bulk action for inclusion/exclusion of sources in a chat session." With many sources, toggling each one's chat-context mode individually is tedious.

Adds a compact **"Context"** dropdown to the Sources column header with two actions:
- **Include all in context** — sets every source to its sensible included mode (insights when the source has insights, else full), mirroring the per-source default.
- **Exclude all from context** — sets every source to `off`.

## Scope note
This is the chat **context-selection** bulk action the issue asks for (operating on the existing `contextSelections` state) — frontend-only, no backend. It is **not** the same as the separate bulk source *membership* management (add/remove sources from a notebook), which is tracked by #884 (`needs design`). PR #231 implemented that membership feature against this issue number, so this PR does not reuse it.

## Changes
- `notebooks/[id]/page.tsx`: `handleBulkSourceContext('include' | 'exclude')` applied to all sources; passed to both (mobile/desktop) `SourcesColumn` instances.
- `SourcesColumn.tsx`: new optional `onBulkContextModeChange` prop + header dropdown (only rendered when the notebook has sources).
- i18n: 3 new `sources.*` keys, translated across all 14 locales (parity + unused-key tests pass).

Frontend `tsc --noEmit`, `eslint`, and the locale parity/unused-key tests pass.

Closes #223

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

