### PR TITLE
docs: add EasyPanel deployment to single-container guide

### DIFF
--- a/docs/1-INSTALLATION/single-container.md
+++ b/docs/1-INSTALLATION/single-container.md
@@ -97,6 +97,15 @@ heroku config:set OPEN_NOTEBOOK_ENCRYPTION_KEY=your-secret-key
 5. Enable persistent volumes
 6. Coolify handles HTTPS automatically
 
+**EasyPanel:**
+
+Open Notebook ships an EasyPanel template at [`examples/easypanel/`](https://github.com/lfnovo/open-notebook/tree/main/examples/easypanel). Unlike the single-image options above, the template provisions **two services** — the Open Notebook app and a dedicated SurrealDB instance — and generates the database password, encryption key, and (optionally) the app password for you.
+
+- **One-click (recommended):** once the template is published to the official [EasyPanel template gallery](https://github.com/easypanel-io/templates), create a new service from "Open Notebook", set an app password (or leave it blank to auto-generate one), and deploy.
+- **Manual:** copy `examples/easypanel/` into `templates/open-notebook` in a checkout of [`easypanel-io/templates`](https://github.com/easypanel-io/templates), run the templates playground (`npm run dev`), and create the template from the generated JSON in your EasyPanel instance.
+
+After deployment, open the EasyPanel domain and configure your AI provider in **Settings → API Keys**. See [`examples/easypanel/README.md`](https://github.com/lfnovo/open-notebook/blob/main/examples/easypanel/README.md) for details.
+
 ---
 
 ## Environment Variables


### PR DESCRIPTION
## Summary

Follow-up to #927 (EasyPanel template). That PR added the template under `examples/easypanel/` plus a contributor-facing README, but EasyPanel wasn't mentioned anywhere in the user-facing docs — it was missing from the cloud-platform deploy list that already covers Railway, Render, DigitalOcean, Heroku, and Coolify.

This adds an **EasyPanel** entry to `docs/1-INSTALLATION/single-container.md`:
- Notes that, unlike the single-image options, the template provisions **two services** (app + dedicated SurrealDB) and auto-generates the DB password, encryption key, and optional app password.
- Documents the **one-click** flow (via the official EasyPanel template gallery, once published) and the **manual** playground flow.
- Links to `examples/easypanel/` and its README.

## Notes

- Docs-only, no code changes.
- Placed in `single-container.md` alongside the other PaaS entries for discoverability, even though the template is multi-service (this is called out in the text).

Refs #189


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

