### PR TITLE
fix: use uv run --no-sync in single-container supervisord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - CRUD endpoints now return `404` (not `500`) for a non-existent resource. `ObjectModel.get()` raises `NotFoundError` rather than returning a falsy value, so the broad `except Exception` in each handler was masking it as a server error. Added an explicit `NotFoundError → 404` arm to the notebook (update / delete / delete-preview / add-source / remove-source), note (get / update / delete / list / create), model (delete), credential (update / delete) and embed handlers (#862)
 - Token counting no longer raises `ValueError: disallowed special token '<|endoftext|>'` when source/context content contains special-token sequences; `token_count()` now encodes with `disallowed_special=()` so such substrings are treated as ordinary text (#667)
+- Single-container image no longer hangs at "API not ready yet" on a brand-new instance. `supervisord.single.conf` ran the API and worker with `uv run` (without `--no-sync`), so at startup `uv` tried to sync dev dependencies it couldn't resolve against the `--no-dev` build. Both processes now use `uv run --no-sync`, matching the multi-container `supervisord.conf` (#609)
 
 ## [1.10.0] - 2026-06-17
 

--- a/supervisord.single.conf
+++ b/supervisord.single.conf
@@ -16,7 +16,7 @@ autostart=true
 startsecs=5
 
 [program:api]
-command=uv run uvicorn api.main:app --host 0.0.0.0 --port 5055
+command=uv run --no-sync uvicorn api.main:app --host 0.0.0.0 --port 5055
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -27,7 +27,7 @@ autostart=true
 startsecs=3
 
 [program:worker]
-command=uv run surreal-commands-worker --import-modules commands
+command=uv run --no-sync surreal-commands-worker --import-modules commands
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Summary

A brand-new single-container instance could hang at "API not ready yet" for a very long time (#609). `supervisord.single.conf` started the API and worker with `uv run` **without** `--no-sync`, so at startup `uv` tried to sync dev dependencies that aren't present in the image's `--no-dev` build — stalling/looping before the server came up.

## Fix

Run both programs with `uv run --no-sync`, matching the multi-container `supervisord.conf` (which already does this):

```
[program:api]
command=uv run --no-sync uvicorn api.main:app --host 0.0.0.0 --port 5055
[program:worker]
command=uv run --no-sync surreal-commands-worker --import-modules commands
```

Fixes #609

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

