### PR TITLE
fix: run file upload writes off the event loop

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -96,18 +96,12 @@ def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
         counter += 1
 
 
-async def save_uploaded_file(upload_file: UploadFile) -> str:
-    """Save uploaded file to uploads folder and return file path."""
-    if not upload_file.filename:
-        raise ValueError("No filename provided")
-
-    # Generate unique filename
-    file_path = generate_unique_filename(upload_file.filename, UPLOADS_FOLDER)
-
+def _write_uploaded_file(filename: str, content: bytes) -> str:
+    """Sync filesystem work for save_uploaded_file() - run via asyncio.to_thread
+    so a large upload doesn't block the event loop for other requests."""
+    file_path = generate_unique_filename(filename, UPLOADS_FOLDER)
     try:
-        # Save file
         with open(file_path, "wb") as f:
-            content = await upload_file.read()
             f.write(content)
 
         logger.info(f"Saved uploaded file to: {file_path}")
@@ -118,6 +112,15 @@ async def save_uploaded_file(upload_file: UploadFile) -> str:
         if os.path.exists(file_path):
             os.unlink(file_path)
         raise
+
+
+async def save_uploaded_file(upload_file: UploadFile) -> str:
+    """Save uploaded file to uploads folder and return file path."""
+    if not upload_file.filename:
+        raise ValueError("No filename provided")
+
+    content = await upload_file.read()
+    return await asyncio.to_thread(_write_uploaded_file, upload_file.filename, content)
 
 
 def parse_source_form_data(


### PR DESCRIPTION
save_uploaded_file() did a plain synchronous open()/write() directly
in the async create_source handler, blocking the event loop - and
every other concurrent request - for the duration of a large upload.
Same bug class the recent chat-graph fix (#971) addressed, just not
applied here.

Move the filesystem work (filename resolution + write) into a sync
helper run via asyncio.to_thread(), matching the pattern already used
for execute_command_sync elsewhere in this file. Confirmed the event
loop stays responsive (ticking normally) during a simulated slow
write, and that errors/cleanup still propagate correctly through the
thread.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

