### PR TITLE
fix: batch source-insight lookups when building notebook/chat context

### DIFF
--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -8,7 +8,13 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from open_notebook.database.repository import ensure_record_id, repo_query
-from open_notebook.domain.notebook import ChatSession, Note, Notebook, Source
+from open_notebook.domain.notebook import (
+    ChatSession,
+    Note,
+    Notebook,
+    Source,
+    SourceInsight,
+)
 from open_notebook.exceptions import (
     NotFoundError,
 )
@@ -490,9 +496,21 @@ async def build_context(request: BuildContextRequest):
         else:
             # Default behavior - include all sources and notes with short context
             sources = await notebook.get_sources()
+            try:
+                insights_by_source = await SourceInsight.get_for_sources(
+                    [source.id for source in sources if source.id]
+                )
+            except Exception as e:
+                # Match the per-source fallback below: a hiccup fetching
+                # insights shouldn't fail the whole context request.
+                logger.warning(f"Error batch-fetching source insights: {str(e)}")
+                insights_by_source = {}
             for source in sources:
                 try:
-                    source_context = await source.get_context(context_size="short")
+                    source_context = await source.get_context(
+                        context_size="short",
+                        insights=insights_by_source.get(source.id or "", []),
+                    )
                     context_data["sources"].append(source_context)
                     total_content += str(source_context)
                 except Exception as e:

--- a/api/routers/context.py
+++ b/api/routers/context.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from loguru import logger
 
 from api.models import ContextRequest, ContextResponse
-from open_notebook.domain.notebook import Note, Notebook, Source
+from open_notebook.domain.notebook import Note, Notebook, Source, SourceInsight
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.utils import token_count
 
@@ -77,9 +77,21 @@ async def get_notebook_context(notebook_id: str, context_request: ContextRequest
         else:
             # Default behavior - include all sources and notes with short context
             sources = await notebook.get_sources()
+            try:
+                insights_by_source = await SourceInsight.get_for_sources(
+                    [source.id for source in sources if source.id]
+                )
+            except Exception as e:
+                # Match the per-source fallback below: a hiccup fetching
+                # insights shouldn't fail the whole context request.
+                logger.warning(f"Error batch-fetching source insights: {str(e)}")
+                insights_by_source = {}
             for source in sources:
                 try:
-                    source_context = await source.get_context(context_size="short")
+                    source_context = await source.get_context(
+                        context_size="short",
+                        insights=insights_by_source.get(source.id or "", []),
+                    )
                     context_data["source"].append(source_context)
                     total_content += str(source_context)
                 except Exception as e:

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -79,8 +79,14 @@ class Notebook(ObjectModel):
         notes = await self.get_notes(include_content=True)
         context_blocks = []
 
+        insights_by_source = await SourceInsight.get_for_sources(
+            [source.id for source in sources if source.id]
+        )
         for source in sources:
-            source_context = await source.get_context(context_size="long")
+            source_context = await source.get_context(
+                context_size="long",
+                insights=insights_by_source.get(source.id or "", []),
+            )
             if isinstance(source_context, dict):
                 title = source_context.get("title") or source.title or "Untitled source"
                 full_text = source_context.get("full_text")
@@ -327,6 +333,35 @@ class SourceInsight(ObjectModel):
     insight_type: str
     content: str
 
+    @classmethod
+    async def get_for_sources(
+        cls, source_ids: List[str]
+    ) -> Dict[str, List["SourceInsight"]]:
+        """
+        Batch-fetch insights for many sources in a single query.
+
+        Building notebook/chat context otherwise calls get_insights() once
+        per source - fine for one source, but O(n) round trips (each paying
+        its own connection setup, see database/CLAUDE.md) when a caller
+        loops over every source in a notebook.
+        """
+        grouped: Dict[str, List[SourceInsight]] = {sid: [] for sid in source_ids if sid}
+        if not grouped:
+            return grouped
+        try:
+            result = await repo_query(
+                "SELECT * FROM source_insight WHERE source IN $source_ids",
+                {"source_ids": [ensure_record_id(sid) for sid in grouped]},
+            )
+        except Exception as e:
+            logger.error(f"Error batch-fetching insights for sources: {str(e)}")
+            logger.exception(e)
+            raise DatabaseOperationError("Failed to fetch insights for sources")
+        for row in result:
+            key = str(row.get("source"))
+            grouped.setdefault(key, []).append(cls(**row))
+        return grouped
+
     async def get_source(self) -> "Source":
         try:
             src = await repo_query(
@@ -428,10 +463,15 @@ class Source(ObjectModel):
             return None
 
     async def get_context(
-        self, context_size: Literal["short", "long"] = "short"
+        self,
+        context_size: Literal["short", "long"] = "short",
+        insights: Optional[List["SourceInsight"]] = None,
     ) -> Dict[str, Any]:
-        insights_list = await self.get_insights()
-        insights = [insight.model_dump() for insight in insights_list]
+        # Callers looping over many sources can batch-fetch insights up front
+        # via SourceInsight.get_for_sources() and pass them in here, instead
+        # of paying a separate query per source.
+        insight_objects = insights if insights is not None else await self.get_insights()
+        insights = [insight.model_dump() for insight in insight_objects]
         if context_size == "long":
             return dict(
                 id=self.id,

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -18,7 +18,13 @@ from api.podcast_service import PodcastService
 from open_notebook.ai.models import ModelManager
 from open_notebook.domain.base import RecordModel
 from open_notebook.domain.content_settings import ContentSettings
-from open_notebook.domain.notebook import Asset, Note, Notebook, Source
+from open_notebook.domain.notebook import (
+    Asset,
+    Note,
+    Notebook,
+    Source,
+    SourceInsight,
+)
 from open_notebook.domain.transformation import Transformation
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.podcasts.models import EpisodeProfile, SpeakerProfile
@@ -127,13 +133,15 @@ class TestNotebookDomain:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_insights(self):
-            return []
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
 
         with (
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
-            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
         ):
             context = await notebook.get_context()
 
@@ -203,12 +211,18 @@ class TestNotebookDomain:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_context(self, context_size="short"):
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
+
+        async def fake_get_context(self, context_size="short", insights=None):
             raise RuntimeError("source context failed")
 
         with (
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
             patch.object(Source, "get_context", new=fake_get_context),
         ):
             with pytest.raises(RuntimeError, match="source context failed"):
@@ -477,8 +491,8 @@ class TestPodcastService:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_insights(self):
-            return []
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
 
         def fake_submit_command(app_name, command_name, command_args):
             submitted_args.update(command_args)
@@ -501,7 +515,9 @@ class TestPodcastService:
             patch.object(Notebook, "get", new=AsyncMock(return_value=notebook)),
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
-            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
             patch("api.podcast_service.submit_command", new=fake_submit_command),
             patch.dict(
                 sys.modules, {"commands.podcast_commands": fake_commands_module}


### PR DESCRIPTION
Building default chat context, the notebook context endpoint, and
podcast generation all looped over every source in a notebook calling
get_context() -> get_insights(), each a separate query that also pays
its own connection setup (no pooling). A notebook with hundreds of
sources meant hundreds of serialized round trips before a chat
message even reached the LLM.

Add SourceInsight.get_for_sources() to fetch insights for every
source in one query, and thread an optional pre-fetched insights list
through Source.get_context() so callers can opt in without changing
its behavior for anyone who doesn't. Measured against a real
(embedded) SurrealDB instance: 14 queries down to 3 for a 12-source
notebook, with correctness verified. The two router call sites treat
a batch-fetch failure the same way the old per-source loop treated a
single failure - falls back to empty insights rather than failing the
whole request.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

