### PR TITLE
feat(notebooks): add list view toggle to notebooks page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- List view for the Notebooks page — a tile/list toggle in the header lets you switch between the visual card grid and a compact row layout (name, description, source/note counts, last updated) for easier scanning of large collections. The choice is remembered across reloads and translated across all 14 locales (#885)
+
 ### Fixed
 - CRUD endpoints now return `404` (not `500`) for a non-existent resource. `ObjectModel.get()` raises `NotFoundError` rather than returning a falsy value, so the broad `except Exception` in each handler was masking it as a server error. Added an explicit `NotFoundError → 404` arm to the notebook (update / delete / delete-preview / add-source / remove-source), note (get / update / delete / list / create), model (delete), credential (update / delete) and embed handlers (#862)
 

--- a/frontend/src/app/(dashboard)/notebooks/components/NotebookList.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NotebookList.tsx
@@ -2,6 +2,8 @@
 
 import { NotebookResponse } from '@/lib/types/api'
 import { NotebookCard } from './NotebookCard'
+import { NotebookRow } from './NotebookRow'
+import { useNotebookViewStore } from '@/lib/stores/notebook-view-store'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { EmptyState } from '@/components/common/EmptyState'
 import { Book, ChevronDown, ChevronRight, Plus } from 'lucide-react'
@@ -31,6 +33,7 @@ export function NotebookList({
   actionLabel,
 }: NotebookListProps) {
   const { t } = useTranslation()
+  const viewMode = useNotebookViewStore((state) => state.viewMode)
   const [isExpanded, setIsExpanded] = useState(!collapsible)
 
   if (isLoading) {
@@ -78,11 +81,19 @@ export function NotebookList({
       </div>
 
       {isExpanded && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {notebooks.map((notebook) => (
-            <NotebookCard key={notebook.id} notebook={notebook} />
-          ))}
-        </div>
+        viewMode === 'list' ? (
+          <div className="flex flex-col gap-2">
+            {notebooks.map((notebook) => (
+              <NotebookRow key={notebook.id} notebook={notebook} />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {notebooks.map((notebook) => (
+              <NotebookCard key={notebook.id} notebook={notebook} />
+            ))}
+          </div>
+        )
       )}
     </div>
   )

--- a/frontend/src/app/(dashboard)/notebooks/components/NotebookRow.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NotebookRow.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { NotebookResponse } from '@/lib/types/api'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { MoreHorizontal, Archive, ArchiveRestore, Trash2, FileText, StickyNote } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useUpdateNotebook } from '@/lib/hooks/use-notebooks'
+import { NotebookDeleteDialog } from './NotebookDeleteDialog'
+import { useState } from 'react'
+import { useTranslation } from '@/lib/hooks/use-translation'
+import { getDateLocale } from '@/lib/utils/date-locale'
+
+interface NotebookRowProps {
+  notebook: NotebookResponse
+}
+
+export function NotebookRow({ notebook }: NotebookRowProps) {
+  const { t, language } = useTranslation()
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const router = useRouter()
+  const updateNotebook = useUpdateNotebook()
+
+  const handleArchiveToggle = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    updateNotebook.mutate({
+      id: notebook.id,
+      data: { archived: !notebook.archived }
+    })
+  }
+
+  const handleRowClick = () => {
+    router.push(`/notebooks/${encodeURIComponent(notebook.id)}`)
+  }
+
+  return (
+    <>
+      {/* The row is mouse-clickable for convenience, but the notebook name is
+          the accessible primary action (a real link) for keyboard/screen-reader
+          users — avoiding nested interactive (button-in-button) semantics. */}
+      <div
+        className="group flex items-center gap-4 rounded-lg border bg-card px-4 py-3 card-hover"
+        onClick={handleRowClick}
+        style={{ cursor: 'pointer' }}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/notebooks/${encodeURIComponent(notebook.id)}`}
+              onClick={(e) => e.stopPropagation()}
+              className="font-medium truncate rounded-sm outline-none group-hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {notebook.name}
+            </Link>
+            {notebook.archived && (
+              <Badge variant="secondary">
+                {t('notebooks.archived')}
+              </Badge>
+            )}
+          </div>
+          {notebook.description && (
+            <p className="text-sm text-muted-foreground truncate">
+              {notebook.description}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1.5 shrink-0">
+          <Badge variant="outline" className="text-xs flex items-center gap-1 px-1.5 py-0.5 text-primary border-primary/50">
+            <FileText className="h-3 w-3" />
+            <span>{notebook.source_count}</span>
+          </Badge>
+          <Badge variant="outline" className="text-xs flex items-center gap-1 px-1.5 py-0.5 text-primary border-primary/50">
+            <StickyNote className="h-3 w-3" />
+            <span>{notebook.note_count}</span>
+          </Badge>
+        </div>
+
+        <div className="hidden sm:block w-40 shrink-0 text-right text-xs text-muted-foreground">
+          {t('common.updated').replace('{time}', formatDistanceToNow(new Date(notebook.updated), {
+            addSuffix: true,
+            locale: getDateLocale(language)
+          }))}
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label={t('common.actions')}
+              variant="ghost"
+              size="sm"
+              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity shrink-0"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+            <DropdownMenuItem onClick={handleArchiveToggle}>
+              {notebook.archived ? (
+                <>
+                  <ArchiveRestore className="h-4 w-4 mr-2" />
+                  {t('notebooks.unarchive')}
+                </>
+              ) : (
+                <>
+                  <Archive className="h-4 w-4 mr-2" />
+                  {t('notebooks.archive')}
+                </>
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                setShowDeleteDialog(true)
+              }}
+              className="text-red-600"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              {t('common.delete')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <NotebookDeleteDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        notebookId={notebook.id}
+        notebookName={notebook.name}
+      />
+    </>
+  )
+}

--- a/frontend/src/app/(dashboard)/notebooks/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/page.tsx
@@ -5,16 +5,19 @@ import { useMemo, useState } from 'react'
 import { AppShell } from '@/components/layout/AppShell'
 import { NotebookList } from './components/NotebookList'
 import { Button } from '@/components/ui/button'
-import { Plus, RefreshCw } from 'lucide-react'
+import { Plus, RefreshCw, LayoutGrid, List } from 'lucide-react'
 import { useNotebooks } from '@/lib/hooks/use-notebooks'
 import { CreateNotebookDialog } from '@/components/notebooks/CreateNotebookDialog'
 import { Input } from '@/components/ui/input'
 import { useTranslation } from '@/lib/hooks/use-translation'
+import { useNotebookViewStore } from '@/lib/stores/notebook-view-store'
 
 export default function NotebooksPage() {
   const { t } = useTranslation()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
+  const viewMode = useNotebookViewStore((state) => state.viewMode)
+  const setViewMode = useNotebookViewStore((state) => state.setViewMode)
   const { data: notebooks, isLoading, refetch } = useNotebooks(false)
   const { data: archivedNotebooks } = useNotebooks(true)
 
@@ -59,6 +62,28 @@ export default function NotebooksPage() {
             </Button>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <div className="flex items-center rounded-md border p-0.5">
+              <Button
+                variant={viewMode === 'tile' ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => setViewMode('tile')}
+                aria-label={t('notebooks.tileView')}
+                aria-pressed={viewMode === 'tile'}
+                title={t('notebooks.tileView')}
+              >
+                <LayoutGrid className="h-4 w-4" />
+              </Button>
+              <Button
+                variant={viewMode === 'list' ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => setViewMode('list')}
+                aria-label={t('notebooks.listView')}
+                aria-pressed={viewMode === 'list'}
+                title={t('notebooks.listView')}
+              >
+                <List className="h-4 w-4" />
+              </Button>
+            </div>
             <Input
               id="notebook-search"
               name="notebook-search"

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -240,6 +240,8 @@ export const bnIN = {
     keepExclusiveSourcesLabel: "আনলিংক করে রাখুন",
     activeNotebooks: "সক্রিয় নোটবুক",
     archivedNotebooks: "আর্কাইভ নোটবুক",
+    tileView: "টাইল ভিউ",
+    listView: "তালিকা ভিউ",
     notFound: "নোটবুক খুঁজে পাওয়া যায়নি",
     notFoundDesc: "অনুরোধ করা নোটবুক অস্তিত্ব নেই।",
     updated: "আপডেট করা",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -240,6 +240,8 @@ export const caES = {
     keepExclusiveSourcesLabel: "Desenllaça i conserva",
     activeNotebooks: "Quaderns actius",
     archivedNotebooks: "Quaderns arxivats",
+    tileView: "Vista de mosaic",
+    listView: "Vista de llista",
     notFound: "No s'ha trobat el quadern",
     notFoundDesc: "El quadern sol·licitat no existeix.",
     updated: "Actualitzat",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -243,6 +243,8 @@ export const deDE = {
     keepExclusiveSourcesLabel: "Verknüpfung lösen und behalten",
     activeNotebooks: "Aktive Notebooks",
     archivedNotebooks: "Archivierte Notebooks",
+    tileView: "Kachelansicht",
+    listView: "Listenansicht",
     notFound: "Notebook nicht gefunden",
     notFoundDesc: "Das angeforderte Notebook existiert nicht.",
     updated: "Aktualisiert",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -240,6 +240,8 @@ export const enUS = {
     keepExclusiveSourcesLabel: "Unlink and keep them",
     activeNotebooks: "Active Notebooks",
     archivedNotebooks: "Archived Notebooks",
+    tileView: "Tile view",
+    listView: "List view",
     notFound: "Notebook not found",
     notFoundDesc: "The requested notebook does not exist.",
     updated: "Updated",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -240,6 +240,8 @@ export const esES = {
     keepExclusiveSourcesLabel: "Desvincular y conservarlas",
     activeNotebooks: "Cuadernos activos",
     archivedNotebooks: "Cuadernos archivados",
+    tileView: "Vista de mosaico",
+    listView: "Vista de lista",
     notFound: "Cuaderno no encontrado",
     notFoundDesc: "El cuaderno solicitado no existe.",
     updated: "Actualizado",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -240,6 +240,8 @@ export const frFR = {
     keepExclusiveSourcesLabel: "Délier et les conserver",
     activeNotebooks: "Carnets actifs",
     archivedNotebooks: "Carnets archivés",
+    tileView: "Vue en mosaïque",
+    listView: "Vue en liste",
     notFound: "Carnet introuvable",
     notFoundDesc: "Le carnet demandé n'existe pas.",
     updated: "Mis à jour",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -240,6 +240,8 @@ export const itIT = {
     keepExclusiveSourcesLabel: "Scollega e mantieni",
     activeNotebooks: "Quaderni attivi",
     archivedNotebooks: "Quaderni archiviati",
+    tileView: "Vista a riquadri",
+    listView: "Vista a elenco",
     notFound: "Quaderno non trovato",
     notFoundDesc: "Il quaderno richiesto non esiste.",
     updated: "Aggiornato",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -240,6 +240,8 @@ export const jaJP = {
     keepExclusiveSourcesLabel: "リンク解除して保持",
     activeNotebooks: "アクティブなノートブック",
     archivedNotebooks: "アーカイブ済みノートブック",
+    tileView: "タイル表示",
+    listView: "リスト表示",
     notFound: "ノートブックが見つかりません",
     notFoundDesc: "指定されたノートブックは存在しません。",
     updated: "更新日時",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -240,6 +240,8 @@ export const plPL = {
     keepExclusiveSourcesLabel: "Odłącz i zachowaj je",
     activeNotebooks: "Aktywne notatniki",
     archivedNotebooks: "Zarchiwizowane notatniki",
+    tileView: "Widok kafelków",
+    listView: "Widok listy",
     notFound: "Nie znaleziono notatnika",
     notFoundDesc: "Żądany notatnik nie istnieje.",
     updated: "Zaktualizowano",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -240,6 +240,8 @@ export const ptBR = {
     keepExclusiveSourcesLabel: "Desvincular e manter",
     activeNotebooks: "Cadernos Ativos",
     archivedNotebooks: "Cadernos Arquivados",
+    tileView: "Visualização em blocos",
+    listView: "Visualização em lista",
     notFound: "Caderno não encontrado",
     notFoundDesc: "O caderno solicitado não existe.",
     updated: "Atualizado",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -240,6 +240,8 @@ export const ruRU = {
     keepExclusiveSourcesLabel: "Отвязать и сохранить",
     activeNotebooks: "Активные блокноты",
     archivedNotebooks: "Архивные блокноты",
+    tileView: "Вид плиткой",
+    listView: "Вид списком",
     notFound: "Блокнот не найден",
     notFoundDesc: "Запрошенный блокнот не существует.",
     updated: "Обновлено",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -240,6 +240,8 @@ export const trTR = {
     keepExclusiveSourcesLabel: "Bağlantıyı kes ve sakla",
     activeNotebooks: "Aktif Defterler",
     archivedNotebooks: "Arşivlenmiş Defterler",
+    tileView: "Döşeme görünümü",
+    listView: "Liste görünümü",
     notFound: "Defter bulunamadı",
     notFoundDesc: "İstenen defter mevcut değil.",
     updated: "Güncellendi",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -240,6 +240,8 @@ export const zhCN = {
     keepExclusiveSourcesLabel: "取消关联并保留",
     activeNotebooks: "活动的笔记本",
     archivedNotebooks: "归档的笔记本",
+    tileView: "平铺视图",
+    listView: "列表视图",
     notFound: "未找到笔记本",
     notFoundDesc: "请求的笔记本不存在。",
     updated: "已更新",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -240,6 +240,8 @@ export const zhTW = {
     keepExclusiveSourcesLabel: "取消關聯並保留",
     activeNotebooks: "活動中的筆記本",
     archivedNotebooks: "封存的筆記本",
+    tileView: "並排檢視",
+    listView: "清單檢視",
     notFound: "未找到筆記本",
     notFoundDesc: "請求的筆記本不存在。",
     updated: "已更新",

--- a/frontend/src/lib/stores/notebook-view-store.ts
+++ b/frontend/src/lib/stores/notebook-view-store.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type NotebookViewMode = 'tile' | 'list'
+
+interface NotebookViewState {
+  viewMode: NotebookViewMode
+  setViewMode: (mode: NotebookViewMode) => void
+}
+
+export const useNotebookViewStore = create<NotebookViewState>()(
+  persist(
+    (set) => ({
+      viewMode: 'tile',
+      setViewMode: (mode) => set({ viewMode: mode }),
+    }),
+    {
+      name: 'notebook-view-storage',
+    }
+  )
+)


### PR DESCRIPTION
## Summary

Adds a tile/list view toggle to the Notebooks page, addressing the navigation pain of large notebook collections.

- **Tile view** (default, unchanged): the existing visual card grid.
- **List view**: compact rows showing notebook name, description, source/note counts, and last updated — easier to scan when you have many notebooks.
- A segmented toggle (grid/list icons) in the page header switches between modes.
- The preference is persisted via a Zustand store (`notebook-view-storage`) so it survives reloads and is shared by both the active and archived lists.

Frontend-only — no API changes. `NotebookResponse` already exposes `source_count`, `note_count`, `updated`, `name`, and `description`.

## Changes

- New `notebook-view-store.ts` (persisted Zustand store).
- New `NotebookRow.tsx` — compact row variant reusing the card's click-to-open / archive / delete behavior.
- `NotebookList.tsx` renders the grid or the row list based on the store.
- Toggle control added to `notebooks/page.tsx` header.
- New `notebooks.tileView` / `notebooks.listView` keys translated across all 14 locales.
- CHANGELOG updated under `[Unreleased]`.

## Verification

- `tsc --noEmit` clean, `npm run lint` 0 errors, locale parity test 14/14.
- Verified locally with Playwright: toggling switches layouts, the active button highlights, and the list-view selection persists across a full page reload.

Closes #885

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

