### PR TITLE
fix: narrow note context mode type

### DIFF
--- a/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
@@ -29,8 +29,8 @@ import {
 
 // Re-exported from the shared types module for backward compatibility; several
 // components historically import these from this route file.
-import type { ContextMode, ContextSelections } from '@/lib/types/notebook-context'
-export type { ContextMode, ContextSelections }
+import type { ContextMode, ContextSelections, NoteContextMode } from '@/lib/types/notebook-context'
+export type { ContextMode, ContextSelections, NoteContextMode }
 
 export default function NotebookPage() {
   const { t } = useTranslation()
@@ -92,13 +92,22 @@ export default function NotebookPage() {
     }
   }, [notes, noteContextDefault])
 
-  // Handler to update context selection
-  const handleContextModeChange = (itemId: string, mode: ContextMode, type: 'source' | 'note') => {
+  const handleSourceContextModeChange = (sourceId: string, mode: ContextMode) => {
     setContextSelections(prev => ({
       ...prev,
-      [type === 'source' ? 'sources' : 'notes']: {
-        ...(type === 'source' ? prev.sources : prev.notes),
-        [itemId]: mode
+      sources: {
+        ...prev.sources,
+        [sourceId]: mode
+      }
+    }))
+  }
+
+  const handleNoteContextModeChange = (noteId: string, mode: NoteContextMode) => {
+    setContextSelections(prev => ({
+      ...prev,
+      notes: {
+        ...prev.notes,
+        [noteId]: mode
       }
     }))
   }
@@ -182,7 +191,7 @@ export default function NotebookPage() {
                     notebookName={notebook?.name}
                     onRefresh={refetchSources}
                     contextSelections={contextSelections.sources}
-                    onContextModeChange={(sourceId, mode) => handleContextModeChange(sourceId, mode, 'source')}
+                    onContextModeChange={handleSourceContextModeChange}
                     onBulkContextModeChange={handleBulkSourceContext}
                     hasNextPage={hasNextPage}
                     isFetchingNextPage={isFetchingNextPage}
@@ -195,7 +204,7 @@ export default function NotebookPage() {
                     isLoading={notesLoading}
                     notebookId={notebookId}
                     contextSelections={contextSelections.notes}
-                    onContextModeChange={(noteId, mode) => handleContextModeChange(noteId, mode, 'note')}
+                    onContextModeChange={handleNoteContextModeChange}
                     onBulkContextModeChange={handleBulkNoteContext}
                   />
                 )}
@@ -228,7 +237,7 @@ export default function NotebookPage() {
                 notebookName={notebook?.name}
                 onRefresh={refetchSources}
                 contextSelections={contextSelections.sources}
-                onContextModeChange={(sourceId, mode) => handleContextModeChange(sourceId, mode, 'source')}
+                onContextModeChange={handleSourceContextModeChange}
                 onBulkContextModeChange={handleBulkSourceContext}
                 hasNextPage={hasNextPage}
                 isFetchingNextPage={isFetchingNextPage}
@@ -246,7 +255,7 @@ export default function NotebookPage() {
                 isLoading={notesLoading}
                 notebookId={notebookId}
                 contextSelections={contextSelections.notes}
-                onContextModeChange={(noteId, mode) => handleContextModeChange(noteId, mode, 'note')}
+                onContextModeChange={handleNoteContextModeChange}
                 onBulkContextModeChange={handleBulkNoteContext}
               />
             </div>

--- a/frontend/src/app/(dashboard)/notebooks/components/NotesColumn.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NotesColumn.tsx
@@ -18,7 +18,7 @@ import { NoteEditorDialog } from './NoteEditorDialog'
 import { getDateLocale } from '@/lib/utils/date-locale'
 import { formatDistanceToNow } from 'date-fns'
 import { ContextToggle } from '@/components/common/ContextToggle'
-import { ContextMode } from '../[id]/page'
+import type { NoteContextMode } from '../[id]/page'
 import type { NoteContextDefault } from '@/lib/utils/source-context'
 import { useDeleteNote } from '@/lib/hooks/use-notes'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
@@ -30,8 +30,8 @@ interface NotesColumnProps {
   notes?: NoteResponse[]
   isLoading: boolean
   notebookId: string
-  contextSelections?: Record<string, ContextMode>
-  onContextModeChange?: (noteId: string, mode: ContextMode) => void
+  contextSelections?: Record<string, NoteContextMode>
+  onContextModeChange?: (noteId: string, mode: NoteContextMode) => void
   onBulkContextModeChange?: (action: NoteContextDefault) => void
 }
 
@@ -53,9 +53,10 @@ export function NotesColumn({
 
   // Collapsible column state
   const { notesCollapsed, toggleNotes } = useNotebookColumnsStore()
+  const notesLabel = t('common.notes')
   const collapseButton = useMemo(
-    () => createCollapseButton(toggleNotes, t('common.notes')),
-    [toggleNotes, t('common.notes')]
+    () => createCollapseButton(toggleNotes, notesLabel),
+    [toggleNotes, notesLabel]
   )
 
   const handleDeleteClick = (noteId: string) => {
@@ -81,12 +82,12 @@ export function NotesColumn({
         isCollapsed={notesCollapsed}
         onToggle={toggleNotes}
         collapsedIcon={StickyNote}
-        collapsedLabel={t('common.notes')}
+        collapsedLabel={notesLabel}
       >
         <Card className="h-full flex flex-col flex-1 overflow-hidden">
           <CardHeader className="pb-3 flex-shrink-0">
             <div className="flex items-center justify-between gap-2">
-              <CardTitle className="text-lg">{t('common.notes')}</CardTitle>
+              <CardTitle className="text-lg">{notesLabel}</CardTitle>
               <div className="flex items-center gap-2">
                 {onBulkContextModeChange && notes && notes.length > 0 && (
                   <DropdownMenu>

--- a/frontend/src/components/common/ContextToggle.tsx
+++ b/frontend/src/components/common/ContextToggle.tsx
@@ -19,7 +19,15 @@ interface ContextToggleProps {
   className?: string
 }
 
-export function ContextToggle({ mode, hasInsights = false, onChange, className }: ContextToggleProps) {
+export function ContextToggle<TMode extends ContextMode = ContextMode>({
+  mode,
+  hasInsights = false,
+  onChange,
+  className
+}: Omit<ContextToggleProps, 'mode' | 'onChange'> & {
+  mode: TMode
+  onChange: (mode: TMode) => void
+}) {
   const { t } = useTranslation()
 
   const MODE_CONFIG = {
@@ -46,9 +54,9 @@ export function ContextToggle({ mode, hasInsights = false, onChange, className }
   const Icon = config.icon
 
   // Determine available modes based on whether item has insights
-  const availableModes: ContextMode[] = hasInsights
+  const availableModes = (hasInsights
     ? ['off', 'insights', 'full']
-    : ['off', 'full']
+    : ['off', 'full']) as TMode[]
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation() // Prevent card click

--- a/frontend/src/lib/types/notebook-context.ts
+++ b/frontend/src/lib/types/notebook-context.ts
@@ -1,7 +1,8 @@
 /** Chat-context inclusion mode for a notebook source or note. */
 export type ContextMode = 'off' | 'insights' | 'full'
+export type NoteContextMode = Exclude<ContextMode, 'insights'>
 
 export interface ContextSelections {
   sources: Record<string, ContextMode>
-  notes: Record<string, ContextMode>
+  notes: Record<string, NoteContextMode>
 }

--- a/frontend/src/lib/utils/source-context.ts
+++ b/frontend/src/lib/utils/source-context.ts
@@ -1,4 +1,4 @@
-import type { ContextMode } from '@/lib/types/notebook-context'
+import type { ContextMode, NoteContextMode } from '@/lib/types/notebook-context'
 
 /**
  * Bulk context actions for sources:
@@ -100,7 +100,7 @@ interface NoteLike {
 }
 
 /** Resolve the context mode a bulk action implies for a single note. */
-export function bulkModeForNote(action: NoteContextDefault): ContextMode {
+export function bulkModeForNote(action: NoteContextDefault): NoteContextMode {
   return action === 'exclude' ? 'off' : 'full'
 }
 
@@ -110,10 +110,10 @@ export function bulkModeForNote(action: NoteContextDefault): ContextMode {
  * action also governs notes that load later.
  */
 export function computeNoteSelections(
-  existing: Record<string, ContextMode>,
+  existing: Record<string, NoteContextMode>,
   notes: NoteLike[],
   defaultAction: NoteContextDefault = 'include',
-): Record<string, ContextMode> {
+): Record<string, NoteContextMode> {
   const next = { ...existing }
   for (const note of notes) {
     if (next[note.id] === undefined) {
@@ -125,10 +125,10 @@ export function computeNoteSelections(
 
 /** Apply a uniform bulk context action to every given note. */
 export function applyBulkNoteContext(
-  existing: Record<string, ContextMode>,
+  existing: Record<string, NoteContextMode>,
   notes: NoteLike[],
   action: NoteContextDefault,
-): Record<string, ContextMode> {
+): Record<string, NoteContextMode> {
   const next = { ...existing }
   for (const note of notes) {
     next[note.id] = bulkModeForNote(action)


### PR DESCRIPTION
## Summary
- Add a `NoteContextMode` type that excludes `insights` from note context selections.
- Type note selection utilities and `NotesColumn` callbacks with the narrower note mode.
- Split notebook context handlers so sources still support `off`/`insights`/`full`, while notes only accept `off`/`full`.

Fixes #917

## Verification
- `npx tsc --noEmit`
- `npm run test -- source-context.test.ts`
- `npx eslint src/lib/types/notebook-context.ts src/lib/utils/source-context.ts src/components/common/ContextToggle.tsx 'src/app/(dashboard)/notebooks/[id]/page.tsx' 'src/app/(dashboard)/notebooks/components/NotesColumn.tsx' --max-warnings=0`
- `npm run lint` exits successfully with existing warnings outside this change

## Notes
- `npm ci` completed from the existing lockfile. It reported existing audit findings: 1 low, 4 moderate, and 1 high.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

