### PR TITLE
fix: handle special-token sequences in token counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CRUD endpoints now return `404` (not `500`) for a non-existent resource. `ObjectModel.get()` raises `NotFoundError` rather than returning a falsy value, so the broad `except Exception` in each handler was masking it as a server error. Added an explicit `NotFoundError → 404` arm to the notebook (update / delete / delete-preview / add-source / remove-source), note (get / update / delete / list / create), model (delete), credential (update / delete) and embed handlers (#862)
+- Token counting no longer raises `ValueError: disallowed special token '<|endoftext|>'` when source/context content contains special-token sequences; `token_count()` now encodes with `disallowed_special=()` so such substrings are treated as ordinary text (#667)
 
 ## [1.10.0] - 2026-06-17
 

--- a/open_notebook/utils/token_utils.py
+++ b/open_notebook/utils/token_utils.py
@@ -26,7 +26,10 @@ def token_count(input_string: str) -> int:
         import tiktoken
 
         encoding = tiktoken.get_encoding("o200k_base")
-        tokens = encoding.encode(input_string)
+        # disallowed_special=() treats sequences like "<|endoftext|>" as ordinary
+        # text instead of raising ValueError. User/source content can legitimately
+        # contain these substrings, and we only need a token count here.
+        tokens = encoding.encode(input_string, disallowed_special=())
         return len(tokens)
     except (ImportError, OSError) as e:
         # Fallback: handles ImportError (tiktoken not installed) AND network/OS


### PR DESCRIPTION
## Summary

`token_count()` (`open_notebook/utils/token_utils.py`) called tiktoken's `encode()` without `disallowed_special`, so any source or context text containing a sequence like `<|endoftext|>` raised `ValueError: disallowed special token '<|endoftext|>'` and aborted source processing / context building.

## Fix

Encode with `disallowed_special=()` so those substrings are treated as ordinary text. We only need a token count, not an encoding that round-trips through the model's special-token vocabulary.

## Test

- Existing token util tests pass.
- `token_count("<|endoftext|>")` now returns a count instead of raising.

Fixes #667

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

