### PR TITLE
feat(deploy): add production server deployment files

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -1,0 +1,76 @@
+# =============================================================================
+# Open Notebook - PRODUCTION environment template
+# =============================================================================
+# Usage:
+#   cp .env.server.example .env.server
+#   $EDITOR .env.server                  # replace every CHANGEME_* value
+#   docker compose -f docker-compose.server.yml --env-file .env.server up -d
+#
+# Anything below marked `CHANGEME_*` MUST be replaced before starting the
+# stack. The compose file uses `${VAR:?msg}` syntax so the stack refuses
+# to start if any required value is missing.
+#
+# Generate random secrets with:
+#   openssl rand -base64 48
+# or
+#   head -c 48 /dev/urandom | base64
+#
+# Verify completion with:
+#   grep -n CHANGEME .env.server && echo "FILL THESE IN" || echo "OK"
+# =============================================================================
+
+
+# ----- Domain ------------------------------------------------------------------
+# Public hostname Caddy serves. Its DNS A/AAAA record MUST point to this
+# server's public IP BEFORE starting the stack (Let's Encrypt HTTP-01).
+DOMAIN=notebook.example.com
+
+# Public URL the browser uses to reach the API. Trailing slash is optional.
+API_URL=https://notebook.example.com
+
+# ----- Encryption key for stored API credentials ------------------------------
+# 32+ random bytes recommended. Losing this key makes previously-stored
+# provider keys unreadable; old encrypted rows will fail to decrypt if
+# rotated.
+OPEN_NOTEBOOK_ENCRYPTION_KEY=CHANGEME_ENCRYPTION_KEY_min_32_chars_random
+
+
+# ----- SurrealDB credentials --------------------------------------------------
+# Used by both the SurrealDB container (to enforce auth) and the Open
+# Notebook app (to log in). They MUST match.
+SURREAL_USER=CHANGEME_DB_USER
+SURREAL_PASSWORD=CHANGEME_DB_PASSWORD_min_32_chars_random
+SURREAL_NAMESPACE=open_notebook
+SURREAL_DATABASE=open_notebook
+
+
+# ----- Application login (optional) -------------------------------------------
+# If set (non-empty), the UI prompts for this password before granting
+# access via PasswordAuthMiddleware. Leave empty ONLY if you front the
+# app with another auth layer (e.g., Cloudflare Access).
+OPEN_NOTEBOOK_PASSWORD=CHANGEME_APP_LOGIN_PASSWORD
+
+
+# ----- CORS -------------------------------------------------------------------
+# Comma-separated list of allowed origins for browser API calls. In a
+# single-domain setup, set to the same value as API_URL. Use "*" only if
+# you do not send cookies / credentials.
+CORS_ORIGINS=https://notebook.example.com
+
+
+# ----- AI provider keys (optional) --------------------------------------------
+# Prefer configuring these in the UI (Settings -> API Keys) so they are
+# stored encrypted in the DB. Set them here ONLY for headless / unattended
+# initial provisioning.
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# GOOGLE_API_KEY=
+# GROQ_API_KEY=
+
+
+# ----- Backup configuration (consumed by scripts/backup.sh) -------------------
+# Absolute path on the host where archives are written. The directory
+# will be created if missing.
+BACKUP_DIR=/var/backups/open-notebook
+# Number of days of archives to keep. Older ones are pruned on each run.
+BACKUP_KEEP_DAYS=7

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ specs/
 .harness/
 
 .mcp.json
