### PR TITLE
refactor: type-check api.auth and remove its mypy ignore_errors

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -3,8 +3,9 @@ from typing import Optional
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from loguru import logger
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
 
 from open_notebook.utils.encryption import get_secret_from_env
 
@@ -16,10 +17,12 @@ class PasswordAuthMiddleware(BaseHTTPMiddleware):
     Supports Docker secrets via OPEN_NOTEBOOK_PASSWORD_FILE.
     """
 
-    def __init__(self, app, excluded_paths: Optional[list] = None):
+    def __init__(
+        self, app: ASGIApp, excluded_paths: Optional[list[str]] = None
+    ) -> None:
         super().__init__(app)
         self.password = get_secret_from_env("OPEN_NOTEBOOK_PASSWORD")
-        self.excluded_paths = excluded_paths or [
+        self.excluded_paths: list[str] = excluded_paths or [
             "/",
             "/health",
             "/docs",
@@ -27,7 +30,9 @@ class PasswordAuthMiddleware(BaseHTTPMiddleware):
             "/redoc",
         ]
 
-    async def dispatch(self, request: Request, call_next):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
         # Skip authentication if no password is set
         if not self.password:
             return await call_next(request)

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,9 +17,6 @@ ignore_errors = True
 [mypy-api.podcast_api_service]
 ignore_errors = True
 
-[mypy-api.auth]
-ignore_errors = True
-
 [mypy-api.routers.models]
 ignore_errors = True
 


### PR DESCRIPTION
## Description

Type-checks the `api.auth` module and removes its `[mypy-api.auth] ignore_errors = True` stanza from `mypy.ini`. This continues the incremental mypy tracker in #945, removing one module from the ignore list at a time.

The change adds the annotations mypy requires in `api/auth.py`:
- `PasswordAuthMiddleware.__init__(self, app: ASGIApp, excluded_paths: Optional[list[str]] = None) -> None`
- `PasswordAuthMiddleware.dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response`
- `self.excluded_paths` annotated as `list[str]`

It imports `ASGIApp` from `starlette.types`, `RequestResponseEndpoint` from `starlette.middleware.base`, and `Response` from `starlette.responses`. These are annotations only; no logic changed.

## Related Issue

Fixes #945

## Type of Change

- [x] Code refactoring (no functional changes)

## How Has This Been Tested?

- [x] Existing tests pass (`uv run pytest`)

**Test Details:**

`uv run python -m mypy --follow-imports=silent api/auth.py` reports `Success: no issues found in 1 source file` with the override removed. The full `uv run python -m mypy .` error count is unchanged versus the base branch (the remaining errors are in other modules still on the ignore list), confirming this PR surfaces no new errors. `ruff check api/auth.py` passes, and the module imports cleanly at runtime.

## Design Alignment

- [x] API-First Architecture

**Explanation:**

Adding type hints to the API auth layer improves correctness guarantees for the API surface without changing behavior.

## Checklist

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [x] I have added type hints to my code (Python)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing
- [x] New and existing unit tests pass locally with my changes
- [x] I ran linting: `make ruff` or `ruff check . --fix`
- [x] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation

N/A - no documentation changes; the module's existing docstrings are unchanged.

### Database Changes

N/A - no database schema changes.

### Breaking Changes

N/A - no breaking changes; this is an annotations-only refactor.

## Screenshots (if applicable)

N/A - no UI changes.

## Additional Context

This leaves the #945 tracker open for the remaining modules still listed in `mypy.ini`.

## Pre-Submission Verification

- [x] I have read CONTRIBUTING.md
- [x] I have read DESIGN_PRINCIPLES.md
- [x] This PR addresses an approved issue
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

