### PR TITLE
feat: add 'Refresh content' action for web-link sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the `ESPERANTO_TTS_TIMEOUT` environment variable (default `300`s) in the environment reference; raise it for slow or self-hosted TTS providers so long podcast segments don't fail with a timeout (#937)
 - `SECURITY.md` with a coordinated-disclosure policy: how to privately report a vulnerability via GitHub's private vulnerability reporting, supported versions, and response expectations (#943)
 - LaTeX math rendering (KaTeX) now also applies to source content, source insights, Ask answers, transformation output, and the note editor preview — previously only chat had it (#269)
+- "Refresh content" action on web-link sources — re-fetches the URL and re-embeds the source so its content stays current, available from the source card menu once processing has completed (translated across all 14 locales) (#259)
 
 ### Changed
 - `docker-compose.yml` now sources the SurrealDB credentials from `SURREAL_USER` / `SURREAL_PASSWORD` (applied to both the database server and the app), defaulting to `root:root` so the zero-config quick start is unchanged. Set them in a `.env` file to use your own credentials before exposing the instance; `.env.example` and the compose file note this (#946)

--- a/frontend/src/app/(dashboard)/notebooks/components/SourcesColumn.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/SourcesColumn.tsx
@@ -226,6 +226,7 @@ export function SourcesColumn({
                     onClick={handleSourceClick}
                     onDelete={handleDeleteClick}
                     onRetry={handleRetry}
+                    onRefreshContent={handleRetry}
                     onRemoveFromNotebook={handleRemoveFromNotebook}
                     onRefresh={onRefresh}
                     showRemoveFromNotebook={true}

--- a/frontend/src/components/sources/SourceCard.tsx
+++ b/frontend/src/components/sources/SourceCard.tsx
@@ -36,6 +36,7 @@ interface SourceCardProps {
   source: SourceListResponse
   onDelete?: (sourceId: string) => void
   onRetry?: (sourceId: string) => void
+  onRefreshContent?: (sourceId: string) => void
   onRemoveFromNotebook?: (sourceId: string) => void
   onClick?: (sourceId: string) => void
   onRefresh?: () => void
@@ -112,6 +113,7 @@ function SourceCardImpl({
   onClick,
   onDelete,
   onRetry,
+  onRefreshContent,
   onRemoveFromNotebook,
   onRefresh,
   className,
@@ -187,6 +189,12 @@ function SourceCardImpl({
   const handleRetry = () => {
     if (onRetry) {
       onRetry(source.id)
+    }
+  }
+
+  const handleRefreshContent = () => {
+    if (onRefreshContent) {
+      onRefreshContent(source.id)
     }
   }
 
@@ -345,6 +353,21 @@ function SourceCardImpl({
                   >
                     <RefreshCw className="h-4 w-4 mr-2" />
                     {t('sources.retryProcessing')}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </>
+              )}
+
+              {sourceType === 'link' && isCompleted && onRefreshContent && (
+                <>
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleRefreshContent()
+                    }}
+                  >
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    {t('sources.refreshContent')}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                 </>

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -389,6 +389,7 @@ export const bnIN = {
     loadFailed: "উৎসের বিবরণ লোড করতে ব্যর্থ",
     removeFromNotebook: "নোটবুক থেকে সরান",
     retryProcessing: "প্রক্রিয়াকরণ পুনরায় চেষ্টা করুন",
+    refreshContent: "বিষয়বস্তু রিফ্রেশ করুন",
     deleteSource: "উৎস মুছে ফেলুন",
     retry: "আবার চেষ্টা",
     addExistingTitle: "বিদ্যমান উৎস যোগ করুন",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -389,6 +389,7 @@ export const caES = {
     loadFailed: "Ha fallat la càrrega dels detalls de la font",
     removeFromNotebook: "Elimina del quadern",
     retryProcessing: "Torna a processar",
+    refreshContent: "Actualitza el contingut",
     deleteSource: "Suprimeix la font",
     retry: "Reintenta",
     addExistingTitle: "Afegeix fonts existents",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -392,6 +392,7 @@ export const deDE = {
     loadFailed: "Quellendetails konnten nicht geladen werden",
     removeFromNotebook: "Aus Notebook entfernen",
     retryProcessing: "Verarbeitung erneut versuchen",
+    refreshContent: "Inhalt aktualisieren",
     deleteSource: "Quelle löschen",
     retry: "Erneut versuchen",
     addExistingTitle: "Vorhandene Quellen hinzufügen",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -389,6 +389,7 @@ export const enUS = {
     loadFailed: "Failed to load source details",
     removeFromNotebook: "Remove from Notebook",
     retryProcessing: "Retry Processing",
+    refreshContent: "Refresh content",
     deleteSource: "Delete Source",
     retry: "Retry",
     addExistingTitle: "Add Existing Sources",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -389,6 +389,7 @@ export const esES = {
     loadFailed: "Error al cargar los detalles de la fuente",
     removeFromNotebook: "Quitar del cuaderno",
     retryProcessing: "Reintentar procesamiento",
+    refreshContent: "Actualizar contenido",
     deleteSource: "Eliminar fuente",
     retry: "Reintentar",
     addExistingTitle: "Agregar fuentes existentes",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -389,6 +389,7 @@ export const frFR = {
     loadFailed: "Échec du chargement des détails de la source",
     removeFromNotebook: "Retirer du carnet",
     retryProcessing: "Réessayer le traitement",
+    refreshContent: "Actualiser le contenu",
     deleteSource: "Supprimer la source",
     retry: "Réessayer",
     addExistingTitle: "Ajouter des sources existantes",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -389,6 +389,7 @@ export const itIT = {
     loadFailed: "Impossibile caricare i dettagli della fonte",
     removeFromNotebook: "Rimuovi dal quaderno",
     retryProcessing: "Riprova elaborazione",
+    refreshContent: "Aggiorna contenuto",
     deleteSource: "Elimina fonte",
     retry: "Riprova",
     addExistingTitle: "Aggiungi fonti esistenti",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -389,6 +389,7 @@ export const jaJP = {
     loadFailed: "ソース詳細の読み込みに失敗しました",
     removeFromNotebook: "ノートブックから削除",
     retryProcessing: "処理を再試行",
+    refreshContent: "コンテンツを更新",
     deleteSource: "ソースを削除",
     retry: "再試行",
     addExistingTitle: "既存ソースを追加",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -389,6 +389,7 @@ export const plPL = {
     loadFailed: "Nie udało się załadować szczegółów źródła",
     removeFromNotebook: "Usuń z notatnika",
     retryProcessing: "Ponów przetwarzanie",
+    refreshContent: "Odśwież treść",
     deleteSource: "Usuń źródło",
     retry: "Ponów",
     addExistingTitle: "Dodaj istniejące źródła",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -389,6 +389,7 @@ export const ptBR = {
     loadFailed: "Falha ao carregar detalhes da fonte",
     removeFromNotebook: "Remover do Caderno",
     retryProcessing: "Tentar Processamento Novamente",
+    refreshContent: "Atualizar conteúdo",
     deleteSource: "Excluir Fonte",
     retry: "Tentar Novamente",
     addExistingTitle: "Adicionar Fontes Existentes",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -389,6 +389,7 @@ export const ruRU = {
     loadFailed: "Не удалось загрузить детали источника",
     removeFromNotebook: "Удалить из блокнота",
     retryProcessing: "Повторить обработку",
+    refreshContent: "Обновить содержимое",
     deleteSource: "Удалить источник",
     retry: "Повторить",
     addExistingTitle: "Добавить существующие источники",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -389,6 +389,7 @@ export const trTR = {
     loadFailed: "Kaynak ayrıntıları yüklenemedi",
     removeFromNotebook: "Defterden Kaldır",
     retryProcessing: "İşlemeyi Yeniden Dene",
+    refreshContent: "İçeriği yenile",
     deleteSource: "Kaynağı Sil",
     retry: "Yeniden Dene",
     addExistingTitle: "Mevcut Kaynakları Ekle",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -389,6 +389,7 @@ export const zhCN = {
     loadFailed: "加载来源详情失败",
     removeFromNotebook: "从笔记本移除",
     retryProcessing: "重试处理",
+    refreshContent: "刷新内容",
     deleteSource: "删除来源",
     retry: "重试",
     addExistingTitle: "添加现有来源",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -389,6 +389,7 @@ export const zhTW = {
     loadFailed: "載入來源詳情失敗",
     removeFromNotebook: "從筆記本移除",
     retryProcessing: "重試處理",
+    refreshContent: "重新整理內容",
     deleteSource: "刪除來源",
     retry: "重試",
     addExistingTitle: "新增現有來源",


### PR DESCRIPTION
## Summary

Web-link sources had no way to re-fetch their content after the underlying page changed (#259). This adds a **Refresh content** action to the source card's menu for completed link sources.

## Implementation

- **`SourceCard`**: new `onRefreshContent` prop and a "Refresh content" dropdown item, shown only when the source is a link (`asset.url`) and its processing is `completed` (failed sources already have "Retry processing").
- **`SourcesColumn`**: wires the action to the existing source-reprocessing mutation.
- Re-uses the `process_source` path with **no transformations** — `trigger_transformations` returns early on an empty list, so refreshing re-extracts the URL and re-embeds **without creating duplicate insights**.
- New `sources.refreshContent` label added to **all 14 locales**.

## Verification

- `npx tsc --noEmit` clean.
- Locale completeness test passes (14/14).
- `npm run build` succeeds.

Fixes #259

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

