### PR TITLE
chore: gitignore local codebase-graphing tool output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ specs/
 .harness/
 
 .mcp.json
+
+# Codebase-graphing tool output (local analysis artifacts, not part of the project)
+graphify-out/


### PR DESCRIPTION
graphify-out/ is a local analysis-tool output directory (cache, graph.json/html, reports) that isn't part of the project - exclude it so it doesn't get swept into commits by an incautious git add -A.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

