### PR TITLE
feat(examples): add EasyPanel template

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,10 @@
 
 This folder contains different `docker-compose.yml` configurations for various use cases.
 
+It also includes an [`easypanel`](./easypanel/) template that can be copied into
+the official EasyPanel templates repository and tested in the EasyPanel
+templates playground.
+
 ## 📋 Available Examples
 
 ### `docker-compose-full-local.yml` - 100% Local AI (No Cloud APIs) 🌟

--- a/examples/easypanel/README.md
+++ b/examples/easypanel/README.md
@@ -1,0 +1,26 @@
+# EasyPanel template
+
+This directory contains an EasyPanel template for Open Notebook. It follows the
+format used by the official EasyPanel templates repository:
+
+- `meta.yaml` describes the template metadata and input schema.
+- `index.ts` generates the EasyPanel services.
+
+The template deploys two services:
+
+- Open Notebook, exposed on port `8502`.
+- SurrealDB v2, kept private on the project network and persisted in a volume.
+
+## Testing
+
+1. Copy this directory to `templates/open-notebook` in
+   `easypanel-io/templates`.
+2. Run the EasyPanel templates playground with `npm run dev`.
+3. Create the template from the generated JSON inside an EasyPanel instance.
+
+Set an Open Notebook password in the form before deploying. If it is left blank,
+the template generates one and stores it in the app service environment as
+`OPEN_NOTEBOOK_PASSWORD`.
+
+After deployment, open the EasyPanel domain and configure AI providers from
+Open Notebook's Settings > API Keys page.

--- a/examples/easypanel/index.ts
+++ b/examples/easypanel/index.ts
@@ -1,0 +1,80 @@
+import {
+  Output,
+  randomPassword,
+  randomString,
+  Services,
+} from "~templates-utils";
+import { Input } from "./meta";
+
+export function generate(input: Input): Output {
+  const services: Services = [];
+  const appPassword = input.appPassword || randomPassword();
+  const databasePassword = randomPassword();
+  const encryptionKey = randomString(64);
+
+  services.push({
+    type: "app",
+    data: {
+      serviceName: input.databaseServiceName,
+      env: [`SURREAL_EXPERIMENTAL_GRAPHQL=true`].join("\n"),
+      source: {
+        type: "image",
+        image: input.databaseServiceImage,
+      },
+      deploy: {
+        command: [
+          "start",
+          "--log info",
+          "--user root",
+          `--pass ${databasePassword}`,
+          "--bind 0.0.0.0:8000",
+          "rocksdb:/mydata/mydatabase.db",
+        ].join(" "),
+      },
+      mounts: [
+        {
+          type: "volume",
+          name: "surreal-data",
+          mountPath: "/mydata",
+        },
+      ],
+    },
+  });
+
+  services.push({
+    type: "app",
+    data: {
+      serviceName: input.appServiceName,
+      env: [
+        `API_URL=https://$(PRIMARY_DOMAIN)`,
+        `INTERNAL_API_URL=http://localhost:5055`,
+        `OPEN_NOTEBOOK_ENCRYPTION_KEY=${encryptionKey}`,
+        `OPEN_NOTEBOOK_PASSWORD=${appPassword}`,
+        `SURREAL_URL=ws://$(PROJECT_NAME)_${input.databaseServiceName}:8000/rpc`,
+        `SURREAL_USER=root`,
+        `SURREAL_PASSWORD=${databasePassword}`,
+        `SURREAL_NAMESPACE=open_notebook`,
+        `SURREAL_DATABASE=open_notebook`,
+      ].join("\n"),
+      source: {
+        type: "image",
+        image: input.appServiceImage,
+      },
+      domains: [
+        {
+          host: "$(EASYPANEL_DOMAIN)",
+          port: 8502,
+        },
+      ],
+      mounts: [
+        {
+          type: "volume",
+          name: "notebook-data",
+          mountPath: "/app/data",
+        },
+      ],
+    },
+  });
+
+  return { services };
+}

--- a/examples/easypanel/meta.yaml
+++ b/examples/easypanel/meta.yaml
@@ -1,0 +1,79 @@
+name: Open Notebook
+description:
+  Open Notebook is an open-source, self-hosted notebook and research workspace
+  for collecting sources, taking notes, searching, chatting with content, and
+  generating podcasts.
+instructions:
+  Deploy the template, open the generated EasyPanel domain, and log in with the
+  configured Open Notebook password. Configure AI providers from Settings > API
+  Keys after the first login. If the password field is left blank, a random
+  password is generated and stored as OPEN_NOTEBOOK_PASSWORD in the app service
+  environment.
+changeLog:
+  - date: 2026-06-19
+    description: First release
+links:
+  - label: Website
+    url: https://www.open-notebook.ai
+  - label: Documentation
+    url: https://github.com/lfnovo/open-notebook/tree/main/docs
+  - label: Github
+    url: https://github.com/lfnovo/open-notebook
+contributors:
+  - name: nyxst4ck
+    url: https://github.com/nyxst4ck
+schema:
+  type: object
+  required:
+    - appServiceName
+    - appServiceImage
+    - databaseServiceName
+    - databaseServiceImage
+  properties:
+    appServiceName:
+      type: string
+      title: App Service Name
+      default: open-notebook
+    appServiceImage:
+      type: string
+      title: App Service Image
+      default: lfnovo/open_notebook:1.10.0
+    databaseServiceName:
+      type: string
+      title: Database Service Name
+      default: surrealdb
+    databaseServiceImage:
+      type: string
+      title: Database Service Image
+      default: surrealdb/surrealdb:v2
+    appPassword:
+      type: string
+      title: Open Notebook Password
+      default: ""
+benefits:
+  - title: One-click deployment
+    description:
+      Creates the Open Notebook app and SurrealDB database services with the
+      required environment variables and persistent volumes.
+  - title: Secure defaults
+    description:
+      Generates database and encryption secrets during template creation and
+      supports a user-provided or generated application password.
+  - title: Reverse-proxy friendly
+    description:
+      Exposes only the frontend port and uses Open Notebook's built-in Next.js
+      API proxy for backend requests.
+features:
+  - title: Source collection
+    description: Save documents, web pages, audio, video, and other research sources.
+  - title: Notebook workspace
+    description: Organize sources and notes into reusable research notebooks.
+  - title: AI chat and search
+    description: Ask questions across notebook context with citations.
+  - title: Podcast generation
+    description: Generate podcast-style audio from selected notebook content.
+tags:
+  - AI
+  - Knowledge Management
+  - Notes
+  - Research


### PR DESCRIPTION
## Summary
- add an EasyPanel template example with Open Notebook and SurrealDB services
- generate database/encryption secrets and support a provided or generated app password
- document how to test/copy the template into the official EasyPanel templates repository

Fixes #189

## Testing
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('examples/easypanel/meta.yaml').read_text()); print('meta.yaml ok')"`
- `git diff --check`

Note: I validated the template shape against the EasyPanel templates repository examples, but did not run the EasyPanel playground locally from this repository.
