### PR TITLE
fix: re-validate provider-credential URLs at request time, not just save time

### DIFF
--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -7,11 +7,8 @@ Extracted from the credentials router to follow the service layer pattern.
 All functions raise ValueError for business errors (router converts to HTTPException).
 """
 
-import ipaddress
 import os
-import socket
 from typing import Dict, List, Optional
-from urllib.parse import urlparse
 
 import httpx
 from loguru import logger
@@ -21,6 +18,7 @@ from api.models import CredentialResponse
 from open_notebook.ai.model_discovery import classify_model_type
 from open_notebook.domain.credential import Credential
 from open_notebook.utils.encryption import get_secret_from_env
+from open_notebook.utils.url_validation import validate_url
 
 # =============================================================================
 # Constants
@@ -82,113 +80,6 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "dashscope": ["language"],
     "minimax": ["language"],
 }
-
-
-# =============================================================================
-# URL Validation (SSRF protection)
-# =============================================================================
-
-
-def validate_url(url: str, provider: str) -> None:
-    """
-    Validate URL format for API endpoints.
-
-    This is a self-hosted application, so we allow:
-    - Private IPs (10.x, 172.16-31.x, 192.168.x) for self-hosted services
-    - Localhost for local services (Ollama, LM Studio, etc.)
-
-    We only block:
-    - Invalid schemes (must be http or https)
-    - Malformed URLs
-    - Link-local addresses (169.254.x.x) - used for cloud metadata endpoints
-    - Hostnames that resolve to link-local addresses
-
-    Args:
-        url: The URL to validate
-        provider: The provider name (for logging/context)
-
-    Raises:
-        ValueError: If the URL is invalid
-    """
-    if not url or not url.strip():
-        return  # Empty URLs handled elsewhere
-
-    try:
-        parsed = urlparse(url.strip())
-
-        # Validate scheme - only http/https allowed
-        if parsed.scheme not in ("http", "https"):
-            raise ValueError(
-                f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
-            )
-
-        # Extract hostname
-        hostname = parsed.hostname
-        if not hostname:
-            raise ValueError("Invalid URL: hostname could not be determined.")
-
-        # Try to parse as IP address to check for dangerous addresses
-        try:
-            ip = ipaddress.ip_address(hostname)
-
-            # Block link-local addresses (169.254.x.x) - used for cloud metadata
-            # These are dangerous as they can expose cloud instance credentials
-            if ip.is_link_local:
-                raise ValueError(
-                    "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
-                    "These addresses are used for cloud metadata endpoints."
-                )
-
-            # Block IPv4-mapped IPv6 addresses pointing to link-local
-            # e.g. ::ffff:169.254.169.254 bypasses IPv6 is_link_local check
-            if hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped and ip.ipv4_mapped.is_link_local:
-                raise ValueError(
-                    "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
-                    "These addresses are used for cloud metadata endpoints."
-                )
-
-        except ValueError as ve:
-            # Re-raise our own ValueErrors
-            if "Link-local" in str(ve) or "Invalid URL" in str(ve):
-                raise
-            # Not an IP address, it's a hostname - need to resolve and check
-            try:
-                # Resolve hostname to IP address
-                resolved_ips = socket.getaddrinfo(hostname, None)
-                for family, _, _, _, sockaddr in resolved_ips:
-                    ip_addr = sockaddr[0]
-                    try:
-                        parsed_ip = ipaddress.ip_address(ip_addr)
-                        if parsed_ip.is_link_local:
-                            raise ValueError(
-                                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) which is not allowed for security reasons. "
-                                "These addresses are used for cloud metadata endpoints."
-                            )
-                        # Block IPv4-mapped IPv6 addresses pointing to link-local
-                        if (
-                            hasattr(parsed_ip, "ipv4_mapped")
-                            and parsed_ip.ipv4_mapped
-                            and parsed_ip.ipv4_mapped.is_link_local
-                        ):
-                            raise ValueError(
-                                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) which is not allowed for security reasons. "
-                                "These addresses are used for cloud metadata endpoints."
-                            )
-                    except ValueError as inner_ve:
-                        if "link-local" in str(inner_ve).lower() or "Link-local" in str(inner_ve):
-                            raise
-                        # Skip non-IP addresses (e.g., IPv6 zones)
-                        continue
-            except socket.gaierror:
-                # Could not resolve hostname - allow it since the URL may be
-                # valid in the deployment environment (e.g., Azure endpoints,
-                # internal DNS names). We only block link-local addresses.
-                pass
-
-    except ValueError:
-        raise
-    except Exception:
-        raise ValueError("Invalid URL format. Check server logs for details.")
 
 
 # =============================================================================
@@ -541,6 +432,10 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
     if provider == "ollama":
         ollama_url = base_url or "http://localhost:11434"
         try:
+            # Re-validate at request time: the base_url may have been saved
+            # against a hostname that only later resolved to an internal
+            # address (DNS rebinding).
+            validate_url(ollama_url, "ollama")
             async with httpx.AsyncClient() as client:
                 response = await client.get(f"{ollama_url}/api/tags", timeout=10.0)
                 response.raise_for_status()
@@ -562,6 +457,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not base_url:
             return []
         try:
+            # Re-validate at request time (see ollama branch above).
+            validate_url(base_url, "openai_compatible")
             headers = {}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
@@ -588,6 +485,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not endpoint or not api_key:
             return []
         try:
+            # Re-validate at request time (see ollama branch above).
+            validate_url(endpoint, "azure")
             url = f"{endpoint.rstrip('/')}/openai/models?api-version={api_version}"
             headers = {"api-key": api_key}
             async with httpx.AsyncClient() as client:

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -13,6 +13,8 @@ from typing import Optional, Tuple
 import httpx
 from loguru import logger
 
+from open_notebook.utils.url_validation import validate_url
+
 # Test models for each provider - uses minimal/cheapest models for testing
 # Format: (model_name, model_type)
 TEST_MODELS = {
@@ -61,6 +63,10 @@ async def _test_azure_connection(
     test_endpoint = test_endpoint.rstrip("/")
 
     try:
+        # Re-validate at request time: the endpoint may have been saved
+        # against a hostname that only later resolved to an internal
+        # address (DNS rebinding), so a save-time check alone isn't enough.
+        validate_url(test_endpoint, "azure")
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
                 f"{test_endpoint}/openai/models?api-version={test_api_version}",
@@ -86,6 +92,8 @@ async def _test_azure_connection(
             else:
                 return False, f"Azure returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to Azure endpoint. Check the URL."
     except httpx.TimeoutException:
@@ -97,6 +105,8 @@ async def _test_azure_connection(
 async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
     """Test Ollama server connectivity."""
     try:
+        # Re-validate at request time (see _test_azure_connection for why).
+        validate_url(base_url, "ollama")
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Try /api/tags endpoint (standard Ollama)
             response = await client.get(f"{base_url}/api/tags")
@@ -121,6 +131,8 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
             else:
                 return False, f"Server returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to Ollama. Check if Ollama server is running."
     except httpx.TimeoutException:
@@ -132,6 +144,8 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
 async def _test_openai_compatible_connection(base_url: str, api_key: Optional[str] = None) -> Tuple[bool, str]:
     """Test OpenAI-compatible server connectivity."""
     try:
+        # Re-validate at request time (see _test_azure_connection for why).
+        validate_url(base_url, "openai_compatible")
         headers = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
@@ -160,6 +174,8 @@ async def _test_openai_compatible_connection(base_url: str, api_key: Optional[st
             else:
                 return False, f"Server returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to server. Check the URL is correct."
     except httpx.TimeoutException:

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -12,8 +12,41 @@ from loguru import logger
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.base import ObjectModel, RecordModel
 from open_notebook.exceptions import ConfigurationError
+from open_notebook.utils.url_validation import validate_url
 
 ModelType = Union[LanguageModel, EmbeddingModel, SpeechToTextModel, TextToSpeechModel]
+
+# Config keys from Credential.to_esperanto_config() that may carry a
+# user-configured URL (ollama/azure/openai_compatible/vertex).
+_URL_CONFIG_KEYS = (
+    "base_url",
+    "endpoint",
+    "endpoint_llm",
+    "endpoint_embedding",
+    "endpoint_stt",
+    "endpoint_tts",
+)
+
+
+def _revalidate_config_urls(config: dict, provider: str) -> None:
+    """
+    Re-validate a credential's URL fields immediately before they're used for
+    a real request.
+
+    validate_url() is also enforced when a credential is created/updated, but
+    that alone leaves a DNS-rebinding TOCTOU window: a hostname that resolved
+    to a public IP at save time can later be repointed to an internal/
+    metadata address, and Esperanto/httpx re-resolve DNS fresh on every
+    connection. Re-checking here narrows that window to "this call", instead
+    of "any time after the credential was saved".
+    """
+    for key in _URL_CONFIG_KEYS:
+        value = config.get(key)
+        if value:
+            try:
+                validate_url(value, provider)
+            except ValueError as e:
+                raise ConfigurationError(str(e)) from e
 
 
 class Model(ObjectModel):
@@ -123,6 +156,7 @@ class ModelManager:
             credential = await model.get_credential_obj()
             if credential:
                 config = credential.to_esperanto_config()
+                _revalidate_config_urls(config, model.provider)
                 logger.debug(
                     f"Using credential '{credential.name}' for model {model.name}"
                 )

--- a/open_notebook/utils/url_validation.py
+++ b/open_notebook/utils/url_validation.py
@@ -1,0 +1,131 @@
+"""
+URL validation shared by the credentials API and the AI provisioning layer.
+
+Lives in open_notebook.utils (not api/) so it can be imported both by the API
+layer (credential create/update, source-URL ingestion) and by open_notebook's
+own AI layer (connection_tester.py, ModelManager) to re-validate a
+provider-configured URL immediately before it is actually used - closing most
+of the DNS-rebinding TOCTOU window left by validating only once, at save time.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# AWS's IMDSv6 metadata endpoint. Unlike the IPv4 metadata address
+# (169.254.169.254), this is a Unique Local Address, not link-local, so it is
+# not caught by ip.is_link_local and must be checked explicitly.
+_AWS_IMDS_V6_ADDRESS = ipaddress.ip_address("fd00:ec2::254")
+
+
+def validate_url(url: str, provider: str) -> None:
+    """
+    Validate URL format for API endpoints.
+
+    This is a self-hosted application, so we allow:
+    - Private IPs (10.x, 172.16-31.x, 192.168.x) for self-hosted services
+    - Localhost for local services (Ollama, LM Studio, etc.)
+
+    We only block:
+    - Invalid schemes (must be http or https)
+    - Malformed URLs
+    - Link-local addresses (169.254.x.x) - used for cloud metadata endpoints
+    - AWS's IPv6 metadata address (fd00:ec2::254)
+    - Hostnames that resolve to any of the above
+
+    Args:
+        url: The URL to validate
+        provider: The provider name (for logging/context)
+
+    Raises:
+        ValueError: If the URL is invalid
+    """
+    if not url or not url.strip():
+        return  # Empty URLs handled elsewhere
+
+    try:
+        parsed = urlparse(url.strip())
+
+        # Validate scheme - only http/https allowed
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
+            )
+
+        # Extract hostname
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("Invalid URL: hostname could not be determined.")
+
+        # Try to parse as IP address to check for dangerous addresses
+        try:
+            ip = ipaddress.ip_address(hostname)
+            _reject_dangerous_ip(ip, hostname)
+
+        except ValueError as ve:
+            # Re-raise our own ValueErrors
+            if "Link-local" in str(ve) or "Invalid URL" in str(ve) or "metadata" in str(ve):
+                raise
+            # Not an IP address, it's a hostname - need to resolve and check
+            try:
+                # Resolve hostname to IP address
+                resolved_ips = socket.getaddrinfo(hostname, None)
+                for family, _, _, _, sockaddr in resolved_ips:
+                    ip_addr = sockaddr[0]
+                    try:
+                        parsed_ip = ipaddress.ip_address(ip_addr)
+                        _reject_dangerous_ip(parsed_ip, hostname, resolved=True)
+                    except ValueError as inner_ve:
+                        if "link-local" in str(inner_ve).lower() or "metadata" in str(inner_ve).lower():
+                            raise
+                        # Skip non-IP addresses (e.g., IPv6 zones)
+                        continue
+            except socket.gaierror:
+                # Could not resolve hostname - allow it since the URL may be
+                # valid in the deployment environment (e.g., Azure endpoints,
+                # internal DNS names). We only block link-local addresses.
+                pass
+
+    except ValueError:
+        raise
+    except Exception:
+        raise ValueError("Invalid URL format. Check server logs for details.")
+
+
+def _reject_dangerous_ip(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+    hostname: str,
+    resolved: bool = False,
+) -> None:
+    """Raise ValueError if `ip` is a link-local or cloud-metadata address."""
+    is_ipv4_mapped_link_local = (
+        hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped and ip.ipv4_mapped.is_link_local
+    )
+
+    # Block link-local addresses (169.254.x.x / fe80::/10) - used for cloud
+    # metadata - including IPv4-mapped IPv6 addresses pointing to link-local
+    # (e.g. ::ffff:169.254.169.254 bypasses IPv6 is_link_local check).
+    if ip.is_link_local or is_ipv4_mapped_link_local:
+        if resolved:
+            raise ValueError(
+                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) "
+                "which is not allowed for security reasons. These addresses are used "
+                "for cloud metadata endpoints."
+            )
+        raise ValueError(
+            "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
+            "These addresses are used for cloud metadata endpoints."
+        )
+
+    # Block AWS's IMDSv6 metadata address - a Unique Local Address, not
+    # link-local, so it needs its own explicit check.
+    if ip == _AWS_IMDS_V6_ADDRESS:
+        if resolved:
+            raise ValueError(
+                f"Hostname '{hostname}' resolves to the AWS IMDSv6 metadata address "
+                "(fd00:ec2::254), which is not allowed for security reasons."
+            )
+        raise ValueError(
+            "The AWS IMDSv6 metadata address (fd00:ec2::254) is not allowed for "
+            "security reasons."
+        )


### PR DESCRIPTION
validate_url() only ran when a credential was created or updated. The
actual HTTP requests (connection testing, model discovery, and real
inference through Esperanto) re-resolve DNS fresh on every call, so a
hostname that resolved to a public IP at save time can later be
repointed to an internal or cloud-metadata address - a classic
DNS-rebinding TOCTOU that a one-time check can't catch.

Move validate_url() to open_notebook/utils so it can be re-run from
the AI layer without an api-depends-on-open_notebook layering
violation, and re-check immediately before every outbound request:
connection_tester's three providers, credential model discovery, and
ModelManager.get_model() on the real-inference path. Also close a
second gap in the same validator: it missed AWS's IPv6 metadata
address (fd00:ec2::254), which isn't link-local so the existing check
never caught it.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

