### PR TITLE
fix: stop compiling user-controlled prompts as Jinja2 template source

### DIFF
--- a/open_notebook/graphs/prompt.py
+++ b/open_notebook/graphs/prompt.py
@@ -19,8 +19,12 @@ class PatternChainState(TypedDict):
 
 async def call_model(state: dict, config: RunnableConfig) -> dict:
     content = state["input_text"]
+    # state["prompt"] is caller-supplied free text. Never compile it as Jinja
+    # template *source* (Prompter(template_text=...)) - pass it as a plain
+    # render variable into a fixed, developer-authored template instead.
+    # See docs/7-DEVELOPMENT/security.md (GHSA-f35w-wx37-26q7).
     system_prompt = Prompter(
-        template_text=state["prompt"], parser=state.get("parser")
+        prompt_template="pattern/generic", parser=state.get("parser")
     ).render(data=state)
     payload = [SystemMessage(content=system_prompt)] + [HumanMessage(content=content)]
     chain = await provision_langchain_model(

--- a/open_notebook/graphs/transformation.py
+++ b/open_notebook/graphs/transformation.py
@@ -30,15 +30,17 @@ async def run_transformation(state: dict, config: RunnableConfig) -> dict:
     try:
         if not content:
             content = source.full_text
-        transformation_template_text = transformation.prompt
+        # transformation.prompt is user-controlled free text. Never compile it as
+        # Jinja template *source* (Prompter(template_text=...)) - pass it as a
+        # plain render variable into a fixed, developer-authored template instead.
+        # See docs/7-DEVELOPMENT/security.md (GHSA-f35w-wx37-26q7).
+        instructions = transformation.prompt
         default_prompts: DefaultPrompts = DefaultPrompts(transformation_instructions=None)
         if default_prompts.transformation_instructions:
-            transformation_template_text = f"{default_prompts.transformation_instructions}\n\n{transformation_template_text}"
+            instructions = f"{default_prompts.transformation_instructions}\n\n{instructions}"
 
-        transformation_template_text = f"{transformation_template_text}\n\n# INPUT"
-
-        system_prompt = Prompter(template_text=transformation_template_text).render(
-            data=state
+        system_prompt = Prompter(prompt_template="transformation/execute").render(
+            data={**state, "instructions": instructions}
         )
         content_str = str(content) if content else ""
         payload = [SystemMessage(content=system_prompt), HumanMessage(content=content_str)]

--- a/prompts/pattern/generic.jinja
+++ b/prompts/pattern/generic.jinja
@@ -1,0 +1,5 @@
+{{ prompt }}
+{%- if format_instructions %}
+
+{{ format_instructions }}
+{%- endif %}

--- a/prompts/transformation/execute.jinja
+++ b/prompts/transformation/execute.jinja
@@ -1,0 +1,3 @@
+{{ instructions }}
+
+# INPUT


### PR DESCRIPTION
transformation.prompt and the generic pattern-chain's prompt were
passed to Prompter(template_text=...), compiling attacker-influenced
text directly as Jinja2 template source. ai-prompter's sandboxed
environment blocks the classic __globals__/__subclasses__ RCE
gadgets, but not an unbounded {% for %} loop - a trivial DoS for any
authenticated user, and one instance of the same "user text becomes
template source" pattern behind a previously-disclosed critical CVE
(GHSA-f35w-wx37-26q7), whose fix only added sandboxing without
removing the pattern itself.

Render through fixed, developer-authored templates instead, with the
user's text passed in as a plain variable. Verified byte-identical
output for legitimate prompts and confirmed the same payload that
used to be a DoS vector now renders as inert text in under a
millisecond.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

