### PR TITLE
fix(api): return 404 instead of 500 for missing resources in CRUD endpoints (#862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CRUD endpoints now return `404` (not `500`) for a non-existent resource. `ObjectModel.get()` raises `NotFoundError` rather than returning a falsy value, so the broad `except Exception` in each handler was masking it as a server error. Added an explicit `NotFoundError → 404` arm to the notebook (update / delete / delete-preview / add-source / remove-source), note (get / update / delete / list / create), model (delete), credential (update / delete) and embed handlers (#862)
+
 ## [1.10.0] - 2026-06-17
 
 ### Security

--- a/api/routers/credentials.py
+++ b/api/routers/credentials.py
@@ -56,6 +56,7 @@ from api.models import (
 )
 from open_notebook.database.repository import ensure_record_id, repo_delete, repo_query
 from open_notebook.domain.credential import Credential
+from open_notebook.exceptions import NotFoundError
 
 router = APIRouter(prefix="/credentials", tags=["credentials"])
 
@@ -251,6 +252,8 @@ async def update_credential(credential_id: str, request: UpdateCredentialRequest
 
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Credential not found")
     except Exception as e:
         logger.error(f"Error updating credential {credential_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to update credential")
@@ -344,6 +347,8 @@ async def delete_credential(
 
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Credential not found")
     except Exception as e:
         logger.error(f"Error deleting credential {credential_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to delete credential")

--- a/api/routers/embedding.py
+++ b/api/routers/embedding.py
@@ -79,8 +79,6 @@ async def embed_content(embed_request: EmbedRequest):
             # Get the item and submit embedding job
             if item_type == "source":
                 source_item = await Source.get(item_id)
-                if not source_item:
-                    raise HTTPException(status_code=404, detail="Source not found")
 
                 # Submit embed_source job (returns command_id for tracking)
                 command_id = await source_item.vectorize()
@@ -88,8 +86,6 @@ async def embed_content(embed_request: EmbedRequest):
 
             elif item_type == "note":
                 note_item = await Note.get(item_id)
-                if not note_item:
-                    raise HTTPException(status_code=404, detail="Note not found")
 
                 # Note.save() internally submits embed_note command and returns command_id
                 command_id = await note_item.save()

--- a/api/routers/embedding.py
+++ b/api/routers/embedding.py
@@ -5,6 +5,7 @@ from api.command_service import CommandService
 from api.models import EmbedRequest, EmbedResponse
 from open_notebook.ai.models import model_manager
 from open_notebook.domain.notebook import Note, Source
+from open_notebook.exceptions import NotFoundError
 
 router = APIRouter()
 
@@ -104,6 +105,10 @@ async def embed_content(embed_request: EmbedRequest):
 
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(
+            status_code=404, detail=f"{embed_request.item_type} not found"
+        )
     except Exception as e:
         logger.error(
             f"Error embedding {embed_request.item_type} {embed_request.item_id}: {str(e)}"

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -23,7 +23,7 @@ from open_notebook.ai.model_discovery import (
 )
 from open_notebook.ai.models import DefaultModels, Model
 from open_notebook.domain.credential import Credential
-from open_notebook.exceptions import InvalidInputError
+from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
@@ -262,6 +262,8 @@ async def delete_model(model_id: str):
         return {"message": "Model deleted successfully"}
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Model not found")
     except Exception as e:
         logger.error(f"Error deleting model {model_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error deleting model: {str(e)}")

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -254,8 +254,6 @@ async def delete_model(model_id: str):
     """Delete a model configuration."""
     try:
         model = await Model.get(model_id)
-        if not model:
-            raise HTTPException(status_code=404, detail="Model not found")
 
         await model.delete()
 

--- a/api/routers/notebooks.py
+++ b/api/routers/notebooks.py
@@ -12,7 +12,7 @@ from api.models import (
 )
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.notebook import Notebook, Source
-from open_notebook.exceptions import InvalidInputError
+from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
@@ -136,6 +136,8 @@ async def get_notebook_delete_preview(notebook_id: str):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except Exception as e:
         logger.error(f"Error getting delete preview for notebook {notebook_id}: {e}")
         raise HTTPException(
@@ -233,6 +235,8 @@ async def update_notebook(notebook_id: str, notebook_update: NotebookUpdate):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except InvalidInputError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -278,6 +282,8 @@ async def add_source_to_notebook(notebook_id: str, source_id: str):
         return {"message": "Source linked to notebook successfully"}
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook or source not found")
     except Exception as e:
         logger.error(
             f"Error linking source {source_id} to notebook {notebook_id}: {str(e)}"
@@ -308,6 +314,8 @@ async def remove_source_from_notebook(notebook_id: str, source_id: str):
         return {"message": "Source removed from notebook successfully"}
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except Exception as e:
         logger.error(
             f"Error removing source {source_id} from notebook {notebook_id}: {str(e)}"
@@ -347,6 +355,8 @@ async def delete_notebook(
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except Exception as e:
         logger.error(f"Error deleting notebook {notebook_id}: {str(e)}")
         raise HTTPException(

--- a/api/routers/notebooks.py
+++ b/api/routers/notebooks.py
@@ -122,8 +122,6 @@ async def get_notebook_delete_preview(notebook_id: str):
     """Get a preview of what will be deleted when this notebook is deleted."""
     try:
         notebook = await Notebook.get(notebook_id)
-        if not notebook:
-            raise HTTPException(status_code=404, detail="Notebook not found")
 
         preview = await notebook.get_delete_preview()
 
@@ -187,8 +185,6 @@ async def update_notebook(notebook_id: str, notebook_update: NotebookUpdate):
     """Update a notebook."""
     try:
         notebook = await Notebook.get(notebook_id)
-        if not notebook:
-            raise HTTPException(status_code=404, detail="Notebook not found")
 
         # Update only provided fields
         if notebook_update.name is not None:
@@ -250,15 +246,9 @@ async def update_notebook(notebook_id: str, notebook_update: NotebookUpdate):
 async def add_source_to_notebook(notebook_id: str, source_id: str):
     """Add an existing source to a notebook (create the reference)."""
     try:
-        # Check if notebook exists
-        notebook = await Notebook.get(notebook_id)
-        if not notebook:
-            raise HTTPException(status_code=404, detail="Notebook not found")
-
-        # Check if source exists
-        source = await Source.get(source_id)
-        if not source:
-            raise HTTPException(status_code=404, detail="Source not found")
+        # Verify the notebook and source exist (raises NotFoundError -> 404)
+        await Notebook.get(notebook_id)
+        await Source.get(source_id)
 
         # Check if reference already exists (idempotency)
         existing_ref = await repo_query(
@@ -297,10 +287,8 @@ async def add_source_to_notebook(notebook_id: str, source_id: str):
 async def remove_source_from_notebook(notebook_id: str, source_id: str):
     """Remove a source from a notebook (delete the reference)."""
     try:
-        # Check if notebook exists
-        notebook = await Notebook.get(notebook_id)
-        if not notebook:
-            raise HTTPException(status_code=404, detail="Notebook not found")
+        # Verify the notebook exists (raises NotFoundError -> 404)
+        await Notebook.get(notebook_id)
 
         # Delete the reference record linking source to notebook
         await repo_query(
@@ -342,8 +330,6 @@ async def delete_notebook(
     """
     try:
         notebook = await Notebook.get(notebook_id)
-        if not notebook:
-            raise HTTPException(status_code=404, detail="Notebook not found")
 
         result = await notebook.delete(delete_exclusive_sources=delete_exclusive_sources)
 

--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from api.models import NoteCreate, NoteResponse, NoteUpdate
 from open_notebook.domain.notebook import Note
-from open_notebook.exceptions import InvalidInputError
+from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
@@ -41,6 +41,8 @@ async def get_notes(
         ]
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except Exception as e:
         logger.error(f"Error fetching notes: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error fetching notes: {str(e)}")
@@ -100,6 +102,8 @@ async def create_note(note_data: NoteCreate):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except InvalidInputError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -125,6 +129,8 @@ async def get_note(note_id: str):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Note not found")
     except Exception as e:
         logger.error(f"Error fetching note {note_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error fetching note: {str(e)}")
@@ -164,6 +170,8 @@ async def update_note(note_id: str, note_update: NoteUpdate):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Note not found")
     except InvalidInputError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -184,6 +192,8 @@ async def delete_note(note_id: str):
         return {"message": "Note deleted successfully"}
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Note not found")
     except Exception as e:
         logger.error(f"Error deleting note {note_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error deleting note: {str(e)}")

--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -21,8 +21,6 @@ async def get_notes(
             from open_notebook.domain.notebook import Notebook
 
             notebook = await Notebook.get(notebook_id)
-            if not notebook:
-                raise HTTPException(status_code=404, detail="Notebook not found")
             notes = await notebook.get_notes()
         else:
             # Get all notes
@@ -86,9 +84,8 @@ async def create_note(note_data: NoteCreate):
         if note_data.notebook_id:
             from open_notebook.domain.notebook import Notebook
 
-            notebook = await Notebook.get(note_data.notebook_id)
-            if not notebook:
-                raise HTTPException(status_code=404, detail="Notebook not found")
+            # Verify the notebook exists (raises NotFoundError -> 404)
+            await Notebook.get(note_data.notebook_id)
             await new_note.add_to_notebook(note_data.notebook_id)
 
         return NoteResponse(
@@ -116,8 +113,6 @@ async def get_note(note_id: str):
     """Get a specific note by ID."""
     try:
         note = await Note.get(note_id)
-        if not note:
-            raise HTTPException(status_code=404, detail="Note not found")
 
         return NoteResponse(
             id=note.id or "",
@@ -141,8 +136,6 @@ async def update_note(note_id: str, note_update: NoteUpdate):
     """Update a note."""
     try:
         note = await Note.get(note_id)
-        if not note:
-            raise HTTPException(status_code=404, detail="Note not found")
 
         # Update only provided fields
         if note_update.title is not None:
@@ -184,8 +177,6 @@ async def delete_note(note_id: str):
     """Delete a note."""
     try:
         note = await Note.get(note_id)
-        if not note:
-            raise HTTPException(status_code=404, detail="Note not found")
 
         await note.delete()
 

--- a/tests/test_crud_404.py
+++ b/tests/test_crud_404.py
@@ -1,0 +1,131 @@
+"""Regression tests for #862: mutating/CRUD endpoints must return 404 (not 500)
+for a non-existent resource.
+
+`ObjectModel.get()` raises `NotFoundError` for a missing record (it never returns
+a falsy value), so each handler needs an explicit `except NotFoundError -> 404`
+arm before its broad `except Exception` (which would otherwise produce a 500).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_notebook.exceptions import NotFoundError
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+def _nf(*_args, **_kwargs):
+    raise NotFoundError("not found")
+
+
+# --- notebooks --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notebooks.Notebook.get", new_callable=AsyncMock)
+async def test_delete_notebook_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.delete("/api/notebooks/notebook:gone").status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notebooks.Notebook.get", new_callable=AsyncMock)
+async def test_update_notebook_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.put("/api/notebooks/notebook:gone", json={"name": "x"}).status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notebooks.Notebook.get", new_callable=AsyncMock)
+async def test_delete_preview_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.get("/api/notebooks/notebook:gone/delete-preview").status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notebooks.Notebook.get", new_callable=AsyncMock)
+async def test_add_source_missing_notebook_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.post("/api/notebooks/notebook:gone/sources/source:1").status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notebooks.Notebook.get", new_callable=AsyncMock)
+async def test_remove_source_missing_notebook_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.delete("/api/notebooks/notebook:gone/sources/source:1").status_code == 404
+
+
+# --- notes ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notes.Note.get", new_callable=AsyncMock)
+async def test_get_note_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.get("/api/notes/note:gone").status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notes.Note.get", new_callable=AsyncMock)
+async def test_update_note_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.put("/api/notes/note:gone", json={"content": "x"}).status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.notes.Note.get", new_callable=AsyncMock)
+async def test_delete_note_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.delete("/api/notes/note:gone").status_code == 404
+
+
+# --- models -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("api.routers.models.Model.get", new_callable=AsyncMock)
+async def test_delete_model_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.delete("/api/models/model:gone").status_code == 404
+
+
+# --- credentials ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("api.routers.credentials.require_encryption_key", new=MagicMock())
+@patch("api.routers.credentials.Credential.get", new_callable=AsyncMock)
+async def test_update_credential_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.put("/api/credentials/credential:gone", json={"name": "x"}).status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("api.routers.credentials.Credential.get", new_callable=AsyncMock)
+async def test_delete_credential_missing_returns_404(mock_get, client):
+    mock_get.side_effect = _nf
+    assert client.delete("/api/credentials/credential:gone").status_code == 404
+
+
+# --- embedding --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("api.routers.embedding.Source.get", new_callable=AsyncMock)
+@patch("api.routers.embedding.model_manager.get_embedding_model", new_callable=AsyncMock)
+async def test_embed_missing_source_returns_404(mock_embed_model, mock_get, client):
+    mock_embed_model.return_value = MagicMock()  # an embedding model is configured
+    mock_get.side_effect = _nf
+    resp = client.post(
+        "/api/embed",
+        json={"item_id": "source:gone", "item_type": "source", "async_processing": False},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
Fixes #862.

## Problem
`ObjectModel.get()` (`open_notebook/domain/base.py:120-128`) never returns a falsy value — on a missing record it raises `NotFoundError`, and re-wraps any inner failure as `NotFoundError`. So the common `if not obj: raise HTTPException(404)` guard is dead code, and each handler's broad `except Exception` caught the `NotFoundError` and re-raised it as `500` — the global `NotFoundError → 404` handler never fired.

## Fix
Add an explicit `except NotFoundError: raise HTTPException(404, ...)` arm before the broad `except` in the affected handlers (same pattern already used in `chat.py` and, for v1.10.0, in `sources.py`):

- `notebooks.py`: update / delete / delete-preview / add-source / remove-source
- `notes.py`: get / update / delete / list / create (the notebook lookups)
- `models.py`: delete
- `credentials.py`: update / delete
- `embedding.py`: sync embed (source/note)

## Tests
`tests/test_crud_404.py` — per-endpoint `TestClient` tests with `.get()` mocked to raise `NotFoundError`, asserting `404` (12 tests). Full suite: 198 passed; ruff clean.

CHANGELOG updated under `[Unreleased]`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