+
+# Production deployment artefacts (see docs/7-DEVELOPMENT/plans/03-server-deployment-plan.md)
+.env.server
+backups/

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,71 @@
+# Open Notebook - Caddy reverse proxy
+# =============================================================================
+# Replace `notebook.example.com` with your real hostname before starting
+# the stack. Caddy will request a Let's Encrypt certificate automatically
+# once the DNS A/AAAA records for that hostname point at this server's
+# public IP.
+#
+# Generate a fresh config from this template with:
+#   sed -i 's/notebook.example.com/your.domain.com/g' Caddyfile
+# =============================================================================
+
+
+# ----- HTTP -> HTTPS redirect -----
+http://notebook.example.com {
+    redir https://{host}{uri} permanent
+}
+
+
+# ----- Main site -----
+notebook.example.com {
+    encode zstd gzip
+
+    # Allow large uploads (PDFs, audio, etc.). Bump higher if you
+    # regularly import larger media files. `request_body` is a top-level
+    # directive inside the site block, not a `reverse_proxy` sub-directive.
+    request_body {
+        max_size 100MB
+    }
+
+    # Reverse-proxy to the open_notebook Next.js frontend container.
+    # Docker's embedded DNS on notebook_private resolves the service name
+    # to the container's IP, so no port mapping on the host is needed.
+    reverse_proxy open_notebook:8502 {
+        # Long-lived AI requests (embedding rebuilds, podcast generation)
+        # can easily exceed 60s. Next.js server-side proxy also benefits.
+        transport http {
+            dial_timeout 30s
+            response_header_timeout 600s
+            read_timeout 600s
+            write_timeout 600s
+        }
+
+        # Forward the original Host + scheme so the app sees the real
+        # public hostname and HTTPS scheme. Caddy sets these itself;
+        # this just makes the intent explicit.
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-Host {host}
+    }
+
+    # Security headers. Tighten as needed for your threat model.
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        # Placeholder CSP - uncomment and adjust if you embed third-party
+        # content (e.g. external podcast players or video iframes).
+        # Content-Security-Policy "default-src 'self'; img-src 'self' data:; ..."
+        -Server
+    }
+
+    # Emit access logs to stdout so `docker logs open-notebook-caddy`
+    # captures them; the json-file driver handles rotation.
+    log {
+        output stdout
+        format console
+        level INFO
+    }
+}

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,0 +1,146 @@
+# Open Notebook - Production Compose
+# =============================================================================
+# Usage:
+#   cp .env.server.example .env.server
+#   $EDITOR .env.server                       # replace every CHANGEME_* value
+#   docker compose -f docker-compose.server.yml --env-file .env.server up -d
+#
+# This is the SERVER-TARGETED counterpart to the zero-config docker-compose.yml
+# at the repo root. It assumes:
+#   - Public HTTPS terminated by Caddy (see ./Caddyfile)
+#   - Domain name and certificates handled automatically by Caddy + Let's Encrypt
+#   - Only ports 22, 80, 443 are open on the host firewall
+#
+# Pin the image tag before going to production; v1-latest is the rolling
+# tag. Replace it with the release version you have validated.
+# =============================================================================
+
+name: open-notebook
+
+services:
+  caddy:
+    image: caddy:2.8-alpine
+    container_name: open-notebook-caddy
+    restart: unless-stopped
+    # Caddy joins BOTH networks: caddy_public for ACME + inbound 80/443,
+    # notebook_private to reach the app container by service name.
+    networks:
+      - caddy_public
+      - notebook_private
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      open_notebook:
+        condition: service_healthy
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    # No healthcheck: Caddy has no reliable /status endpoint we can rely
+    # on across versions; depends_on + restart policy is sufficient.
+
+  surrealdb:
+    image: surrealdb/surrealdb:v2
+    container_name: open-notebook-surrealdb
+    restart: unless-stopped
+    # Internal-only. Caddy and the app reach SurrealDB over notebook_private.
+    # Deliberately no host port mapping.
+    networks:
+      - notebook_private
+    command: >
+      start --log info
+      --user ${SURREAL_USER}
+      --pass ${SURREAL_PASSWORD}
+      rocksdb:/mydata/mydatabase.db
+    volumes:
+      - notebook_surreal_data:/mydata
+    environment:
+      - SURREAL_EXPERIMENTAL_GRAPHQL=true
+    healthcheck:
+      # `surreal isready` is shipped in surrealdb/surrealdb:v2.
+      test: ["CMD", "surreal", "isready", "--conn", "ws://localhost:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  open_notebook:
+    image: lfnovo/open_notebook:v1-latest
+    container_name: open-notebook-app
+    restart: unless-stopped
+    # Internal-only. Caddy reaches us at open_notebook:8502 via
+    # notebook_private. Deliberately no host port mapping; debug via
+    # `docker compose exec` or `docker compose logs` instead.
+    networks:
+      - notebook_private
+    environment:
+      # REQUIRED - no fallback. Fail-fast if unset. The `?msg` form
+      # surfaces a clear error on `docker compose up`.
+      - OPEN_NOTEBOOK_ENCRYPTION_KEY=${OPEN_NOTEBOOK_ENCRYPTION_KEY:?OPEN_NOTEBOOK_ENCRYPTION_KEY must be set}
+
+      # Database
+      - SURREAL_URL=ws://surrealdb:8000/rpc
+      - SURREAL_USER=${SURREAL_USER}
+      - SURREAL_PASSWORD=${SURREAL_PASSWORD}
+      - SURREAL_NAMESPACE=${SURREAL_NAMESPACE:-open_notebook}
+      - SURREAL_DATABASE=${SURREAL_DATABASE:-open_notebook}
+
+      # Public-facing config consumed by the API and the frontend.
+      - API_URL=${API_URL}
+      - CORS_ORIGINS=${CORS_ORIGINS:-*}
+      - OPEN_NOTEBOOK_PASSWORD=${OPEN_NOTEBOOK_PASSWORD:-}
+    volumes:
+      # /app/data holds uploads, podcast artefacts, and LangGraph SQLite
+      # checkpoints. /app/tiktoken-cache is INTENTIONALLY not mounted
+      # (see Dockerfile) so the pre-baked encodings are preserved.
+      - notebook_app_data:/app/data
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+    healthcheck:
+      # FastAPI /health is unauthenticated. 127.0.0.1 to dodge IPv6
+      # surprises on slim images.
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:5055/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    # Do not silently pull v1-latest on every start. Change to `never`
+    # after pinning a specific tag in production.
+    pull_policy: missing
+
+networks:
+  caddy_public:
+    name: caddy_public
+    driver: bridge
+  notebook_private:
+    name: notebook_private
+    # internal: true  -> no outbound, no route to host external iface.
+    # Caddy is exempted by also being attached to caddy_public above.
+    internal: true
+
+volumes:
+  notebook_surreal_data:
+    name: notebook_surreal_data
+  notebook_app_data:
+    name: notebook_app_data
+  caddy_data:
+    name: caddy_data
+  caddy_config:
+    name: caddy_config

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Backup Open Notebook data volumes to a timestamped .tar.gz archive.
+#
+# Required env (sourced from .env.server if not exported):
+#   BACKUP_DIR           Destination directory on the host (will be created).
+#   BACKUP_KEEP_DAYS     Prune archives older than N days (default: 7).
+#
+# Usage:
+#   ./scripts/backup.sh
+#   BACKUP_KEEP_DAYS=30 ./scripts/backup.sh
+#
+# Cron suggestion (run daily at 02:17 server-local time):
+#   17 2 * * * /opt/open-notebook/scripts/backup.sh \
+#       >> /var/log/open-notebook-backup.log 2>&1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Prefer inline env vars; fall back to sourcing .env.server if it exists.
+if [[ -z "${BACKUP_DIR:-}" && -f "${REPO_ROOT}/.env.server" ]]; then
+    # shellcheck disable=SC1091
+    set -a; source "${REPO_ROOT}/.env.server"; set +a
+fi
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/open-notebook}"
+BACKUP_KEEP_DAYS="${BACKUP_KEEP_DAYS:-7}"
+
+# Project name comes from `name:` field in docker-compose.server.yml.
+PROJECT_NAME="open-notebook"
+VOL_SURREAL="${PROJECT_NAME}_notebook_surreal_data"
+VOL_APP="${PROJECT_NAME}_notebook_app_data"
+
+mkdir -p "${BACKUP_DIR}"
+
+# UTC timestamp so archives sort cleanly across timezones.
+STAMP="$(date -u +%Y-%m-%d-%H%MZ)"
+ARCHIVE_NAME="open-notebook-${STAMP}.tar.gz"
+ARCHIVE_PATH="${BACKUP_DIR}/${ARCHIVE_NAME}"
+
+echo "[backup] target:  ${ARCHIVE_PATH}"
+echo "[backup] volumes: ${VOL_SURREAL}, ${VOL_APP}"
+
+# One-shot alpine container mounts BOTH volumes (read-only) and the
+# backup directory, then tar's them into a single archive. alpine ships
+# with tar + gzip so no extra packages are needed.
+docker run --rm \
+    -v "${VOL_SURREAL}:/src/surreal:ro" \
+    -v "${VOL_APP}:/src/notebook:ro" \
+    -v "${BACKUP_DIR}:/dst" \
+    alpine:3.20 \
+    sh -c "
+        set -e
+        tar -czf /dst/${ARCHIVE_NAME} -C /src surreal notebook
+        echo '[backup] archive size:' \$(stat -c%s /dst/${ARCHIVE_NAME}) bytes
+    "
+
+# Prune archives older than BACKUP_KEEP_DAYS.
+if [[ -d "${BACKUP_DIR}" ]]; then
+    while IFS= read -r old; do
+        echo "[backup] pruning: ${old}"
+        rm -f -- "${old}"
+    done < <(find "${BACKUP_DIR}" -maxdepth 1 -type f \
+                -name 'open-notebook-*.tar.gz' \
+                -mtime "+${BACKUP_KEEP_DAYS}")
+fi
+
+echo "[backup] done. Remaining archives:"
+ls -lh "${BACKUP_DIR}"/open-notebook-*.tar.gz 2>/dev/null || echo "  (none)"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Restore Open Notebook data from a backup archive.
+#
+# DANGER: this stops the stack and REPLACES the current data volumes.
+# You will be asked to type 'yes' to confirm.
+#
+# Usage:
+#   ./scripts/restore.sh
+#   ./scripts/restore.sh /var/backups/open-notebook/open-notebook-2026-07-01-0217Z.tar.gz
+#
+# If no archive path is given, the newest archive in BACKUP_DIR is used.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [[ -z "${BACKUP_DIR:-}" && -f "${REPO_ROOT}/.env.server" ]]; then
+    # shellcheck disable=SC1091
+    set -a; source "${REPO_ROOT}/.env.server"; set +a
+fi
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/open-notebook}"
+
+PROJECT_NAME="open-notebook"
+VOL_SURREAL="${PROJECT_NAME}_notebook_surreal_data"
+VOL_APP="${PROJECT_NAME}_notebook_app_data"
+COMPOSE_FILE="${REPO_ROOT}/docker-compose.server.yml"
+ENV_FILE="${REPO_ROOT}/.env.server"
+
+# Pick archive: explicit arg > newest in BACKUP_DIR.
+if [[ $# -ge 1 ]]; then
+    ARCHIVE="$1"
+else
+    ARCHIVE="$(ls -1t "${BACKUP_DIR}"/open-notebook-*.tar.gz 2>/dev/null | head -1 || true)"
+    if [[ -z "${ARCHIVE}" ]]; then
+        echo "ERROR: no archive found in ${BACKUP_DIR}" >&2
+        echo "Hint: run scripts/backup.sh first, or pass an explicit path." >&2
+        exit 1
+    fi
+    echo "[restore] no archive specified; using newest: ${ARCHIVE}"
+fi
+
+if [[ ! -f "${ARCHIVE}" ]]; then
+    echo "ERROR: archive not found: ${ARCHIVE}" >&2
+    exit 1
+fi
+
+echo "[restore] verifying archive contents..."
+if ! tar -tzf "${ARCHIVE}" | grep -Eq '(^|/)surreal(/|$)' ; then
+    echo "ERROR: archive missing a 'surreal/' top-level entry" >&2
+    exit 1
+fi
+if ! tar -tzf "${ARCHIVE}" | grep -Eq '(^|/)notebook(/|$)' ; then
+    echo "ERROR: archive missing a 'notebook/' top-level entry" >&2
+    exit 1
+fi
+
+echo "[restore] WARNING: this will STOP the stack and REPLACE all data."
+read -r -p "Type 'yes' to continue: " CONFIRM
+if [[ "${CONFIRM}" != "yes" ]]; then
+    echo "aborted."
+    exit 1
+fi
+
+echo "[restore] stopping stack..."
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    --project-name "${PROJECT_NAME}" down
+
+echo "[restore] clearing existing volume contents..."
+docker run --rm \
+    -v "${VOL_SURREAL}:/dst/surreal" \
+    -v "${VOL_APP}:/dst/notebook" \
+    alpine:3.20 \
+    sh -c "shopt -s dotglob && rm -rf /dst/surreal/* /dst/notebook/*"
+
+echo "[restore] extracting $(basename "${ARCHIVE}")..."
+docker run --rm \
+    -v "${VOL_SURREAL}:/dst/surreal" \
+    -v "${VOL_APP}:/dst/notebook" \
+    -v "$(dirname "${ARCHIVE}"):/src:ro" \
+    alpine:3.20 \
+    sh -c "tar -xzf /src/$(basename "${ARCHIVE}") -C /dst"
+
+echo "[restore] restarting stack..."
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    --project-name "${PROJECT_NAME}" up -d
+
+echo "[restore] waiting for open_notebook healthcheck..."
+CONTAINER_NAME="${PROJECT_NAME}-open_notebook-1"
+for i in $(seq 1 30); do
+    STATUS="$(docker inspect --format='{{.State.Health.Status}}' \
+        "${CONTAINER_NAME}" 2>/dev/null || echo 'starting')"
+    echo "  attempt ${i}/30: ${STATUS}"
+    if [[ "${STATUS}" == "healthy" ]]; then
+        echo "[restore] done. Verify at: https://${DOMAIN:-your-domain}/"
+        exit 0
+    fi
+    sleep 5
+done
+
+echo "[restore] WARNING: container did not become healthy within timeout."
+echo "Check logs with: docker compose -f ${COMPOSE_FILE} logs open_notebook"
+exit 1


### PR DESCRIPTION
## Description

Implements the production server deployment plan from `docs/7-DEVELOPMENT/plans/03-server-deployment-plan.md`. This adds a self-contained, single-user production deployment path on a public Linux server with HTTPS, network isolation, persistence, and backup/restore — without introducing multi-user SaaS concerns.

The new files are intentionally additive: the existing `docker-compose.yml` (zero-config dev) is untouched. Users opt into the production stack by using the new `docker-compose.server.yml`.

### What's added

- **`docker-compose.server.yml`** — production compose with:
  - Dual networks: `caddy_public` (bridge, for ACME + ingress 80/443) and `notebook_private` (`internal: true`, no route to host)
  - Named volumes: `notebook_surreal_data`, `notebook_app_data`, `caddy_data`, `caddy_config` (no host bind-mount paths, so directory renames don't recreate empty volumes)
  - Healthchecks for `surrealdb` (`surreal isready`) and `open_notebook` (`curl 127.0.0.1:5055/health`) with `depends_on: condition: service_healthy`
  - Log rotation: `json-file` driver, `max-size: 10m`, `max-file: 3`
  - Fail-fast: `${OPEN_NOTEBOOK_ENCRYPTION_KEY:?msg}` so the stack refuses to start without it
  - `pull_policy: missing` to avoid silent v1-latest drift
  - SurrealDB and Open Notebook publish **no** host ports; only 22/80/443 are exposed

- **`Caddyfile`** — reverse proxy with:
  - Automatic HTTPS via Let's Encrypt (HTTP-01 challenge)
  - HTTP → HTTPS redirect
  - `request_body { max_size 100MB }` (top-level, not nested in `reverse_proxy`)
  - `read_timeout` / `write_timeout` 600s for long AI tasks (embedding rebuilds, podcast generation)
  - Forwards `Host` / `X-Forwarded-*` so the app sees the real public scheme
  - Security headers: HSTS, X-Content-Type-Options, Referrer-Policy, hide `Server`
  - Logs to stdout for `docker logs` collection

- **`.env.server.example`** — production env template:
  - All secrets as `CHANGEME_*` placeholders (no real values, no `my-secret` bait)
  - `OPEN_NOTEBOOK_ENCRYPTION_KEY`, `SURREAL_USER`, `SURREAL_PASSWORD`, `OPEN_NOTEBOOK_PASSWORD` all required
  - `API_URL` and `CORS_ORIGINS` default to `https://notebook.example.com`
  - `BACKUP_DIR` and `BACKUP_KEEP_DAYS` consumed by `scripts/backup.sh`

- **`scripts/backup.sh`** — archives `notebook_surreal_data` and `notebook_app_data` named volumes to `open-notebook-YYYY-MM-DD-HHMMZ.tar.gz` via a one-shot `alpine:3.20` container; prunes archives older than `BACKUP_KEEP_DAYS` (default 7).

- **`scripts/restore.sh`** — stops the stack with `docker compose down`, clears existing volume contents via a one-shot alpine, extracts the archive, restarts, and polls the `open_notebook` healthcheck for up to 30×5s before reporting success.

- **`.gitignore`** — appends `.env.server` (real secrets) and `backups/` (relative-path archives).

### What is intentionally NOT in this PR

- Multi-user architecture, OAuth, JWT, tenant isolation — out of scope per plan §「后续升级触发条件」
- Object storage (MinIO/S3), independent worker queues, SurrealDB HA, Kubernetes — all gated on actual scale triggers
- Pinning the image tag — `v1-latest` is preserved per the plan; `pull_policy: missing` is the guard against silent drift. The plan suggests replacing with a fixed tag once the user has validated a release.

## Related Issue

Closes the gap described in `docs/7-DEVELOPMENT/plans/03-server-deployment-plan.md`. No issue was filed for this — the plan document itself is the spec.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- [x] Tested locally with Docker

**Test Details:**

The end-to-end runtime check (actually starting SurrealDB + app + Caddy on a public server with DNS) requires a real Linux host with public IP and was not executed in this worktree. The checks I did perform:

- `bash -n scripts/backup.sh scripts/restore.sh` — shell syntax passes
- `docker compose -f docker-compose.server.yml --env-file .env.server.example config` — parses cleanly with `CHANGEME_*` placeholders visible
- `docker compose -f docker-compose.server.yml --env-file /tmp/empty.env up open_notebook` — fails fast with exact message: `required variable OPEN_NOTEBOOK_ENCRYPTION_KEY is missing a value: OPEN_NOTEBOOK_ENCRYPTION_KEY must be set`
- `docker run --rm -v $PWD/Caddyfile:/etc/caddy/Caddyfile:ro caddy:2.8-alpine caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile` — returns `Valid configuration` (after one fix: `request_body` must be a site-block top-level directive, not a `reverse_proxy` sub-directive)
- `cp .env.server.example .env.server && git status` — `.env.server` correctly absent from untracked list (`.gitignore` works)
- Confirmed `caddy isready` is available in `surrealdb/surrealdb:v2` (matches the image already pinned in the existing `docker-compose.yml`)
- Confirmed FastAPI `/health` is unauthenticated (`api/main.py` + `PasswordAuthMiddleware` excluded paths) so the container healthcheck can hit it
- Confirmed `OPEN_NOTEBOOK_ENCRYPTION_KEY` is required at startup (`open_notebook/utils/encryption.py`) — fail-fast in compose is the right place to enforce it
- Confirmed `/app/tiktoken-cache` is intentionally NOT mounted in the volume (per `Dockerfile:36-41`); only `/app/data` is

End-to-end validation commands a reviewer can run on a real server are documented in the plan file at `docs/7-DEVELOPMENT/plans/03-server-deployment-plan.md` (验收清单 section, lines 174-184).

## Design Alignment

- [x] Privacy First — data stays on user's own server; no third-party hosting required
- [x] Simplicity Over Features — single compose file, single Caddyfile, two shell scripts; no Kubernetes, no Redis, no Terraform
- [x] Self-hosting (extension of the project's core mission) — `lfnovo/open_notebook` is already a self-hosted alternative to NotebookLM; this makes the production path concrete

**Explanation:** This PR operationalizes the "fully self-hosted option" core value of Open Notebook. It does not change any application code or break existing dev workflows. The zero-config `docker-compose.yml` is untouched.

## Checklist

### Code Quality
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [x] Manual testing performed (describe above)
- [ ] Added new unit tests (N/A — no application code touched)
- [ ] Existing tests pass (N/A — no application code touched)

### Documentation
- [x] The plan itself lives in `docs/7-DEVELOPMENT/plans/03-server-deployment-plan.md`; inline comments in each new file reference it
- [ ] I have not added a separate user-facing deployment guide yet — happy to follow up with one if the maintainer wants it in `docs/`

## Pre-Submission Verification

- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format
- [x] Only files listed in the plan are touched: 5 new files + 1 `.gitignore` append

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

