### PR TITLE
feat: unhardcode api listen host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Refresh content" action on web-link sources — re-fetches the URL and re-embeds the source so its content stays current, available from the source card menu once processing has completed (translated across all 14 locales) (#259)
 
 ### Changed
+- The API's listen interface in the Docker images is now configurable via a new `API_HOST` environment variable instead of a hardcoded `--host 0.0.0.0`. The default is unchanged (`0.0.0.0`); set `API_HOST=::` to serve IPv6/dual-stack environments (#985)
 - `docker-compose.yml` now sources the SurrealDB credentials from `SURREAL_USER` / `SURREAL_PASSWORD` (applied to both the database server and the app), defaulting to `root:root` so the zero-config quick start is unchanged. Set them in a `.env` file to use your own credentials before exposing the instance; `.env.example` and the compose file note this (#946)
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
 
 # Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
 ENV HOSTNAME=0.0.0.0
+# Bind the API to all interfaces via IPv6 dual-stack (accepts IPv4 too); override with API_HOST
+ENV API_HOST=::
 
 # Copy built frontend from builder stage
 COPY --from=builder /app/frontend/.next/standalone /app/frontend/

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,8 @@ ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
 
 # Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
 ENV HOSTNAME=0.0.0.0
-# Bind the API to all interfaces via IPv6 dual-stack (accepts IPv4 too); override with API_HOST
-ENV API_HOST=::
+# Bind the API to all interfaces (IPv4). Set API_HOST=:: for IPv6 dual-stack environments
+ENV API_HOST=0.0.0.0
 
 # Copy built frontend from builder stage
 COPY --from=builder /app/frontend/.next/standalone /app/frontend/

--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -84,8 +84,8 @@ COPY --from=frontend-builder /app/frontend/public /app/frontend/public
 
 # Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
 ENV HOSTNAME=0.0.0.0
-# Bind the API to all interfaces via IPv6 dual-stack (accepts IPv4 too); override with API_HOST
-ENV API_HOST=::
+# Bind the API to all interfaces (IPv4). Set API_HOST=:: for IPv6 dual-stack environments
+ENV API_HOST=0.0.0.0
 # Point the app at the pre-baked tiktoken encoding (see open_notebook/config.py)
 ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
 

--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -84,6 +84,8 @@ COPY --from=frontend-builder /app/frontend/public /app/frontend/public
 
 # Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
 ENV HOSTNAME=0.0.0.0
+# Bind the API to all interfaces via IPv6 dual-stack (accepts IPv4 too); override with API_HOST
+ENV API_HOST=::
 # Point the app at the pre-baked tiktoken encoding (see open_notebook/config.py)
 ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
 

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -14,6 +14,7 @@ Comprehensive list of all environment variables available in Open Notebook.
 | `OPEN_NOTEBOOK_PASSWORD` | No | None | Password to protect Open Notebook instance |
 | `OPEN_NOTEBOOK_ENCRYPTION_KEY` | **Yes** | None | Secret string to encrypt credentials stored in database (any string works). **Required** for the credential system. Supports Docker secrets via `_FILE` suffix. |
 | `HOSTNAME` | No | `0.0.0.0` (in Docker) | Network interface for Next.js to bind to. Default `0.0.0.0` ensures accessibility from reverse proxies |
+| `API_HOST` | No | `0.0.0.0` (in Docker) | Network interface for the API (uvicorn) to bind to. Set to `::` for IPv6 dual-stack environments (listens on IPv6 and, on Linux defaults, IPv4 too) |
 
 > **Important**: `OPEN_NOTEBOOK_ENCRYPTION_KEY` is required for storing AI provider credentials via the Settings UI. Without it, you cannot save credentials. If you change or lose this key, all stored credentials become unreadable.
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,7 +5,7 @@ logfile_maxbytes=0
 pidfile=/tmp/supervisord.pid
 
 [program:api]
-command=uv run --no-sync uvicorn api.main:app --host 0.0.0.0 --port 5055
+command=uv run --no-sync uvicorn api.main:app --host %(ENV_API_HOST)s --port 5055
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/supervisord.single.conf
+++ b/supervisord.single.conf
@@ -16,7 +16,7 @@ autostart=true
 startsecs=5
 
 [program:api]
-command=uv run --no-sync uvicorn api.main:app --host 0.0.0.0 --port 5055
+command=uv run --no-sync uvicorn api.main:app --host %(ENV_API_HOST)s --port 5055
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Description

Change the uvicorn host binding in the Docker images from the hardcoded --host 0.0.0.0 to a configurable API_HOST env var, defaulting to :: (IPv6 dual-stack).


### Why

0.0.0.0 only binds to IPv4. On hosts/networks that route over IPv6 (e.g. some container platforms and reverse-proxy setups), the API is unreachable. Binding to :: listens on all IPv6 interfaces and, thanks to dual-stack (bindv6only=0, the Linux default), also accepts IPv4 — so it works in both IPv4 and IPv6 environments.

### Changes

- supervisord.conf / supervisord.single.conf: uvicorn now uses --host %(ENV_API_HOST)s instead of the hardcoded 0.0.0.0.
- Dockerfile / Dockerfile.single: added ENV API_HOST=:: as the default. This keeps the value overridable at runtime via -e API_HOST=... (or compose), and guarantees the env var is always present so supervisord's %(ENV_API_HOST)s expansion never fails.

### Notes

- The API host is now configurable without rebuilding the image (docker run -e API_HOST=0.0.0.0 ...).
- Local dev via run_api.py is unchanged (still defaults to 127.0.0.1).
- Dual-stack requires net.ipv6.bindv6only=0 (the default on Linux / standard base images). If IPv6 is fully disabled in your environment, override with API_HOST=0.0.0.0.



## Related Issue
https://github.com/lfnovo/open-notebook/issues/985


Fixes #985

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [V] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

<!-- Describe the tests you ran and/or how you verified your changes work -->

- [V] Tested locally with Docker
- [ ] Tested locally with development setup
- [ ] Added new unit tests
- [ ] Existing tests pass (`uv run pytest`)
- [ ] Manual testing performed (describe below)

**Test Details:**
Tested on my k8s cluster with ipv6 only, for testing used this cmd


```yaml
command:
  - /bin/sh
  - -c
  - |
    sed -i 's|--host 0.0.0.0|--host ::|' /etc/supervisor/conf.d/supervisord.conf
    exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
```

## Design Alignment

<!-- This section helps ensure your PR aligns with our project vision -->

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [ ] Simplicity Over Features
- [ ] API-First Architecture
- [ ] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**
<!-- Brief explanation of how your changes align with these principles -->

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality
- [ ] My code follows PEP 8 style guidelines (Python)
- [ ] My code follows TypeScript best practices (Frontend)
- [ ] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Context

<!-- Add any other context about the PR here -->

## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [ ] This PR addresses an approved issue that was assigned to me
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")

---

**Thank you for contributing to Open Notebook!** 🎉


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

