### PR TITLE
feat: sort sources by all table columns

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -200,7 +200,9 @@ async def get_sources(
             )
 
         # Build ORDER BY clause
-        order_clause = f"ORDER BY {SOURCE_SORT_FIELDS[sort_by]} {sort_order.upper()}"
+        order_clause = (
+            f"ORDER BY {SOURCE_SORT_FIELDS[sort_by]} {sort_order.upper()}, id ASC"
+        )
 
         # Build the query
         if notebook_id:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -37,6 +37,18 @@ from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
+SOURCE_SORT_FIELDS = {
+    "created": "created",
+    "updated": "updated",
+    "title": "title",
+    "insights_count": "insights_count",
+    "embedded": "embedded",
+    "type": (
+        "IF asset.file_path != NONE THEN 'file' "
+        "ELSE IF asset.url != NONE THEN 'link' ELSE 'text' END END"
+    ),
+}
+
 
 def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
     """Generate unique filename like Streamlit app (append counter if file exists)."""
@@ -166,16 +178,21 @@ async def get_sources(
     ),
     offset: int = Query(0, ge=0, description="Number of sources to skip"),
     sort_by: str = Query(
-        "updated", description="Field to sort by (created or updated)"
+        "updated",
+        description="Field to sort by (type, title, created, updated, insights_count, or embedded)",
     ),
     sort_order: str = Query("desc", description="Sort order (asc or desc)"),
 ):
     """Get sources with pagination and sorting support."""
     try:
         # Validate sort parameters
