### PR TITLE
fix: prevent SurrealQL injection in repo_relate/repo_upsert/repo_update

### DIFF
--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -3,7 +3,7 @@ from loguru import logger
 
 from api.models import NoteResponse, SaveAsNoteRequest, SourceInsightResponse
 from open_notebook.domain.notebook import SourceInsight
-from open_notebook.exceptions import InvalidInputError
+from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
@@ -73,6 +73,8 @@ async def save_insight_as_note(insight_id: str, request: SaveAsNoteRequest):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except InvalidInputError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/open_notebook/database/repository.py
+++ b/open_notebook/database/repository.py
@@ -1,12 +1,28 @@
 import os
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from loguru import logger
 from surrealdb import AsyncSurreal, RecordID  # type: ignore
+from surrealdb.data.types.table import Table  # type: ignore
 
 T = TypeVar("T", Dict[str, Any], List[Dict[str, Any]])
+
+# Bare SurrealDB table/relation identifier: no ':', whitespace, or query
+# syntax. Used to validate the parts of RELATE/UPSERT/UPDATE that name a
+# table or edge-relation and therefore can't be bound as a query parameter
+# (SurrealQL only allows binding record/table *values*, not identifiers in
+# that position).
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _ensure_safe_identifier(value: str, kind: str) -> str:
+    """Validate a table/relationship name before it is interpolated into a query."""
+    if not isinstance(value, str) or not _IDENTIFIER_RE.match(value):
+        raise ValueError(f"Invalid {kind} name: {value!r}")
+    return value
 
 
 def _get_env_or_default(name: str, default: str) -> str:
@@ -117,17 +133,26 @@ async def repo_create(table: str, data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def repo_relate(
-    source: str, relationship: str, target: str, data: Optional[Dict[str, Any]] = None
+    source: Union[str, RecordID],
+    relationship: str,
+    target: Union[str, RecordID],
+    data: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Create a relationship between two records with optional data"""
     if data is None:
         data = {}
-    query = f"RELATE {source}->{relationship}->{target} CONTENT $data;"
+    # relationship is an edge-table name, not a record value, so it can't be
+    # bound as a query parameter; validate it against an identifier allowlist
+    # instead of trusting the caller. source/target are always bound.
+    _ensure_safe_identifier(relationship, "relationship")
+    query = f"RELATE $source->{relationship}->$target CONTENT $data;"
     # logger.debug(f"Relate query: {query}")
 
     return await repo_query(
         query,
         {
+            "source": ensure_record_id(source),
+            "target": ensure_record_id(target),
             "data": data,
         },
     )
@@ -140,27 +165,32 @@ async def repo_upsert(
     data.pop("id", None)
     if add_timestamp:
         data["updated"] = datetime.now(timezone.utc)
-    query = f"UPSERT {id if id else table} MERGE $data;"
-    return await repo_query(query, {"data": data})
+    _ensure_safe_identifier(table, "table")
+    target: Union[RecordID, Table] = ensure_record_id(id) if id else Table(table)
+    query = "UPSERT $target MERGE $data;"
+    return await repo_query(query, {"target": target, "data": data})
 
 
 async def repo_update(
-    table: str, id: str, data: Dict[str, Any]
+    table: str, id: Union[str, RecordID], data: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
     """Update an existing record by table and id"""
     # If id already contains the table name, use it as is
     try:
-        if isinstance(id, RecordID) or (":" in id and id.startswith(f"{table}:")):
-            record_id = id
+        _ensure_safe_identifier(table, "table")
+        if isinstance(id, RecordID):
+            record_id: RecordID = id
+        elif ":" in id and id.startswith(f"{table}:"):
+            record_id = ensure_record_id(id)
         else:
-            record_id = f"{table}:{id}"
+            record_id = RecordID(table, id)
         data.pop("id", None)
         if "created" in data and isinstance(data["created"], str):
             data["created"] = datetime.fromisoformat(data["created"])
         data["updated"] = datetime.now(timezone.utc)
-        query = f"UPDATE {record_id} MERGE $data;"
+        query = "UPDATE $target MERGE $data;"
         # logger.debug(f"Update query: {query}")
-        result = await repo_query(query, {"data": data})
+        result = await repo_query(query, {"target": record_id, "data": data})
         # if isinstance(result, list):
         #     return [_return_data(item) for item in result]
         return parse_record_ids(result)

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -475,6 +475,7 @@ class Source(ObjectModel):
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
+        await Notebook.get(notebook_id)  # raises NotFoundError if invalid/missing
         return await self.relate("reference", notebook_id)
 
     async def vectorize(self) -> str:
@@ -662,6 +663,7 @@ class Note(ObjectModel):
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
+        await Notebook.get(notebook_id)  # raises NotFoundError if invalid/missing
         return await self.relate("artifact", notebook_id)
 
     def get_context(


### PR DESCRIPTION
repo_relate() interpolated the relate target directly into the query
string, reachable via an unvalidated notebook_id on the save-insight-
as-note flow - a crafted ID could inject and execute arbitrary
SurrealQL (confirmed against a live embedded instance: a single
crafted RELATE call wiped an entire table). Bind record identifiers
as query parameters instead of building them into the query text, and
validate notebook_id exists before relating, matching the pattern
already used by every other caller of add_to_notebook().



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

