### PR TITLE
chore(security): source docker-compose SurrealDB creds from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ OPEN_NOTEBOOK_ENCRYPTION_KEY=change-me-to-a-secret-string
 # =============================================================================
 
 SURREAL_URL=ws://surrealdb:8000/rpc
+# root:root is fine for local use. Change these before exposing the instance to a
+# network — docker-compose.yml reads them for both the SurrealDB server and the
+# app, so the two stay in sync.
 SURREAL_USER=root
 SURREAL_PASSWORD=root
 SURREAL_NAMESPACE=open_notebook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - List view for the Notebooks page — a tile/list toggle in the header lets you switch between the visual card grid and a compact row layout (name, description, source/note counts, last updated) for easier scanning of large collections. The choice is remembered across reloads and translated across all 14 locales (#885)
 - Documented the `ESPERANTO_TTS_TIMEOUT` environment variable (default `300`s) in the environment reference; raise it for slow or self-hosted TTS providers so long podcast segments don't fail with a timeout (#937)
 
+### Changed
+- `docker-compose.yml` now sources the SurrealDB credentials from `SURREAL_USER` / `SURREAL_PASSWORD` (applied to both the database server and the app), defaulting to `root:root` so the zero-config quick start is unchanged. Set them in a `.env` file to use your own credentials before exposing the instance; `.env.example` and the compose file note this (#946)
+
 ### Fixed
 - CRUD endpoints now return `404` (not `500`) for a non-existent resource. `ObjectModel.get()` raises `NotFoundError` rather than returning a falsy value, so the broad `except Exception` in each handler was masking it as a server error. Added an explicit `NotFoundError → 404` arm to the notebook (update / delete / delete-preview / add-source / remove-source), note (get / update / delete / list / create), model (delete), credential (update / delete) and embed handlers (#862)
 - Token counting no longer raises `ValueError: disallowed special token '<|endoftext|>'` when source/context content contains special-token sequences; `token_count()` now encodes with `disallowed_special=()` so such substrings are treated as ordinary text (#667)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 services:
   surrealdb:
     image: surrealdb/surrealdb:v2
-    command: start --log info --user root --pass root rocksdb:/mydata/mydatabase.db
+    # Credentials default to root:root for a zero-config local setup. Before
+    # exposing this instance to a network, set SURREAL_USER / SURREAL_PASSWORD
+    # in a .env file (see .env.example) — they are applied here and to the
+    # open_notebook service below, so the two always stay in sync.
+    command: start --log info --user ${SURREAL_USER:-root} --pass ${SURREAL_PASSWORD:-root} rocksdb:/mydata/mydatabase.db
     user: root  # Required for bind mounts on Linux
     ports:
       - "8000:8000"
@@ -22,10 +26,12 @@ services:
       # This encrypts your API keys in the database
       - OPEN_NOTEBOOK_ENCRYPTION_KEY=change-me-to-a-secret-string
 
-      # Database connection (default values - no need to change)
+      # Database connection. SURREAL_USER / SURREAL_PASSWORD default to root:root
+      # for local use; override them in a .env file before exposing the instance
+      # (the same values configure the surrealdb service above).
       - SURREAL_URL=ws://surrealdb:8000/rpc
-      - SURREAL_USER=root
-      - SURREAL_PASSWORD=root
+      - SURREAL_USER=${SURREAL_USER:-root}
+      - SURREAL_PASSWORD=${SURREAL_PASSWORD:-root}
       - SURREAL_NAMESPACE=open_notebook
       - SURREAL_DATABASE=open_notebook
     volumes:


### PR DESCRIPTION
## Summary

`docker-compose.yml` hardcoded `root:root` for SurrealDB in two places that must match — the database server `command` (`--user`/`--pass`) and the app's `SURREAL_USER`/`SURREAL_PASSWORD`. This nudges self-hosted users toward exposing an instance with publicly-known credentials.

## Approach (Option A)

Parameterize both places via env interpolation, **defaulting to `root:root`** so the zero-config quick start is completely unchanged:

```yaml
command: start --log info --user ${SURREAL_USER:-root} --pass ${SURREAL_PASSWORD:-root} ...
...
- SURREAL_USER=${SURREAL_USER:-root}
- SURREAL_PASSWORD=${SURREAL_PASSWORD:-root}
```

- No install friction: with no `.env`, behavior is identical to today (root:root).
- Users can now set `SURREAL_USER`/`SURREAL_PASSWORD` in a `.env` to use their own credentials — the same values feed the server and the app, so they stay in sync.
- Inline comments in `docker-compose.yml` and a note in `.env.example` warn to change them before exposing the instance.

## Notes

- Existing deployments are unaffected (default path unchanged). Only users who explicitly set a password in `.env` get different credentials.
- Deliberately did **not** use the `:?` required-var form, which would break the zero-config `docker compose up` — install simplicity was prioritized.

Fixes #946

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

