### PR TITLE
feat: render LaTeX math beyond chat (sources, insights, ask, transforms, notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - List view for the Notebooks page — a tile/list toggle in the header lets you switch between the visual card grid and a compact row layout (name, description, source/note counts, last updated) for easier scanning of large collections. The choice is remembered across reloads and translated across all 14 locales (#885)
 - Documented the `ESPERANTO_TTS_TIMEOUT` environment variable (default `300`s) in the environment reference; raise it for slow or self-hosted TTS providers so long podcast segments don't fail with a timeout (#937)
 - `SECURITY.md` with a coordinated-disclosure policy: how to privately report a vulnerability via GitHub's private vulnerability reporting, supported versions, and response expectations (#943)
+- LaTeX math rendering (KaTeX) now also applies to source content, source insights, Ask answers, transformation output, and the note editor preview — previously only chat had it (#269)
 
 ### Changed
 - `docker-compose.yml` now sources the SurrealDB credentials from `SURREAL_USER` / `SURREAL_PASSWORD` (applied to both the database server and the app), defaulting to `root:root` so the zero-config quick start is unchanged. Set them in a `.env` file to use your own credentials before exposing the instance; `.env.example` and the compose file note this (#946)

--- a/frontend/src/app/(dashboard)/transformations/components/TransformationPlayground.tsx
+++ b/frontend/src/app/(dashboard)/transformations/components/TransformationPlayground.tsx
@@ -14,6 +14,8 @@ import { ModelSelector } from '@/components/common/ModelSelector'
 import { useTranslation } from '@/lib/hooks/use-translation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 
 interface TransformationPlaygroundProps {
   transformations: Transformation[] | undefined
@@ -125,7 +127,8 @@ export function TransformationPlayground({ transformations, selectedTransformati
                   <CardContent className="pt-6">
                     <div className="prose prose-sm max-w-none dark:prose-invert">
                       <ReactMarkdown
-                        remarkPlugins={[remarkGfm]}
+                        remarkPlugins={[remarkGfm, remarkMath]}
+                        rehypePlugins={[rehypeKatex]}
                         components={{
                           table: ({ children }) => (
                             <div className="my-4 overflow-x-auto">

--- a/frontend/src/components/search/StreamingResponse.tsx
+++ b/frontend/src/components/search/StreamingResponse.tsx
@@ -8,6 +8,8 @@ import { CheckCircle, Sparkles, Lightbulb, ChevronDown } from 'lucide-react'
 import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 import { convertReferencesToMarkdownLinks, createReferenceLinkComponent } from '@/lib/utils/source-references'
 import { useModalManager } from '@/lib/hooks/use-modal-manager'
 import { useTranslation } from '@/lib/hooks/use-translation'
@@ -175,7 +177,8 @@ function FinalAnswerContent({
   return (
     <div className="prose prose-sm max-w-none dark:prose-invert break-words prose-a:break-all prose-p:leading-relaxed prose-headings:mt-4 prose-headings:mb-2">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
         components={{
           a: LinkComponent,
           table: ({ children }) => (

--- a/frontend/src/components/source/SourceDetailContent.tsx
+++ b/frontend/src/components/source/SourceDetailContent.tsx
@@ -5,6 +5,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { isAxiosError } from 'axios'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 import { sourcesApi } from '@/lib/api/sources'
 import { insightsApi, SourceInsightResponse } from '@/lib/api/insights'
 import { transformationsApi } from '@/lib/api/transformations'
@@ -522,7 +524,8 @@ export function SourceDetailContent({
                 )}
                 <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none prose-headings:font-semibold prose-a:text-blue-600 prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-p:mb-4 prose-p:leading-7 prose-li:mb-2">
                   <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
+                    remarkPlugins={[remarkGfm, remarkMath]}
+                    rehypePlugins={[rehypeKatex]}
                     components={{
                       p: ({ children }) => <p className="mb-4">{children}</p>,
                       h1: ({ children }) => <h1 className="text-2xl font-bold mt-6 mb-4">{children}</h1>,

--- a/frontend/src/components/source/SourceInsightDialog.tsx
+++ b/frontend/src/components/source/SourceInsightDialog.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button'
 import { FileText } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 import { useInsight } from '@/lib/hooks/use-insights'
 import { useModalManager } from '@/lib/hooks/use-modal-manager'
 import { useTranslation } from '@/lib/hooks/use-translation'
@@ -127,7 +129,8 @@ export function SourceInsightDialog({ open, onOpenChange, insight, onDelete }: S
             ) : displayInsight ? (
               <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none">
                 <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
+                  remarkPlugins={[remarkGfm, remarkMath]}
+                  rehypePlugins={[rehypeKatex]}
                   components={{
                     table: ({ children }) => (
                       <div className="my-4 overflow-x-auto">

--- a/frontend/src/components/ui/markdown-editor.tsx
+++ b/frontend/src/components/ui/markdown-editor.tsx
@@ -2,11 +2,22 @@
 
 import dynamic from 'next/dynamic'
 import { forwardRef } from 'react'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 
 const MDEditor = dynamic(
   () => import('@uiw/react-md-editor').then((mod) => mod.default),
   { ssr: false }
 )
+
+// Render `$...$` / `$$...$$` math in the live preview. @uiw/react-md-editor
+// concatenates these with its defaults (gfm, prism, raw), so syntax
+// highlighting and GFM are preserved. KaTeX CSS is loaded globally in
+// app/layout.tsx.
+const PREVIEW_OPTIONS = {
+  remarkPlugins: [remarkMath],
+  rehypePlugins: [rehypeKatex],
+}
 
 export interface MarkdownEditorProps {
   value?: string
@@ -35,6 +46,7 @@ export const MarkdownEditor = forwardRef<HTMLDivElement, MarkdownEditorProps>(
             id: textareaId,
             name: name,
           }}
+          previewOptions={PREVIEW_OPTIONS}
           data-color-mode="light"
         />
       </div>


### PR DESCRIPTION
## Summary

LaTeX math rendering (KaTeX) was added in #606 but only wired into the **chat** panel — `remark-math` + `rehype-katex` lived in `ChatPanel.tsx` alone. Source content, insights, Ask answers, transformation output, and note editing rendered `$…$` as raw text.

This extends math rendering to all the markdown surfaces:

- `SourceDetailContent.tsx` (source content)
- `SourceInsightDialog.tsx` (insights)
- `StreamingResponse.tsx` (Ask answers)
- `TransformationPlayground.tsx` (transformation output)
- `markdown-editor.tsx` note editor **live preview** (via `previewOptions`)

## Notes

- The KaTeX stylesheet is already imported globally in `app/layout.tsx`, so no new CSS.
- For the note editor, `@uiw/react-md-editor` **concatenates** `previewOptions.remarkPlugins`/`rehypePlugins` with its own defaults (verified in the lib source), so GFM, `rehype-raw`, and Prism syntax highlighting are preserved — math is additive.
- Consistent with chat's existing behavior, `$`-delimited spans are now treated as math on these surfaces too (the standard remark-math tradeoff).

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds.

Fixes #269

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