-        if sort_by not in ["created", "updated"]:
+        if sort_by not in SOURCE_SORT_FIELDS:
             raise HTTPException(
-                status_code=400, detail="sort_by must be 'created' or 'updated'"
+                status_code=400,
+                detail=(
+                    "sort_by must be one of: type, title, created, updated, "
+                    "insights_count, embedded"
+                ),
             )
         if sort_order.lower() not in ["asc", "desc"]:
             raise HTTPException(
@@ -183,7 +200,7 @@ async def get_sources(
             )
 
         # Build ORDER BY clause
-        order_clause = f"ORDER BY {sort_by} {sort_order.upper()}"
+        order_clause = f"ORDER BY {SOURCE_SORT_FIELDS[sort_by]} {sort_order.upper()}"
 
         # Build the query
         if notebook_id:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -43,11 +43,13 @@ SOURCE_SORT_FIELDS = {
     "title": "title",
     "insights_count": "insights_count",
     "embedded": "embedded",
-    "type": (
-        "IF asset.file_path != NONE THEN 'file' "
-        "ELSE IF asset.url != NONE THEN 'link' ELSE 'text' END END"
-    ),
+    "type": "type",
 }
+
+SOURCE_TYPE_EXPRESSION = (
+    "IF asset.file_path != NONE THEN 'file' "
+    "ELSE IF asset.url != NONE THEN 'link' ELSE 'text' END"
+)
 
 
 def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
@@ -214,6 +216,7 @@ async def get_sources(
             # Query sources for specific notebook - include command field with FETCH
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command,
+                ({SOURCE_TYPE_EXPRESSION}) AS type,
                 (SELECT VALUE count() FROM source_insight WHERE source = $parent.id GROUP ALL)[0].count OR 0 AS insights_count,
                 (SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded
                 FROM (select value in from reference where out=$notebook_id)
@@ -233,6 +236,7 @@ async def get_sources(
             # Query all sources - include command field with FETCH
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command,
+                ({SOURCE_TYPE_EXPRESSION}) AS type,
                 (SELECT VALUE count() FROM source_insight WHERE source = $parent.id GROUP ALL)[0].count OR 0 AS insights_count,
                 (SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded
                 FROM source

--- a/frontend/src/app/(dashboard)/sources/page.tsx
+++ b/frontend/src/app/(dashboard)/sources/page.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { sourcesApi } from '@/lib/api/sources'
+import { sourcesApi, type SourceSortField } from '@/lib/api/sources'
 import { SourceListResponse } from '@/lib/types/api'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { EmptyState } from '@/components/common/EmptyState'
 import { AppShell } from '@/components/layout/AppShell'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
-import { FileText, Link as LinkIcon, Upload, AlignLeft, Trash2, ArrowUpDown } from 'lucide-react'
+import { FileText, Link as LinkIcon, Upload, AlignLeft, Trash2, ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -20,12 +20,13 @@ import { getApiErrorKey } from '@/lib/utils/error-handler'
 
 export default function SourcesPage() {
   const { t, language } = useTranslation()
+  const failedToLoadMessage = t('sources.failedToLoad')
   const [sources, setSources] = useState<SourceListResponse[]>([])
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [sortBy, setSortBy] = useState<'created' | 'updated'>('updated')
+  const [sortBy, setSortBy] = useState<SourceSortField>('updated')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [deleteDialog, setDeleteDialog] = useState<{ open: boolean; source: SourceListResponse | null }>({
     open: false,
@@ -75,14 +76,14 @@ export default function SourcesPage() {
       offsetRef.current += data.length
     } catch (err) {
       console.error('Failed to fetch sources:', err)
-      setError(t('sources.failedToLoad'))
-      toast.error(t('sources.failedToLoad'))
+      setError(failedToLoadMessage)
+      toast.error(failedToLoadMessage)
     } finally {
       setLoading(false)
       setLoadingMore(false)
       loadingMoreRef.current = false
     }
-  }, [sortBy, sortOrder, t('sources.failedToLoad')])
+  }, [sortBy, sortOrder, failedToLoadMessage])
 
   // Initial load and when sort changes
   useEffect(() => {
@@ -202,7 +203,7 @@ export default function SourcesPage() {
     }
   }, [fetchSources, sources.length])
 
-  const toggleSort = (field: 'created' | 'updated') => {
+  const toggleSort = (field: SourceSortField) => {
     if (sortBy === field) {
       // Toggle order if clicking the same field
       setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')
@@ -211,6 +212,33 @@ export default function SourcesPage() {
       setSortBy(field)
       setSortOrder('desc')
     }
+  }
+
+  const renderSortableHeader = (
+    field: SourceSortField,
+    label: string,
+    align: 'left' | 'center' = 'left'
+  ) => {
+    const active = sortBy === field
+    const SortIcon = active ? (sortOrder === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown
+
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => toggleSort(field)}
+        className={cn(
+          "h-8 px-2 hover:bg-muted",
+          align === 'center' && "mx-auto"
+        )}
+      >
+        {label}
+        <SortIcon className={cn(
+          "ml-2 h-3 w-3",
+          active ? 'opacity-100' : 'opacity-30'
+        )} />
+      </Button>
+    )
   }
 
   const getSourceIcon = (source: SourceListResponse) => {
@@ -297,11 +325,12 @@ export default function SourcesPage() {
           <table
             ref={tableRef}
             tabIndex={0}
-            className="w-full min-w-[800px] outline-none table-fixed"
+            className="w-full min-w-[920px] outline-none table-fixed"
           >
             <colgroup>
               <col className="w-[120px]" />
               <col className="w-auto" />
+              <col className="w-[140px]" />
               <col className="w-[140px]" />
               <col className="w-[100px]" />
               <col className="w-[100px]" />
@@ -310,35 +339,22 @@ export default function SourcesPage() {
             <thead className="sticky top-0 bg-background z-10">
               <tr className="border-b bg-muted/50">
                 <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground">
-                  {t('common.type')}
+                  {renderSortableHeader('type', t('common.type'))}
                 </th>
                 <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground">
-                  {t('common.title')}
+                  {renderSortableHeader('title', t('common.title'))}
                 </th>
                 <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground hidden sm:table-cell">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => toggleSort('created')}
-                    className="h-8 px-2 hover:bg-muted"
-                  >
-                    {t('common.created_label')}
-                    <ArrowUpDown className={cn(
-                      "ml-2 h-3 w-3",
-                      sortBy === 'created' ? 'opacity-100' : 'opacity-30'
-                    )} />
-                    {sortBy === 'created' && (
-                      <span className="ml-1 text-xs">
-                        {sortOrder === 'asc' ? '↑' : '↓'}
-                      </span>
-                    )}
-                  </Button>
+                  {renderSortableHeader('created', t('common.created_label'))}
+                </th>
+                <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground hidden sm:table-cell">
+                  {renderSortableHeader('updated', t('common.updated_label'))}
                 </th>
                 <th className="h-12 px-4 text-center align-middle font-medium text-muted-foreground hidden md:table-cell">
-                  {t('sources.insights')}
+                  {renderSortableHeader('insights_count', t('sources.insights'), 'center')}
                 </th>
                 <th className="h-12 px-4 text-center align-middle font-medium text-muted-foreground hidden lg:table-cell">
-                  {t('sources.embedded')}
+                  {renderSortableHeader('embedded', t('sources.embedded'), 'center')}
                 </th>
                 <th className="h-12 px-4 text-right align-middle font-medium text-muted-foreground">
                   {t('common.actions')}
@@ -384,6 +400,12 @@ export default function SourcesPage() {
                       locale: getDateLocale(language)
                     })}
                   </td>
+                  <td className="h-12 px-4 text-muted-foreground text-sm hidden sm:table-cell">
+                    {formatDistanceToNow(new Date(source.updated), {
+                      addSuffix: true,
+                      locale: getDateLocale(language)
+                    })}
+                  </td>
                   <td className="h-12 px-4 text-center hidden md:table-cell">
                     <span className="text-sm font-medium">{source.insights_count || 0}</span>
                   </td>
@@ -406,7 +428,7 @@ export default function SourcesPage() {
               ))}
               {loadingMore && (
                 <tr>
-                  <td colSpan={6} className="h-16 text-center">
+                  <td colSpan={7} className="h-16 text-center">
                     <div className="flex items-center justify-center">
                       <LoadingSpinner />
                       <span className="ml-2 text-muted-foreground">{t('sources.loadingMore')}</span>

--- a/frontend/src/app/(dashboard)/sources/page.tsx
+++ b/frontend/src/app/(dashboard)/sources/page.tsx
@@ -204,6 +204,7 @@ export default function SourcesPage() {
   }, [fetchSources, sources.length])
 
   const toggleSort = (field: SourceSortField) => {
+    setSelectedIndex(0)
     if (sortBy === field) {
       // Toggle order if clicking the same field
       setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -10,12 +10,14 @@ import {
   UpdateSourceRequest 
 } from '@/lib/types/api'
 
+export type SourceSortField = 'type' | 'title' | 'created' | 'updated' | 'insights_count' | 'embedded'
+
 export const sourcesApi = {
   list: async (params?: {
     notebook_id?: string
     limit?: number
     offset?: number
-    sort_by?: 'created' | 'updated'
+    sort_by?: SourceSortField
     sort_order?: 'asc' | 'desc'
   }) => {
     const response = await apiClient.get<SourceListResponse[]>('/sources', { params })

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -146,7 +146,7 @@ export const bnIN = {
     invalidSourceType: "অবৈধ উৎস ধরন",
     processingFailed: "প্রক্রিয়াকরণ ব্যর্থ",
     failedToQueue: "প্রক্রিয়াকরণ কিউ করতে ব্যর্থ",
-    invalidSortBy: "সাজানোর ফিল্ড 'created' বা 'updated' হতে হবে",
+    invalidSortBy: "সাজানোর ফিল্ড type, title, created, updated, insights count, বা embedded হতে হবে",
     invalidSortOrder: "সাজানোর ক্রম 'asc' বা 'desc' হতে হবে",
     accessDenied: "ফাইলের অ্যাক্সেস অস্বীকৃত",
     fileNotFoundOnServer: "সার্ভারে ফাইল খুঁজে পাওয়া যায়নি",

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -146,7 +146,7 @@ export const bnIN = {
     invalidSourceType: "অবৈধ উৎস ধরন",
     processingFailed: "প্রক্রিয়াকরণ ব্যর্থ",
     failedToQueue: "প্রক্রিয়াকরণ কিউ করতে ব্যর্থ",
-    invalidSortBy: "সাজানোর ফিল্ড type, title, created, updated, insights count, বা embedded হতে হবে",
+    invalidSortBy: "সাজানোর ফিল্ড type, title, created, updated, insights_count, বা embedded হতে হবে",
     invalidSortOrder: "সাজানোর ক্রম 'asc' বা 'desc' হতে হবে",
     accessDenied: "ফাইলের অ্যাক্সেস অস্বীকৃত",
     fileNotFoundOnServer: "সার্ভারে ফাইল খুঁজে পাওয়া যায়নি",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -146,7 +146,7 @@ export const caES = {
     invalidSourceType: "Tipus de font no vàlid",
     processingFailed: "Ha fallat el processament",
     failedToQueue: "Ha fallat l'addició a la cua de processament",
-    invalidSortBy: "El camp d'ordenació ha de ser 'created' o 'updated'",
+    invalidSortBy: "El camp d'ordenació ha de ser type, title, created, updated, recompte d'insights o embedded",
     invalidSortOrder: "L'ordre d'ordenació ha de ser 'asc' o 'desc'",
     accessDenied: "Accés al fitxer denegat",
     fileNotFoundOnServer: "No s'ha trobat el fitxer al servidor",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -146,7 +146,7 @@ export const caES = {
     invalidSourceType: "Tipus de font no vàlid",
     processingFailed: "Ha fallat el processament",
     failedToQueue: "Ha fallat l'addició a la cua de processament",
-    invalidSortBy: "El camp d'ordenació ha de ser type, title, created, updated, recompte d'insights o embedded",
+    invalidSortBy: "El camp d'ordenació ha de ser type, title, created, updated, insights_count o embedded",
     invalidSortOrder: "L'ordre d'ordenació ha de ser 'asc' o 'desc'",
     accessDenied: "Accés al fitxer denegat",
     fileNotFoundOnServer: "No s'ha trobat el fitxer al servidor",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -149,7 +149,7 @@ export const deDE = {
     invalidSourceType: "Ungültiger Quellentyp",
     processingFailed: "Verarbeitung fehlgeschlagen",
     failedToQueue: "Verarbeitung konnte nicht in die Warteschlange gestellt werden",
-    invalidSortBy: "Sortierfeld muss „created“ oder „updated“ sein",
+    invalidSortBy: "Sortierfeld muss type, title, created, updated, insights count oder embedded sein",
     invalidSortOrder: "Sortierreihenfolge muss „asc“ oder „desc“ sein",
     accessDenied: "Zugriff auf Datei verweigert",
     fileNotFoundOnServer: "Datei auf dem Server nicht gefunden",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -149,7 +149,7 @@ export const deDE = {
     invalidSourceType: "Ungültiger Quellentyp",
     processingFailed: "Verarbeitung fehlgeschlagen",
     failedToQueue: "Verarbeitung konnte nicht in die Warteschlange gestellt werden",
-    invalidSortBy: "Sortierfeld muss type, title, created, updated, insights count oder embedded sein",
+    invalidSortBy: "Sortierfeld muss type, title, created, updated, insights_count oder embedded sein",
     invalidSortOrder: "Sortierreihenfolge muss „asc“ oder „desc“ sein",
     accessDenied: "Zugriff auf Datei verweigert",
     fileNotFoundOnServer: "Datei auf dem Server nicht gefunden",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -146,7 +146,7 @@ export const enUS = {
     invalidSourceType: "Invalid source type",
     processingFailed: "Processing failed",
     failedToQueue: "Failed to queue processing",
-    invalidSortBy: "Sort field must be 'created' or 'updated'",
+    invalidSortBy: "Sort field must be type, title, created, updated, insights count, or embedded",
     invalidSortOrder: "Sort order must be 'asc' or 'desc'",
     accessDenied: "Access to file denied",
     fileNotFoundOnServer: "File not found on server",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -146,7 +146,7 @@ export const enUS = {
     invalidSourceType: "Invalid source type",
     processingFailed: "Processing failed",
     failedToQueue: "Failed to queue processing",
-    invalidSortBy: "Sort field must be type, title, created, updated, insights count, or embedded",
+    invalidSortBy: "Sort field must be type, title, created, updated, insights_count, or embedded",
     invalidSortOrder: "Sort order must be 'asc' or 'desc'",
     accessDenied: "Access to file denied",
     fileNotFoundOnServer: "File not found on server",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -146,7 +146,7 @@ export const esES = {
     invalidSourceType: "Tipo de fuente inválido",
     processingFailed: "El procesamiento falló",
     failedToQueue: "Error al poner en cola el procesamiento",
-    invalidSortBy: "El campo de ordenamiento debe ser 'created' o 'updated'",
+    invalidSortBy: "El campo de ordenamiento debe ser type, title, created, updated, recuento de insights o embedded",
     invalidSortOrder: "El orden debe ser 'asc' o 'desc'",
     accessDenied: "Acceso al archivo denegado",
     fileNotFoundOnServer: "Archivo no encontrado en el servidor",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -146,7 +146,7 @@ export const esES = {
     invalidSourceType: "Tipo de fuente inválido",
     processingFailed: "El procesamiento falló",
     failedToQueue: "Error al poner en cola el procesamiento",
-    invalidSortBy: "El campo de ordenamiento debe ser type, title, created, updated, recuento de insights o embedded",
+    invalidSortBy: "El campo de ordenamiento debe ser type, title, created, updated, insights_count o embedded",
     invalidSortOrder: "El orden debe ser 'asc' o 'desc'",
     accessDenied: "Acceso al archivo denegado",
     fileNotFoundOnServer: "Archivo no encontrado en el servidor",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -146,7 +146,7 @@ export const frFR = {
     invalidSourceType: "Type de source invalide",
     processingFailed: "Échec du traitement",
     failedToQueue: "Échec de la mise en file d'attente du traitement",
-    invalidSortBy: "Le champ de tri doit être type, title, created, updated, nombre d'insights ou embedded",
+    invalidSortBy: "Le champ de tri doit être type, title, created, updated, insights_count ou embedded",
     invalidSortOrder: "L'ordre de tri doit être 'asc' ou 'desc'",
     accessDenied: "Accès au fichier refusé",
     fileNotFoundOnServer: "Fichier introuvable sur le serveur",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -146,7 +146,7 @@ export const frFR = {
     invalidSourceType: "Type de source invalide",
     processingFailed: "Échec du traitement",
     failedToQueue: "Échec de la mise en file d'attente du traitement",
-    invalidSortBy: "Le champ de tri doit être 'created' ou 'updated'",
+    invalidSortBy: "Le champ de tri doit être type, title, created, updated, nombre d'insights ou embedded",
     invalidSortOrder: "L'ordre de tri doit être 'asc' ou 'desc'",
     accessDenied: "Accès au fichier refusé",
     fileNotFoundOnServer: "Fichier introuvable sur le serveur",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -146,7 +146,7 @@ export const itIT = {
     invalidSourceType: "Tipo di fonte non valido",
     processingFailed: "Elaborazione fallita",
     failedToQueue: "Impossibile accodare l'elaborazione",
-    invalidSortBy: "Il campo di ordinamento deve essere type, title, created, updated, conteggio insight o embedded",
+    invalidSortBy: "Il campo di ordinamento deve essere type, title, created, updated, insights_count o embedded",
     invalidSortOrder: "L'ordine deve essere 'asc' o 'desc'",
     accessDenied: "Accesso al file negato",
     fileNotFoundOnServer: "File non trovato sul server",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -146,7 +146,7 @@ export const itIT = {
     invalidSourceType: "Tipo di fonte non valido",
     processingFailed: "Elaborazione fallita",
     failedToQueue: "Impossibile accodare l'elaborazione",
-    invalidSortBy: "Il campo di ordinamento deve essere 'created' o 'updated'",
+    invalidSortBy: "Il campo di ordinamento deve essere type, title, created, updated, conteggio insight o embedded",
     invalidSortOrder: "L'ordine deve essere 'asc' o 'desc'",
     accessDenied: "Accesso al file negato",
     fileNotFoundOnServer: "File non trovato sul server",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -146,7 +146,7 @@ export const jaJP = {
     invalidSourceType: "無効なソースタイプです",
     processingFailed: "処理に失敗しました",
     failedToQueue: "処理キューへの追加に失敗しました",
-    invalidSortBy: "ソートフィールドは type、title、created、updated、insights count、または embedded である必要があります",
+    invalidSortBy: "ソートフィールドは type、title、created、updated、insights_count、または embedded である必要があります",
     invalidSortOrder: "ソート順は'asc'または'desc'である必要があります",
     accessDenied: "ファイルへのアクセスが拒否されました",
     fileNotFoundOnServer: "サーバー上にファイルが見つかりません",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -146,7 +146,7 @@ export const jaJP = {
     invalidSourceType: "無効なソースタイプです",
     processingFailed: "処理に失敗しました",
     failedToQueue: "処理キューへの追加に失敗しました",
-    invalidSortBy: "ソートフィールドは'created'または'updated'である必要があります",
+    invalidSortBy: "ソートフィールドは type、title、created、updated、insights count、または embedded である必要があります",
     invalidSortOrder: "ソート順は'asc'または'desc'である必要があります",
     accessDenied: "ファイルへのアクセスが拒否されました",
     fileNotFoundOnServer: "サーバー上にファイルが見つかりません",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -146,7 +146,7 @@ export const plPL = {
     invalidSourceType: "Nieprawidłowy typ źródła",
     processingFailed: "Przetwarzanie nie powiodło się",
     failedToQueue: "Nie udało się dodać do kolejki przetwarzania",
-    invalidSortBy: "Pole sortowania musi mieć wartość type, title, created, updated, liczba insights lub embedded",
+    invalidSortBy: "Pole sortowania musi mieć wartość type, title, created, updated, insights_count lub embedded",
     invalidSortOrder: "Kolejność sortowania musi mieć wartość „asc” lub „desc”",
     accessDenied: "Odmowa dostępu do pliku",
     fileNotFoundOnServer: "Nie znaleziono pliku na serwerze",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -146,7 +146,7 @@ export const plPL = {
     invalidSourceType: "Nieprawidłowy typ źródła",
     processingFailed: "Przetwarzanie nie powiodło się",
     failedToQueue: "Nie udało się dodać do kolejki przetwarzania",
-    invalidSortBy: "Pole sortowania musi mieć wartość „created” lub „updated”",
+    invalidSortBy: "Pole sortowania musi mieć wartość type, title, created, updated, liczba insights lub embedded",
     invalidSortOrder: "Kolejność sortowania musi mieć wartość „asc” lub „desc”",
     accessDenied: "Odmowa dostępu do pliku",
     fileNotFoundOnServer: "Nie znaleziono pliku na serwerze",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -146,7 +146,7 @@ export const ptBR = {
     invalidSourceType: "Tipo de fonte inválido",
     processingFailed: "Processamento falhou",
     failedToQueue: "Falha ao enfileirar processamento",
-    invalidSortBy: "Campo de ordenação deve ser type, title, created, updated, contagem de insights ou embedded",
+    invalidSortBy: "Campo de ordenação deve ser type, title, created, updated, insights_count ou embedded",
     invalidSortOrder: "Ordem deve ser 'asc' ou 'desc'",
     accessDenied: "Acesso ao arquivo negado",
     fileNotFoundOnServer: "Arquivo não encontrado no servidor",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -146,7 +146,7 @@ export const ptBR = {
     invalidSourceType: "Tipo de fonte inválido",
     processingFailed: "Processamento falhou",
     failedToQueue: "Falha ao enfileirar processamento",
-    invalidSortBy: "Campo de ordenação deve ser 'created' ou 'updated'",
+    invalidSortBy: "Campo de ordenação deve ser type, title, created, updated, contagem de insights ou embedded",
     invalidSortOrder: "Ordem deve ser 'asc' ou 'desc'",
     accessDenied: "Acesso ao arquivo negado",
     fileNotFoundOnServer: "Arquivo não encontrado no servidor",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -146,7 +146,7 @@ export const ruRU = {
     invalidSourceType: "Недопустимый тип источника",
     processingFailed: "Обработка не удалась",
     failedToQueue: "Не удалось поставить в очередь обработки",
-    invalidSortBy: "Поле сортировки должно быть type, title, created, updated, количество insights или embedded",
+    invalidSortBy: "Поле сортировки должно быть type, title, created, updated, insights_count или embedded",
     invalidSortOrder: "Порядок сортировки должен быть 'asc' или 'desc'",
     accessDenied: "Доступ к файлу запрещён",
     fileNotFoundOnServer: "Файл не найден на сервере",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -146,7 +146,7 @@ export const ruRU = {
     invalidSourceType: "Недопустимый тип источника",
     processingFailed: "Обработка не удалась",
     failedToQueue: "Не удалось поставить в очередь обработки",
-    invalidSortBy: "Поле сортировки должно быть 'created' или 'updated'",
+    invalidSortBy: "Поле сортировки должно быть type, title, created, updated, количество insights или embedded",
     invalidSortOrder: "Порядок сортировки должен быть 'asc' или 'desc'",
     accessDenied: "Доступ к файлу запрещён",
     fileNotFoundOnServer: "Файл не найден на сервере",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -146,7 +146,7 @@ export const trTR = {
     invalidSourceType: "Geçersiz kaynak türü",
     processingFailed: "İşleme başarısız",
     failedToQueue: "İşleme kuyruğa eklenemedi",
-    invalidSortBy: "Sıralama alanı 'created' veya 'updated' olmalıdır",
+    invalidSortBy: "Sıralama alanı type, title, created, updated, insights count veya embedded olmalıdır",
     invalidSortOrder: "Sıralama yönü 'asc' veya 'desc' olmalıdır",
     accessDenied: "Dosyaya erişim reddedildi",
     fileNotFoundOnServer: "Sunucuda dosya bulunamadı",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -146,7 +146,7 @@ export const trTR = {
     invalidSourceType: "Geçersiz kaynak türü",
     processingFailed: "İşleme başarısız",
     failedToQueue: "İşleme kuyruğa eklenemedi",
-    invalidSortBy: "Sıralama alanı type, title, created, updated, insights count veya embedded olmalıdır",
+    invalidSortBy: "Sıralama alanı type, title, created, updated, insights_count veya embedded olmalıdır",
     invalidSortOrder: "Sıralama yönü 'asc' veya 'desc' olmalıdır",
     accessDenied: "Dosyaya erişim reddedildi",
     fileNotFoundOnServer: "Sunucuda dosya bulunamadı",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -146,7 +146,7 @@ export const zhCN = {
     invalidSourceType: "无效的源类型",
     processingFailed: "处理失败",
     failedToQueue: "排队处理失败",
-    invalidSortBy: "排序字段必须是 'created' 或 'updated'",
+    invalidSortBy: "排序字段必须是 type、title、created、updated、insights count 或 embedded",
     invalidSortOrder: "排序方向必须是 'asc' 或 'desc'",
     accessDenied: "文件访问被拒绝",
     fileNotFoundOnServer: "服务器上找不到该文件",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -146,7 +146,7 @@ export const zhCN = {
     invalidSourceType: "无效的源类型",
     processingFailed: "处理失败",
     failedToQueue: "排队处理失败",
-    invalidSortBy: "排序字段必须是 type、title、created、updated、insights count 或 embedded",
+    invalidSortBy: "排序字段必须是 type、title、created、updated、insights_count 或 embedded",
     invalidSortOrder: "排序方向必须是 'asc' 或 'desc'",
     accessDenied: "文件访问被拒绝",
     fileNotFoundOnServer: "服务器上找不到该文件",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -146,7 +146,7 @@ export const zhTW = {
     invalidSourceType: "無效的源類型",
     processingFailed: "處理失敗",
     failedToQueue: "排隊處理失敗",
-    invalidSortBy: "排序欄位必須是 'created' 或 'updated'",
+    invalidSortBy: "排序欄位必須是 type、title、created、updated、insights count 或 embedded",
     invalidSortOrder: "排序方向必須是 'asc' 或 'desc'",
     accessDenied: "檔案存取被拒絕",
     fileNotFoundOnServer: "伺服器上找不到該檔案",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -146,7 +146,7 @@ export const zhTW = {
     invalidSourceType: "無效的源類型",
     processingFailed: "處理失敗",
     failedToQueue: "排隊處理失敗",
-    invalidSortBy: "排序欄位必須是 type、title、created、updated、insights count 或 embedded",
+    invalidSortBy: "排序欄位必須是 type、title、created、updated、insights_count 或 embedded",
     invalidSortOrder: "排序方向必須是 'asc' 或 'desc'",
     accessDenied: "檔案存取被拒絕",
     fileNotFoundOnServer: "伺服器上找不到該檔案",

--- a/frontend/src/lib/utils/error-handler.ts
+++ b/frontend/src/lib/utils/error-handler.ts
@@ -11,7 +11,7 @@ export const ERROR_MAP: Record<string, string> = {
   "Invalid source type": "apiErrors.invalidSourceType",
   "Processing failed": "apiErrors.processingFailed",
   "Failed to queue processing": "apiErrors.failedToQueue",
-  "sort_by must be 'created' or 'updated'": "apiErrors.invalidSortBy",
+  "sort_by must be one of: type, title, created, updated, insights_count, embedded": "apiErrors.invalidSortBy",
   "sort_order must be 'asc' or 'desc'": "apiErrors.invalidSortOrder",
   "Access to file denied": "apiErrors.accessDenied",
   "File not found on server": "apiErrors.fileNotFoundOnServer",


### PR DESCRIPTION
## Summary
- Expand `/api/sources` sorting to support type, title, insights count, embedded status, created, and updated
- Add sortable headers for all Sources table columns, including an Updated column
- Update frontend source sort typing and the invalid sort-field error copy

Fixes #895

## Verification
- `npx eslint 'src/app/(dashboard)/sources/page.tsx' src/lib/api/sources.ts src/lib/utils/error-handler.ts --max-warnings=0`
- `npx tsc --noEmit`
- `uv run ruff check api/routers/sources.py`
- `git diff --check`
- `npm run lint` exits 0 with existing unrelated warnings outside this change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

