### PR TITLE
docs: document flow-driven release process

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -1,0 +1,52 @@
+# Release Process
+
+Open Notebook uses a flow-driven release process. Work moves from `ready`
+issues into pull requests, pull requests merge to `main`, and maintainers cut a
+version when the branch has enough validated change to ship.
+
+## Release Model
+
+- Patch releases ship backwards-compatible fixes.
+- Minor releases ship backwards-compatible features and improvements.
+- Major releases are planned with a milestone when they include breaking
+  changes or migrations that need user coordination.
+- Release candidates and community soak labels are no longer part of the
+  process. Use the `in-dev-build` label for changes available in development
+  images and `released` for shipped work.
+
+## Normal Flow
+
+1. Triage issues into `ready` once the scope and design are clear.
+2. Implement each change in a focused pull request linked to the approved issue.
+3. Merge the pull request after review and required checks pass.
+4. Let the development build publish the `v1-dev` image from `main`.
+5. Cut a stable release when `main` has a coherent set of changes ready for
+   users.
+
+## Cutting A Stable Release
+
+1. Confirm `main` is green and review the changes since the previous release.
+2. Update `pyproject.toml` with the target semantic version.
+3. Move the relevant `CHANGELOG.md` entries from `Unreleased` into a dated
+   version section.
+4. Create a GitHub release for the version tag, for example `v1.11.0`.
+5. Run the `Build and Release` workflow. Push `v1-latest` tags for normal
+   stable releases.
+6. Verify the published images are available in GHCR and Docker Hub when
+   Docker Hub credentials are configured.
+7. Mark shipped issues with `released` and close any release-tracking tasks.
+
+## Manual Verification
+
+Before publishing a stable release, manually verify the areas touched by the
+release. At minimum, cover:
+
+- installation or upgrade path changed by the release;
+- source ingestion and processing when content or worker behavior changed;
+- chat, search, notes, and notebooks when user workflows changed;
+- provider setup when model, credential, or API behavior changed;
+- Docker image startup when packaging, environment, or dependency changes
+  landed.
+
+Automated checks should catch regressions where possible, but the release owner
+chooses the manual matrix from the actual changes in the release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Documented the flow-driven release process in `.github/RELEASE_PROCESS.md`, including the `ready` to `main` to stable release path, dev/stable image labels, and maintainer verification checklist (#938)
 - List view for the Notebooks page — a tile/list toggle in the header lets you switch between the visual card grid and a compact row layout (name, description, source/note counts, last updated) for easier scanning of large collections. The choice is remembered across reloads and translated across all 14 locales (#885)
 - Documented the `ESPERANTO_TTS_TIMEOUT` environment variable (default `300`s) in the environment reference; raise it for slow or self-hosted TTS providers so long podcast segments don't fail with a timeout (#937)
 - `SECURITY.md` with a coordinated-disclosure policy: how to privately report a vulnerability via GitHub's private vulnerability reporting, supported versions, and response expectations (#943)


### PR DESCRIPTION
﻿## Description

Adds `.github/RELEASE_PROCESS.md` to document the current flow-driven release process: `ready` issues move through PRs into `main`, development images come from `main`, and maintainers cut stable releases when the branch has a coherent set of validated changes.

Also adds an Unreleased changelog entry for the new maintainer-facing release doc.

## Related Issue

Fixes #938

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] Manual testing performed

Test details:
- Ran `git diff --check`
- Verified no stale release-candidate script/doc references remain with ripgrep across `.github`, `docs`, `scripts`, and `CHANGELOG.md`
- Checked current upstream labels; the deprecated release labels appear to have already been removed from the repo label list

## Design Alignment

Supports simplicity and maintainability by documenting the release flow that the repository workflows already follow.

## Checklist

- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have updated the relevant documentation
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

