### PR TITLE
fix: update Google/Vertex connection test model to gemini-2.5-flash

### DIFF
--- a/open_notebook/ai/CLAUDE.md
+++ b/open_notebook/ai/CLAUDE.md
@@ -172,7 +172,7 @@ Maps each provider to `(model_name, model_type)` for testing:
 TEST_MODELS = {
     "openai": ("gpt-3.5-turbo", "language"),
     "anthropic": ("claude-3-haiku-20240307", "language"),
-    "google": ("gemini-1.5-flash", "language"),
+    "google": ("gemini-2.5-flash", "language"),
     "groq": ("llama-3.1-8b-instant", "language"),
     "voyage": ("voyage-3-lite", "embedding"),
     "elevenlabs": ("eleven_multilingual_v2", "text_to_speech"),

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -18,7 +18,7 @@ from loguru import logger
 TEST_MODELS = {
     "openai": ("gpt-3.5-turbo", "language"),
     "anthropic": ("claude-3-haiku-20240307", "language"),
-    "google": ("gemini-2.0-flash", "language"),
+    "google": ("gemini-2.5-flash", "language"),
     "groq": ("llama-3.1-8b-instant", "language"),
     "mistral": ("mistral-small-latest", "language"),
     "deepseek": ("deepseek-chat", "language"),
@@ -29,7 +29,7 @@ TEST_MODELS = {
     "deepgram": ("aura-2-thalia-en", "text_to_speech"),
     "ollama": (None, "language"),  # Dynamic - will use first available model
     # Complex providers with additional configuration
-    "vertex": ("gemini-2.0-flash", "language"),  # Uses Google Vertex AI
+    "vertex": ("gemini-2.5-flash", "language"),  # Uses Google Vertex AI
     "azure": ("gpt-35-turbo", "language"),  # Azure OpenAI deployment name
     "openai_compatible": (None, "language"),  # Dynamic - will use first available model
     "dashscope": ("qwen-plus", "language"),

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -259,6 +259,14 @@ class TestAudioMatrixWiring:
         assert "text_to_speech" in PROVIDER_MODALITIES["vertex"]
         assert "speech_to_text" in PROVIDER_MODALITIES["elevenlabs"]
 
+    def test_google_and_vertex_use_current_test_model(self):
+        # Regression test for #970: the connection test used the retired
+        # gemini-2.0-flash, so testing a valid Google AI key failed with 404.
+        from open_notebook.ai.connection_tester import TEST_MODELS
+
+        assert TEST_MODELS["google"] == ("gemini-2.5-flash", "language")
+        assert TEST_MODELS["vertex"] == ("gemini-2.5-flash", "language")
+
     def test_classify_matrix(self):
         from open_notebook.ai.model_discovery import classify_model_type
 


### PR DESCRIPTION
## Description

Testing a perfectly valid Google AI key on the Manage Models page fails with a 404, because the connection test calls `gemini-2.0-flash` — which Google has retired. Same for the Vertex entry.

This swaps both `TEST_MODELS` entries to `gemini-2.5-flash`, as suggested in the issue thread. Also updated the stale `TEST_MODELS` snippet in `open_notebook/ai/CLAUDE.md` so the docs match the code.

Left alone on purpose: the static `VERTEX_MODELS` discovery list in `api/credentials_service.py` also carries some older model names, but that's model discovery, not the connection test — happy to do a follow-up if you want it refreshed too.

## Related Issue

Fixes #970

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [ ] Tested locally with Docker
- [x] Tested locally with development setup
- [x] Added new unit tests
- [x] Existing tests pass (`uv run pytest`)
- [ ] Manual testing performed (describe below)

**Test Details:**

Added a regression test in `tests/test_credentials_api.py` pinning the google/vertex test models to `gemini-2.5-flash` (it fails on `main`, passes here). Full suite: 223 passed. `ruff check` clean. I didn't run a live key test against Google's API, but the change is exactly the model swap suggested by @lfnovo in the issue.

## Design Alignment

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [ ] Simplicity Over Features
- [ ] API-First Architecture
- [x] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**

Keeps the Google/Vertex provider path actually usable — a key test that always fails defeats the point of supporting the provider.

## Checklist

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [ ] My code follows TypeScript best practices (Frontend)
- [ ] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .` (mypy isn't in the dev deps of my env; change is a string-literal swap)

### Documentation
- [x] I have updated the relevant documentation in `/docs` (if applicable) — updated the `TEST_MODELS` snippet in `open_notebook/ai/CLAUDE.md`
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

N/A

## Additional Context

The issue is labeled `ready` + `good first issue` and had been quiet for a bit, so I picked it up — hope that's fine. Happy to adjust if you'd rather use a different model name.

## Pre-Submission Verification

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [ ] This PR addresses an approved issue that was assigned to me (approved/`ready`, but not formally assigned — see Additional Context)
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

