### PR TITLE
feat: Recently Viewed section for notebooks and sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the `ESPERANTO_TTS_TIMEOUT` environment variable (default `300`s) in the environment reference; raise it for slow or self-hosted TTS providers so long podcast segments don't fail with a timeout (#937)
 - `SECURITY.md` with a coordinated-disclosure policy: how to privately report a vulnerability via GitHub's private vulnerability reporting, supported versions, and response expectations (#943)
 - LaTeX math rendering (KaTeX) now also applies to source content, source insights, Ask answers, transformation output, and the note editor preview — previously only chat had it (#269)
+- "Recently Viewed" section on the Notebooks page — a collapsible grid of the last 12 notebooks and sources you opened, newest first, hidden when there's no view history. Backed by a new `last_viewed_at` timestamp stamped on read and a `GET /api/recently-viewed` endpoint (translated across all 14 locales) (#850)
 - Per-transformation model selection — each transformation can now be assigned its own language model from the transformation editor, overriding the global transformation default for that transformation only. Runs without an explicit model keep using the system default as before (#776)
 - "Refresh content" action on web-link sources — re-fetches the URL and re-embeds the source so its content stays current, available from the source card menu once processing has completed (translated across all 14 locales) (#259)
 

--- a/api/models.py
+++ b/api/models.py
@@ -28,6 +28,13 @@ class NotebookResponse(BaseModel):
     note_count: int
 
 
+class RecentlyViewedResponse(BaseModel):
+    type: Literal["notebook", "source"]
+    id: str
+    title: str
+    last_viewed_at: str
+
+
 # Search models
 class SearchRequest(BaseModel):
     query: str = Field(..., description="Search query")
@@ -456,12 +463,8 @@ class SetApiKeyRequest(BaseModel):
     base_url: Optional[str] = Field(
         None, description="Base URL for URL-based providers (Ollama, OpenAI-compatible)"
     )
-    endpoint: Optional[str] = Field(
-        None, description="Endpoint URL for Azure OpenAI"
-    )
-    api_version: Optional[str] = Field(
-        None, description="API version for Azure OpenAI"
-    )
+    endpoint: Optional[str] = Field(None, description="Endpoint URL for Azure OpenAI")
+    api_version: Optional[str] = Field(None, description="API version for Azure OpenAI")
     endpoint_llm: Optional[str] = Field(
         None, description="Service-specific endpoint for LLM (Azure)"
     )

--- a/api/routers/notebooks.py
+++ b/api/routers/notebooks.py
@@ -23,10 +23,17 @@ def _last_viewed_sort_key(item: RecentlyViewedResponse) -> str:
 
 
 async def _stamp_notebook_view(notebook_id: str) -> None:
-    await repo_query(
-        "UPDATE $notebook_id SET last_viewed_at = time::now();",
-        {"notebook_id": ensure_record_id(notebook_id)},
-    )
+    # Best-effort write-on-read: recording the view timestamp must never turn a
+    # successful read into a 500. Log and move on if the stamp update fails.
+    try:
+        await repo_query(
+            "UPDATE $notebook_id SET last_viewed_at = time::now();",
+            {"notebook_id": ensure_record_id(notebook_id)},
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failed to stamp last_viewed_at for notebook {notebook_id}: {e}"
+        )
 
 
 def _recently_viewed_notebook(row: dict) -> RecentlyViewedResponse:
@@ -179,9 +186,11 @@ async def get_recently_viewed(
         items.sort(key=_last_viewed_sort_key, reverse=True)
         return items[:limit]
     except Exception as e:
-        logger.error(f"Error fetching recently viewed items: {str(e)}")
+        # Log full context server-side; return a generic message so internal
+        # details are not leaked to clients.
+        logger.exception(f"Error fetching recently viewed items: {e}")
         raise HTTPException(
-            status_code=500, detail=f"Error fetching recently viewed items: {str(e)}"
+            status_code=500, detail="Error fetching recently viewed items"
         )
 
 

--- a/api/routers/notebooks.py
+++ b/api/routers/notebooks.py
@@ -9,12 +9,42 @@ from api.models import (
     NotebookDeleteResponse,
     NotebookResponse,
     NotebookUpdate,
+    RecentlyViewedResponse,
 )
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.notebook import Notebook, Source
 from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
+
+
+def _last_viewed_sort_key(item: RecentlyViewedResponse) -> str:
+    return item.last_viewed_at
+
+
+async def _stamp_notebook_view(notebook_id: str) -> None:
+    await repo_query(
+        "UPDATE $notebook_id SET last_viewed_at = time::now();",
+        {"notebook_id": ensure_record_id(notebook_id)},
+    )
+
+
+def _recently_viewed_notebook(row: dict) -> RecentlyViewedResponse:
+    return RecentlyViewedResponse(
+        type="notebook",
+        id=str(row.get("id", "")),
+        title=row.get("title") or row.get("name") or "Untitled notebook",
+        last_viewed_at=str(row.get("last_viewed_at", "")),
+    )
+
+
+def _recently_viewed_source(row: dict) -> RecentlyViewedResponse:
+    return RecentlyViewedResponse(
+        type="source",
+        id=str(row.get("id", "")),
+        title=row.get("title") or "Untitled source",
+        last_viewed_at=str(row.get("last_viewed_at", "")),
+    )
 
 
 @router.get("/notebooks", response_model=List[NotebookResponse])
@@ -115,6 +145,46 @@ async def create_notebook(notebook: NotebookCreate):
         )
 
 
+@router.get("/recently-viewed", response_model=List[RecentlyViewedResponse])
+async def get_recently_viewed(
+    limit: int = Query(12, ge=1, le=50, description="Number of items to return"),
+):
+    """Get recently viewed notebooks and sources, newest first."""
+    try:
+        notebooks = await repo_query(
+            """
+            SELECT id, name AS title, last_viewed_at
+            FROM notebook
+            WHERE last_viewed_at != NONE AND last_viewed_at != NULL
+            ORDER BY last_viewed_at DESC
+            LIMIT $limit
+            """,
+            {"limit": limit},
+        )
+        sources = await repo_query(
+            """
+            SELECT id, title, last_viewed_at
+            FROM source
+            WHERE last_viewed_at != NONE AND last_viewed_at != NULL
+            ORDER BY last_viewed_at DESC
+            LIMIT $limit
+            """,
+            {"limit": limit},
+        )
+
+        items = [
+            *[_recently_viewed_notebook(nb) for nb in notebooks],
+            *[_recently_viewed_source(src) for src in sources],
+        ]
+        items.sort(key=_last_viewed_sort_key, reverse=True)
+        return items[:limit]
+    except Exception as e:
+        logger.error(f"Error fetching recently viewed items: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error fetching recently viewed items: {str(e)}"
+        )
+
+
 @router.get(
     "/notebooks/{notebook_id}/delete-preview", response_model=NotebookDeletePreview
 )
@@ -159,6 +229,8 @@ async def get_notebook(notebook_id: str):
 
         if not result:
             raise HTTPException(status_code=404, detail="Notebook not found")
+
+        await _stamp_notebook_view(notebook_id)
 
         nb = result[0]
         return NotebookResponse(
@@ -331,7 +403,9 @@ async def delete_notebook(
     try:
         notebook = await Notebook.get(notebook_id)
 
-        result = await notebook.delete(delete_exclusive_sources=delete_exclusive_sources)
+        result = await notebook.delete(
+            delete_exclusive_sources=delete_exclusive_sources
+        )
 
         return NotebookDeleteResponse(
             message="Notebook deleted successfully",

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -53,10 +53,15 @@ SOURCE_TYPE_EXPRESSION = (
 
 
 async def _stamp_source_view(source_id: str) -> None:
-    await repo_query(
-        "UPDATE $source_id SET last_viewed_at = time::now();",
-        {"source_id": ensure_record_id(source_id)},
-    )
+    # Best-effort write-on-read: recording the view timestamp must never turn a
+    # successful read into a 500. Log and move on if the stamp update fails.
+    try:
+        await repo_query(
+            "UPDATE $source_id SET last_viewed_at = time::now();",
+            {"source_id": ensure_record_id(source_id)},
+        )
+    except Exception as e:
+        logger.warning(f"Failed to stamp last_viewed_at for source {source_id}: {e}")
 
 
 def generate_unique_filename(original_filename: str, upload_folder: str) -> str:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -52,6 +52,13 @@ SOURCE_TYPE_EXPRESSION = (
 )
 
 
+async def _stamp_source_view(source_id: str) -> None:
+    await repo_query(
+        "UPDATE $source_id SET last_viewed_at = time::now();",
+        {"source_id": ensure_record_id(source_id)},
+    )
+
+
 def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
     """Generate unique filename like Streamlit app (append counter if file exists)."""
     file_path = Path(upload_folder)
@@ -654,6 +661,8 @@ async def get_source(source_id: str):
         source = await Source.get(source_id)
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")
+
+        await _stamp_source_view(source.id or source_id)
 
         # Get status information if command exists
         status = None

--- a/frontend/src/app/(dashboard)/notebooks/components/RecentlyViewed.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/RecentlyViewed.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+import type { Locale } from 'date-fns/locale'
+import { BookOpen, ChevronDown, ChevronRight, FileText } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { notebooksApi } from '@/lib/api/notebooks'
+import type { RecentlyViewedResponse } from '@/lib/types/api'
+import { useTranslation } from '@/lib/hooks/use-translation'
+import { getDateLocale } from '@/lib/utils/date-locale'
+
+interface RecentlyViewedProps {
+  limit?: number
+}
+
+function getItemHref(item: RecentlyViewedResponse) {
+  if (item.type === 'notebook') {
+    return `/notebooks/${encodeURIComponent(item.id)}`
+  }
+
+  return `/sources/${item.id}`
+}
+
+function formatViewedAt(value: string, locale: Locale) {
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return formatDistanceToNow(date, {
+    addSuffix: true,
+    locale,
+  })
+}
+
+export function RecentlyViewed({ limit = 12 }: RecentlyViewedProps) {
+  const { t, language } = useTranslation()
+  const [isOpen, setIsOpen] = useState(true)
+  const locale = getDateLocale(language)
+  const { data: items, isLoading, isError } = useQuery({
+    queryKey: ['recently-viewed', limit],
+    queryFn: () => notebooksApi.recentlyViewed(limit),
+  })
+
+  if (isLoading || isError || !items || items.length === 0) {
+    return null
+  }
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="space-y-4">
+      <div className="flex items-center gap-2">
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+            {isOpen ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <span className="sr-only">
+              {t('notebooks.toggleRecentlyViewed', {
+                defaultValue: 'Toggle recently viewed',
+              })}
+            </span>
+          </Button>
+        </CollapsibleTrigger>
+        <h2 className="text-lg font-semibold">
+          {t('notebooks.recentlyViewed', { defaultValue: 'Recently Viewed' })}
+        </h2>
+        <span className="text-sm text-muted-foreground">({items.length})</span>
+      </div>
+
+      <CollapsibleContent>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => {
+            const Icon = item.type === 'notebook' ? BookOpen : FileText
+            const typeLabel =
+              item.type === 'notebook'
+                ? t('notebooks.recentlyViewedNotebook', {
+                    defaultValue: 'Notebook',
+                  })
+                : t('notebooks.recentlyViewedSource', {
+                    defaultValue: 'Source',
+                  })
+
+            return (
+              <Link
+                key={`${item.type}-${item.id}`}
+                href={getItemHref(item)}
+                className="group flex min-h-20 items-center gap-3 rounded-md border border-border/60 p-3 transition-colors hover:border-primary/40 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground transition-colors group-hover:text-primary">
+                  <Icon className="h-4 w-4" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <p className="truncate text-sm font-medium">{item.title}</p>
+                    <Badge variant="outline" className="shrink-0 text-[11px]">
+                      {typeLabel}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 truncate text-xs text-muted-foreground">
+                    {t('notebooks.lastViewed', {
+                      time: formatViewedAt(item.last_viewed_at, locale),
+                      defaultValue: 'Viewed {{time}}',
+                    })}
+                  </p>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/frontend/src/app/(dashboard)/notebooks/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react'
 
 import { AppShell } from '@/components/layout/AppShell'
 import { NotebookList } from './components/NotebookList'
+import { RecentlyViewed } from './components/RecentlyViewed'
 import { Button } from '@/components/ui/button'
 import { Plus, RefreshCw, LayoutGrid, List } from 'lucide-react'
 import { useNotebooks } from '@/lib/hooks/use-notebooks'
@@ -102,6 +103,8 @@ export default function NotebooksPage() {
         </div>
         
         <div className="space-y-8">
+          <RecentlyViewed />
+
           <NotebookList 
             notebooks={filteredActive} 
             isLoading={isLoading}

--- a/frontend/src/lib/api/notebooks.ts
+++ b/frontend/src/lib/api/notebooks.ts
@@ -1,6 +1,7 @@
 import apiClient from './client'
 import {
   NotebookResponse,
+  RecentlyViewedResponse,
   CreateNotebookRequest,
   UpdateNotebookRequest,
   NotebookDeletePreview,
@@ -10,6 +11,13 @@ import {
 export const notebooksApi = {
   list: async (params?: { archived?: boolean; order_by?: string }) => {
     const response = await apiClient.get<NotebookResponse[]>('/notebooks', { params })
+    return response.data
+  },
+
+  recentlyViewed: async (limit: number = 12) => {
+    const response = await apiClient.get<RecentlyViewedResponse[]>('/recently-viewed', {
+      params: { limit },
+    })
     return response.data
   },
 

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -262,6 +262,11 @@ export const bnIN = {
     createSuccess: "নোটবুক সফলভাবে তৈরি হয়েছে",
     updateSuccess: "নোটবুক সফলভাবে আপডেট হয়েছে",
     deleteSuccess: "নোটবুক সফলভাবে মুছে ফেলা হয়েছে",
+    recentlyViewed: "সম্প্রতি দেখা",
+    toggleRecentlyViewed: "সম্প্রতি দেখা টগল করুন",
+    recentlyViewedNotebook: "নোটবুক",
+    recentlyViewedSource: "উৎস",
+    lastViewed: "{{time}} দেখা হয়েছে",
   },
   sources: {
     bulkContext: "প্রসঙ্গ",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -262,6 +262,11 @@ export const caES = {
     createSuccess: "S'ha creat el quadern correctament",
     updateSuccess: "S'ha actualitzat el quadern correctament",
     deleteSuccess: "S'ha suprimit el quadern correctament",
+    recentlyViewed: "Vistos recentment",
+    toggleRecentlyViewed: "Commuta els vistos recentment",
+    recentlyViewedNotebook: "Quadern",
+    recentlyViewedSource: "Font",
+    lastViewed: "Vist {{time}}",
   },
   sources: {
     bulkContext: "Context",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -265,6 +265,11 @@ export const deDE = {
     createSuccess: "Notebook erfolgreich erstellt",
     updateSuccess: "Notebook erfolgreich aktualisiert",
     deleteSuccess: "Notebook erfolgreich gelöscht",
+    recentlyViewed: "Zuletzt angesehen",
+    toggleRecentlyViewed: "Zuletzt angesehen ein-/ausblenden",
+    recentlyViewedNotebook: "Notebook",
+    recentlyViewedSource: "Quelle",
+    lastViewed: "Angesehen {{time}}",
   },
   sources: {
     bulkContext: "Kontext",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -262,6 +262,11 @@ export const enUS = {
     createSuccess: "Notebook created successfully",
     updateSuccess: "Notebook updated successfully",
     deleteSuccess: "Notebook deleted successfully",
+    recentlyViewed: "Recently Viewed",
+    toggleRecentlyViewed: "Toggle recently viewed",
+    recentlyViewedNotebook: "Notebook",
+    recentlyViewedSource: "Source",
+    lastViewed: "Viewed {{time}}",
   },
   sources: {
     title: "Sources",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -262,6 +262,11 @@ export const esES = {
     createSuccess: "Cuaderno creado exitosamente",
     updateSuccess: "Cuaderno actualizado exitosamente",
     deleteSuccess: "Cuaderno eliminado exitosamente",
+    recentlyViewed: "Vistos recientemente",
+    toggleRecentlyViewed: "Alternar vistos recientemente",
+    recentlyViewedNotebook: "Cuaderno",
+    recentlyViewedSource: "Fuente",
+    lastViewed: "Visto {{time}}",
   },
   sources: {
     bulkContext: "Contexto",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -262,6 +262,11 @@ export const frFR = {
     createSuccess: "Carnet créé avec succès",
     updateSuccess: "Carnet mis à jour avec succès",
     deleteSuccess: "Carnet supprimé avec succès",
+    recentlyViewed: "Consultés récemment",
+    toggleRecentlyViewed: "Afficher/masquer les éléments récents",
+    recentlyViewedNotebook: "Carnet",
+    recentlyViewedSource: "Source",
+    lastViewed: "Consulté {{time}}",
   },
   sources: {
     bulkContext: "Contexte",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -262,6 +262,11 @@ export const itIT = {
     createSuccess: "Quaderno creato con successo",
     updateSuccess: "Quaderno aggiornato con successo",
     deleteSuccess: "Quaderno eliminato con successo",
+    recentlyViewed: "Visti di recente",
+    toggleRecentlyViewed: "Mostra/nascondi visti di recente",
+    recentlyViewedNotebook: "Quaderno",
+    recentlyViewedSource: "Fonte",
+    lastViewed: "Visto {{time}}",
   },
   sources: {
     bulkContext: "Contesto",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -262,6 +262,11 @@ export const jaJP = {
     createSuccess: "ノートブックを作成しました",
     updateSuccess: "ノートブックを更新しました",
     deleteSuccess: "ノートブックを削除しました",
+    recentlyViewed: "最近表示した項目",
+    toggleRecentlyViewed: "最近表示した項目の表示切替",
+    recentlyViewedNotebook: "ノートブック",
+    recentlyViewedSource: "ソース",
+    lastViewed: "{{time}}に表示",
   },
   sources: {
     bulkContext: "コンテキスト",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -262,6 +262,11 @@ export const plPL = {
     createSuccess: "Notatnik utworzony pomyślnie",
     updateSuccess: "Notatnik zaktualizowany pomyślnie",
     deleteSuccess: "Notatnik usunięty pomyślnie",
+    recentlyViewed: "Ostatnio przeglądane",
+    toggleRecentlyViewed: "Przełącz ostatnio przeglądane",
+    recentlyViewedNotebook: "Notatnik",
+    recentlyViewedSource: "Źródło",
+    lastViewed: "Wyświetlono {{time}}",
   },
   sources: {
     bulkContext: "Kontekst",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -262,6 +262,11 @@ export const ptBR = {
     createSuccess: "Caderno criado com sucesso",
     updateSuccess: "Caderno atualizado com sucesso",
     deleteSuccess: "Caderno excluído com sucesso",
+    recentlyViewed: "Vistos recentemente",
+    toggleRecentlyViewed: "Alternar vistos recentemente",
+    recentlyViewedNotebook: "Caderno",
+    recentlyViewedSource: "Fonte",
+    lastViewed: "Visto {{time}}",
   },
   sources: {
     bulkContext: "Contexto",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -262,6 +262,11 @@ export const ruRU = {
     createSuccess: "Блокнот успешно создан",
     updateSuccess: "Блокнот успешно обновлён",
     deleteSuccess: "Блокнот успешно удалён",
+    recentlyViewed: "Недавно просмотренные",
+    toggleRecentlyViewed: "Показать/скрыть недавно просмотренные",
+    recentlyViewedNotebook: "Блокнот",
+    recentlyViewedSource: "Источник",
+    lastViewed: "Просмотрено {{time}}",
   },
   sources: {
     bulkContext: "Контекст",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -262,6 +262,11 @@ export const trTR = {
     createSuccess: "Defter başarıyla oluşturuldu",
     updateSuccess: "Defter başarıyla güncellendi",
     deleteSuccess: "Defter başarıyla silindi",
+    recentlyViewed: "Son Görüntülenenler",
+    toggleRecentlyViewed: "Son görüntülenenleri aç/kapat",
+    recentlyViewedNotebook: "Defter",
+    recentlyViewedSource: "Kaynak",
+    lastViewed: "{{time}} görüntülendi",
   },
   sources: {
     bulkContext: "Bağlam",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -262,6 +262,11 @@ export const zhCN = {
     createSuccess: "笔记本创建成功",
     updateSuccess: "笔记本更新成功",
     deleteSuccess: "笔记本删除成功",
+    recentlyViewed: "最近查看",
+    toggleRecentlyViewed: "切换最近查看",
+    recentlyViewedNotebook: "笔记本",
+    recentlyViewedSource: "来源",
+    lastViewed: "查看于{{time}}",
   },
   sources: {
     bulkContext: "上下文",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -262,6 +262,11 @@ export const zhTW = {
     createSuccess: "筆記本新增成功",
     updateSuccess: "筆記本更新成功",
     deleteSuccess: "筆記本刪除成功",
+    recentlyViewed: "最近檢視",
+    toggleRecentlyViewed: "切換最近檢視",
+    recentlyViewedNotebook: "筆記本",
+    recentlyViewedSource: "來源",
+    lastViewed: "檢視於{{time}}",
   },
   sources: {
     bulkContext: "上下文",

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -239,3 +239,10 @@ export interface BuildContextResponse {
   token_count: number
   char_count: number
 }
+
+export interface RecentlyViewedResponse {
+  type: 'notebook' | 'source'
+  id: string
+  title: string
+  last_viewed_at: string
+}

--- a/open_notebook/database/async_migrate.py
+++ b/open_notebook/database/async_migrate.py
@@ -127,6 +127,9 @@ class AsyncMigrationManager:
             AsyncMigration.from_file(
                 "open_notebook/database/migrations/17.surrealql"
             ),
+            AsyncMigration.from_file(
+                "open_notebook/database/migrations/18.surrealql"
+            ),
         ]
         self.down_migrations = [
             AsyncMigration.from_file(
@@ -179,6 +182,9 @@ class AsyncMigrationManager:
             ),
             AsyncMigration.from_file(
                 "open_notebook/database/migrations/17_down.surrealql"
+            ),
+            AsyncMigration.from_file(
+                "open_notebook/database/migrations/18_down.surrealql"
             ),
         ]
         self.runner = AsyncMigrationRunner(

--- a/open_notebook/database/migrations/18.surrealql
+++ b/open_notebook/database/migrations/18.surrealql
@@ -1,0 +1,10 @@
+-- Migration 18: Recently viewed timestamps
+-- Adds optional last-viewed timestamps for notebooks and sources.
+
+DEFINE FIELD IF NOT EXISTS last_viewed_at ON TABLE notebook TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_viewed_at ON TABLE source TYPE option<datetime>;
+
+-- Indexes backing the recently-viewed query (ORDER BY last_viewed_at DESC LIMIT)
+-- so it does not degrade into a full table scan as data grows.
+DEFINE INDEX IF NOT EXISTS idx_notebook_last_viewed ON TABLE notebook FIELDS last_viewed_at CONCURRENTLY;
+DEFINE INDEX IF NOT EXISTS idx_source_last_viewed ON TABLE source FIELDS last_viewed_at CONCURRENTLY;

--- a/open_notebook/database/migrations/18_down.surrealql
+++ b/open_notebook/database/migrations/18_down.surrealql
@@ -1,0 +1,6 @@
+-- Migration 18 rollback: Remove recently viewed timestamps
+
+REMOVE INDEX IF EXISTS idx_notebook_last_viewed ON TABLE notebook;
+REMOVE INDEX IF EXISTS idx_source_last_viewed ON TABLE source;
+REMOVE FIELD IF EXISTS last_viewed_at ON TABLE notebook;
+REMOVE FIELD IF EXISTS last_viewed_at ON TABLE source;

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Union
 
@@ -18,6 +19,7 @@ class Notebook(ObjectModel):
     name: str
     description: str
     archived: Optional[bool] = False
+    last_viewed_at: Optional[datetime] = None
 
     @field_validator("name")
     @classmethod
@@ -359,6 +361,7 @@ class Source(ObjectModel):
     title: Optional[str] = None
     topics: Optional[List[str]] = Field(default_factory=list)
     full_text: Optional[str] = None
+    last_viewed_at: Optional[datetime] = None
     command: Optional[Union[str, RecordID]] = Field(
         default=None, description="Link to surreal-commands processing job"
     )
@@ -516,9 +519,7 @@ class Source(ObjectModel):
         except ValueError:
             raise
         except Exception as e:
-            logger.error(
-                f"Failed to submit embed_source job for source {self.id}: {e}"
-            )
+            logger.error(f"Failed to submit embed_source job for source {self.id}: {e}")
             logger.exception(e)
             raise DatabaseOperationError(e)
 

--- a/tests/test_recently_viewed_api.py
+++ b/tests/test_recently_viewed_api.py
@@ -1,0 +1,181 @@
+"""Tests for recently viewed notebooks and sources."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_notebook.domain.notebook import Source
+
+
+@pytest.fixture
+def client():
+    """Create test client after environment variables have been cleared by conftest."""
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestRecentlyViewedApi:
+    @patch("api.routers.notebooks.repo_query", new_callable=AsyncMock)
+    def test_recently_viewed_returns_mixed_items_newest_first(
+        self, mock_repo_query, client
+    ):
+        mock_repo_query.side_effect = [
+            [
+                {
+                    "id": "notebook:old",
+                    "title": "Older Notebook",
+                    "last_viewed_at": "2026-06-26T10:00:00Z",
+                }
+            ],
+            [
+                {
+                    "id": "source:new",
+                    "title": "Newer Source",
+                    "last_viewed_at": "2026-06-27T10:00:00Z",
+                }
+            ],
+        ]
+
+        response = client.get("/api/recently-viewed")
+
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "type": "source",
+                "id": "source:new",
+                "title": "Newer Source",
+                "last_viewed_at": "2026-06-27T10:00:00Z",
+            },
+            {
+                "type": "notebook",
+                "id": "notebook:old",
+                "title": "Older Notebook",
+                "last_viewed_at": "2026-06-26T10:00:00Z",
+            },
+        ]
+
+    @patch("api.routers.notebooks.repo_query", new_callable=AsyncMock)
+    def test_recently_viewed_honors_limit(self, mock_repo_query, client):
+        mock_repo_query.side_effect = [
+            [
+                {
+                    "id": "notebook:1",
+                    "title": "Notebook 1",
+                    "last_viewed_at": "2026-06-27T09:00:00Z",
+                },
+                {
+                    "id": "notebook:2",
+                    "title": "Notebook 2",
+                    "last_viewed_at": "2026-06-27T07:00:00Z",
+                },
+            ],
+            [
+                {
+                    "id": "source:1",
+                    "title": "Source 1",
+                    "last_viewed_at": "2026-06-27T10:00:00Z",
+                },
+                {
+                    "id": "source:2",
+                    "title": "Source 2",
+                    "last_viewed_at": "2026-06-27T08:00:00Z",
+                },
+            ],
+        ]
+
+        response = client.get("/api/recently-viewed?limit=2")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [item["id"] for item in data] == ["source:1", "notebook:1"]
+        assert len(data) == 2
+        assert mock_repo_query.await_args_list[0].args[1] == {"limit": 2}
+        assert mock_repo_query.await_args_list[1].args[1] == {"limit": 2}
+
+    @patch("api.routers.notebooks.repo_query", new_callable=AsyncMock)
+    def test_recently_viewed_empty_when_no_view_history(self, mock_repo_query, client):
+        mock_repo_query.side_effect = [[], []]
+
+        response = client.get("/api/recently-viewed")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @patch("api.routers.notebooks.repo_query", new_callable=AsyncMock)
+    def test_get_notebook_stamps_last_viewed_at(self, mock_repo_query, client):
+        mock_repo_query.side_effect = [
+            [
+                {
+                    "id": "notebook:1",
+                    "name": "Notebook",
+                    "description": "",
+                    "archived": False,
+                    "created": "2026-06-27T09:00:00Z",
+                    "updated": "2026-06-27T09:00:00Z",
+                    "source_count": 0,
+                    "note_count": 0,
+                }
+            ],
+            [],
+        ]
+
+        response = client.get("/api/notebooks/notebook:1")
+
+        assert response.status_code == 200
+        assert (
+            "UPDATE $notebook_id SET last_viewed_at = time::now()"
+            in (mock_repo_query.await_args_list[1].args[0])
+        )
+
+    @patch("api.routers.sources.Source.get_embedded_chunks", new_callable=AsyncMock)
+    @patch("api.routers.sources.Source.get", new_callable=AsyncMock)
+    @patch("api.routers.sources.repo_query", new_callable=AsyncMock)
+    def test_get_source_stamps_last_viewed_at(
+        self, mock_repo_query, mock_get_source, mock_chunks, client
+    ):
+        mock_get_source.return_value = Source(
+            id="source:1",
+            title="Source",
+            topics=[],
+            full_text="Source text",
+            created="2026-06-27T09:00:00Z",
+            updated="2026-06-27T09:00:00Z",
+        )
+        mock_chunks.return_value = 0
+        mock_repo_query.side_effect = [[], []]
+
+        response = client.get("/api/sources/source:1")
+
+        assert response.status_code == 200
+        assert (
+            "UPDATE $source_id SET last_viewed_at = time::now()"
+            in (mock_repo_query.await_args_list[0].args[0])
+        )
+
+    @patch("api.routers.notebooks.repo_query", new_callable=AsyncMock)
+    def test_recently_viewed_reorders_after_notebook_is_viewed_again(
+        self, mock_repo_query, client
+    ):
+        mock_repo_query.side_effect = [
+            [
+                {
+                    "id": "notebook:1",
+                    "title": "Notebook",
+                    "last_viewed_at": "2026-06-27T11:00:00Z",
+                }
+            ],
+            [
+                {
+                    "id": "source:1",
+                    "title": "Source",
+                    "last_viewed_at": "2026-06-27T10:00:00Z",
+                }
+            ],
+        ]
+
+        response = client.get("/api/recently-viewed")
+
+        assert response.status_code == 200
+        assert [item["id"] for item in response.json()] == ["notebook:1", "source:1"]


### PR DESCRIPTION
## Description

Add a migration (`open_notebook/database/migrations/16.surrealql` + `_down`) defining an additive optional `last_viewed_at` datetime field on the `notebook` and `source` tables. Surface the field on the domain models in `open_notebook/domain/notebook.py`. Stamp `last_viewed_at = time::now()` write-on-read inside the single-record GET handlers (`api/routers/notebooks.py` `GET /notebooks/{notebook_id}` and `api/routers/sources.py` `GET /sources/{source_id}`).

Once a user accumulates many notebooks and sources, jumping back to a recently opened item is a multi-click chore. The issue requests a collapsible "Recently Viewed" section showing the last ~12 notebooks/sources by last-viewed time, hidden when empty. The maintainer (lfnovo) approved it as-is and gave the approach: add an additive `last_viewed_at` field (via SurrealDB `DEFINE FIELD`, not `ALTER TABLE`) on notebooks and sources, write-on-read on the respective `GET /{id}` endpoints, expose `GET /api/recently-viewed?limit=12` returning a mixed list, and render a collapsible home-page section that hides when empty. Single-tenant for now, so the timestamp lives on the record (no per-user history).

Fixes #850

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## How Has This Been Tested?

- [x] Tested locally with Docker
- [x] Tested locally with development setup
- [x] Added new unit tests
- [x] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)
- Happy path: open a notebook then a source via their GET endpoints; `GET /api/recently-viewed` returns both, most-recent first. - Limit honored: with more than `limit` viewed items, only the newest `limit` are returned. - Empty state: a fresh install with no view history returns an empty list (frontend hides the section).

## Design Alignment

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [ ] Simplicity Over Features
- [ ] API-First Architecture
- [ ] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**

## Checklist



### Code Quality

- [x] My code follows PEP 8 style guidelines (Python)
- [x] My code follows TypeScript best practices (Frontend)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran linting: `make ruff` or `ruff check . --fix`
- [x] I ran type checking: `make lint` or `uv run python -m mypy .`
- Happy path: open a notebook then a source via their GET endpoints; `GET /api/recently-viewed` returns both, most-recent first. - Limit honored: with more than `limit` viewed items, only the newest `limit` are returned. - Empty state: a fresh install with no view history returns an empty list (frontend hides the section).

### Documentation



### Database Changes

- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [x] Migration has been tested locally

### Breaking Changes

- [ ] This PR includes breaking changes

## Screenshots (if applicable)



## Additional Context



## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] This PR addresses an approved issue that was assigned to me
- [ ] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")

---

**Thank you for contributing to Open Notebook!** 🎉

AI was used for assistance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

