### PR TITLE
docs: add SECURITY.md with disclosure policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - List view for the Notebooks page — a tile/list toggle in the header lets you switch between the visual card grid and a compact row layout (name, description, source/note counts, last updated) for easier scanning of large collections. The choice is remembered across reloads and translated across all 14 locales (#885)
 - Documented the `ESPERANTO_TTS_TIMEOUT` environment variable (default `300`s) in the environment reference; raise it for slow or self-hosted TTS providers so long podcast segments don't fail with a timeout (#937)
+- `SECURITY.md` with a coordinated-disclosure policy: how to privately report a vulnerability via GitHub's private vulnerability reporting, supported versions, and response expectations (#943)
 
 ### Changed
 - `docker-compose.yml` now sources the SurrealDB credentials from `SURREAL_USER` / `SURREAL_PASSWORD` (applied to both the database server and the app), defaulting to `root:root` so the zero-config quick start is unchanged. Set them in a `.env` file to use your own credentials before exposing the instance; `.env.example` and the compose file note this (#946)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Supported Versions
+
+Open Notebook is an actively developed project. Security fixes are applied to the
+**latest released version** only; there are no long-term support branches.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest release (`1.x`, current minor) | :white_check_mark: |
+| Older releases | :x: |
+
+If you are running an older version, please upgrade to the latest release before
+reporting an issue — the problem may already be fixed.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's built-in **private vulnerability
+reporting**:
+
+1. Go to the [Security tab](https://github.com/lfnovo/open-notebook/security) of
+   the repository.
+2. Click **"Report a vulnerability"**.
+3. Fill out the form with as much detail as you can.
+
+This keeps the report private between you and the maintainers until a fix is
+available.
+
+When reporting, please include where relevant:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a proof of concept, affected endpoint/component, or sample
+  configuration).
+- The Open Notebook version and how you are running it (Docker Compose,
+  single-container, from source).
+- Any suggested remediation, if you have one.
+
+## What to Expect
+
+- **Acknowledgement:** we aim to acknowledge a report within **5 business days**.
+- **Assessment:** we will investigate, confirm the issue, and determine the
+  affected versions.
+- **Fix & disclosure:** once a fix is ready we will release it and, with your
+  consent, credit you in the release notes. We follow a coordinated-disclosure
+  approach and ask that you keep the report private until a fix is published.
+
+## Scope
+
+Open Notebook is **self-hosted**: you run the API, frontend, and SurrealDB
+yourself, and you control the AI provider credentials. Please keep in mind:
+
+- The built-in password middleware (`OPEN_NOTEBOOK_PASSWORD`) is a basic access
+  control, not a full authentication system. See
+  [docs/5-CONFIGURATION/security.md](docs/5-CONFIGURATION/security.md) for
+  hardening guidance (encryption key, reverse proxy, CORS, default credentials).
+- Misconfiguration of your own deployment (e.g. exposing SurrealDB with default
+  credentials, or running without `OPEN_NOTEBOOK_ENCRYPTION_KEY`) is a
+  deployment concern covered by that hardening guide rather than a vulnerability
+  in the project — though we welcome reports where the defaults or docs actively
+  steer users toward an insecure setup.
+
+Thank you for helping keep Open Notebook and its users safe.


### PR DESCRIPTION
## Summary

The repo had no `SECURITY.md`, so there was no documented way to privately report a vulnerability (GitHub also surfaces a "Security policy: not enabled" prompt without one).

Adds a standard `SECURITY.md` covering:
- **Reporting** via GitHub's built-in **private vulnerability reporting** (Security tab → "Report a vulnerability"), with a request not to use public issues.
- **Supported versions** (latest release only; no LTS branches).
- **What to expect** — acknowledgement target, assessment, coordinated disclosure + credit.
- **Scope** — notes that Open Notebook is self-hosted and links to the existing hardening guide (`docs/5-CONFIGURATION/security.md`) for deployment-config concerns.

Docs-only — no code changes.

> Note: GitHub's *private vulnerability reporting* needs to be enabled once in **Settings → Code security and analysis** for the "Report a vulnerability" button to appear.

Fixes #943

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

