### PR TITLE
fix: sanitize raw HTML in the note/transformation markdown preview

### DIFF
--- a/frontend/src/components/ui/markdown-editor.test.tsx
+++ b/frontend/src/components/ui/markdown-editor.test.tsx
@@ -63,6 +63,18 @@ describe('MarkdownEditor preview sanitization', () => {
     expect(container.querySelectorAll('span[class*="token"]').length).toBeGreaterThan(0)
   })
 
+  it('still renders the code-block copy button the library injects', () => {
+    // The preview library's rehypeRewrite injects div.copied[data-code] with
+    // two octicon SVGs before user plugins run; the sanitize schema must let
+    // exactly that markup through or the copy feature dies silently.
+    const { container } = renderPreview('```js\nconst a = 1;\n```')
+    const button = container.querySelector('pre div.copied')
+    expect(button).not.toBeNull()
+    expect(button?.getAttribute('data-code')).toContain('const a = 1;')
+    expect(button?.querySelector('svg.octicon-copy')).not.toBeNull()
+    expect(button?.querySelector('svg.octicon-check')).not.toBeNull()
+  })
+
   it('still renders GFM tables, task lists, and safe links', () => {
     const { container } = renderPreview(
       '| a | b |\n|---|---|\n| 1 | 2 |\n\n- [x] done\n- [ ] todo\n\n[a link](https://example.com)'

--- a/frontend/src/components/ui/markdown-editor.tsx
+++ b/frontend/src/components/ui/markdown-editor.tsx
@@ -4,7 +4,8 @@ import dynamic from 'next/dynamic'
 import { forwardRef } from 'react'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
-import rehypeSanitize from 'rehype-sanitize'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import type { PluggableList } from 'unified'
 
 const MDEditor = dynamic(
   () => import('@uiw/react-md-editor').then((mod) => mod.default),
@@ -24,9 +25,28 @@ const MDEditor = dynamic(
 // (katex-html spans, MathML) isn't in the default sanitize schema and gets
 // stripped if sanitize runs after it - order here is load-bearing, verified
 // against the actual rendered output for math/code/GFM before changing it.
+// The library's rehypeRewrite injects a copy button into code blocks
+// (div.copied[data-code] + two octicon SVGs) *before* user plugins run, so
+// the default schema strips it. Allow exactly that markup back in. The div
+// keys must be the literal lowercase 'class'/'data-code' the library sets
+// (hast-util-sanitize matches raw property keys); the SVGs are authored in
+// camelCase, so camelCase is correct there. Worst case this permits from
+// user-authored raw HTML: a decoy div that copies attacker-chosen text on
+// click, plus inert static SVGs.
+const SANITIZE_SCHEMA = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'svg', 'path'],
+  attributes: {
+    ...defaultSchema.attributes,
+    div: [...(defaultSchema.attributes?.div ?? []), ['class', 'copied'], 'data-code'],
+    svg: [['className', 'octicon-copy', 'octicon-check'], 'ariaHidden', 'viewBox', 'fill', 'height', 'width'],
+    path: ['fillRule', 'd'],
+  },
+}
+
 export const PREVIEW_OPTIONS = {
-  remarkPlugins: [remarkMath],
-  rehypePlugins: [rehypeSanitize, rehypeKatex],
+  remarkPlugins: [remarkMath] as PluggableList,
+  rehypePlugins: [[rehypeSanitize, SANITIZE_SCHEMA], rehypeKatex] as PluggableList,
 }
 
 export interface MarkdownEditorProps {


### PR DESCRIPTION
MarkdownEditor's live preview renders through @uiw/react-markdown-
preview, which parses literal HTML in the markdown source into real
elements (its `raw` default) - including a live <iframe>. Notes can
hold AI-generated content that echoes an indirect prompt injection
from an ingested document, so this was reachable without the user
writing any HTML themselves.

Add rehype-sanitize (default schema) ahead of rehype-katex in the
preview pipeline. Ordering matters: sanitizing after katex strips
katex's own generated markup (not in the default allowlist), while
sanitizing before it only touches the raw-HTML-derived tree and
leaves not-yet-rendered math nodes alone. Verified against the real
preview component that this strips <iframe>/<script>/<style>/
javascript: URLs while fully preserving math, syntax highlighting,
and GFM tables/task-lists.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

