### PR TITLE
fix: don't leak filesystem info via Vertex credential test errors

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -220,6 +220,7 @@ The `/credentials/{credential_id}/test` endpoint uses minimal API calls to verif
 - Uses cheapest/smallest models per provider (TEST_MODELS map)
 - Returns success status and descriptive message
 - Special handlers for ollama, openai_compatible, and azure providers
+- Vertex-specific: `credentials_path` is free text with no path validation, and Google's auth library raises distinguishable exceptions for "file missing"/"not JSON"/"wrong shape" - `_is_vertex_credentials_file_error()` catches all three and returns one generic "Invalid or inaccessible credentials file" message (both here and in `test_individual_model()`) so testing a credential can't be used as a filesystem oracle
 
 ### Migration Workflows
 

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -265,6 +265,7 @@ async def test_credential(credential_id: str) -> dict:
         config = cred.to_esperanto_config()
 
         from open_notebook.ai.connection_tester import (
+            _is_vertex_credentials_file_error,
             _test_azure_connection,
             _test_ollama_connection,
             _test_openai_compatible_connection,
@@ -350,6 +351,14 @@ async def test_credential(credential_id: str) -> dict:
         }
 
     except Exception as e:
+        if provider == "vertex" and _is_vertex_credentials_file_error(e):
+            logger.debug(f"Vertex credentials file error for credential {credential_id}: {e}")
+            return {
+                "provider": provider,
+                "success": False,
+                "message": "Invalid or inaccessible credentials file",
+            }
+
         error_msg = str(e)
         if "401" in error_msg or "unauthorized" in error_msg.lower():
             return {"provider": provider, "success": False, "message": "Invalid API key"}

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -32,9 +32,18 @@ def _is_vertex_credentials_file_error(exc: Exception) -> bool:
     create/test a Vertex credential could probe for the existence and
     contents-shape of arbitrary files on the server. Callers should catch
     these and return one generic message instead of the raw exception text.
-    """
-    from google.auth.exceptions import GoogleAuthError
 
+    Network failures are excluded even though they'd otherwise match
+    (ConnectionError/TimeoutError are OSError subclasses, TransportError a
+    GoogleAuthError subclass): they say nothing about the credentials file,
+    and classifying them here would tell a user with a blocked network to
+    go debug their file path. Letting them fall through reveals only the
+    error's category ("connection error"), which keeps the oracle closed.
+    """
+    from google.auth.exceptions import GoogleAuthError, TransportError
+
+    if isinstance(exc, (ConnectionError, TimeoutError, TransportError)):
+        return False
     return isinstance(exc, (OSError, json.JSONDecodeError, GoogleAuthError))
 
 

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -6,6 +6,7 @@ by making minimal API calls to each provider, and to test individual model
 configurations end-to-end.
 """
 import io
+import json
 import os
 import struct
 from typing import Optional, Tuple
@@ -14,6 +15,28 @@ import httpx
 from loguru import logger
 
 from open_notebook.utils.url_validation import validate_url
+
+
+def _is_vertex_credentials_file_error(exc: Exception) -> bool:
+    """
+    True if `exc` came from loading a Vertex service-account file
+    (credentials_path - free text, no path validation; see
+    open_notebook/ai/key_provider.py).
+
+    Google's auth library raises distinguishable exceptions for "file
+    missing" (FileNotFoundError, an OSError), "not valid JSON"
+    (json.JSONDecodeError), and "valid JSON but wrong shape"
+    (google.auth.exceptions.GoogleAuthError) - confirmed by direct
+    reproduction. Echoing any of these back to an API caller turns
+    credential/model testing into a filesystem oracle: an attacker who can
+    create/test a Vertex credential could probe for the existence and
+    contents-shape of arbitrary files on the server. Callers should catch
+    these and return one generic message instead of the raw exception text.
+    """
+    from google.auth.exceptions import GoogleAuthError
+
+    return isinstance(exc, (OSError, json.JSONDecodeError, GoogleAuthError))
+
 
 # Test models for each provider - uses minimal/cheapest models for testing
 # Format: (model_name, model_type)
@@ -337,6 +360,10 @@ async def test_individual_model(model) -> Tuple[bool, str]:
             return False, f"Unsupported model type: {model.type}"
 
     except Exception as e:
+        if model.provider == "vertex" and _is_vertex_credentials_file_error(e):
+            logger.debug(f"Vertex credentials file error for model {model.id}: {e}")
+            return False, "Invalid or inaccessible credentials file"
+
         error_msg = str(e)
         success, normalized = _normalize_error_message(error_msg)
         if success:

--- a/tests/test_vertex_credentials_file_oracle.py
+++ b/tests/test_vertex_credentials_file_oracle.py
@@ -1,0 +1,164 @@
+"""
+Tests for the Vertex credentials_path file-existence oracle fix.
+
+credentials_path (Vertex service-account file path) is free text with no
+path validation (open_notebook/ai/key_provider.py sets it directly as
+GOOGLE_APPLICATION_CREDENTIALS). Google's auth library raises
+distinguishable exceptions - confirmed by direct reproduction against the
+real library - for "file missing" (FileNotFoundError), "not valid JSON"
+(json.JSONDecodeError), and "valid JSON but wrong shape"
+(google.auth.exceptions.GoogleAuthError). Both api/credentials_service.py's
+test_credential() (POST /credentials/{id}/test) and
+connection_tester.py's test_individual_model() (POST /models/{id}/test)
+used to echo the raw exception text (up to 100 chars, or the entire message
+for test_individual_model) back to the API caller, including the
+attacker-supplied path - turning credential/model testing into a
+filesystem oracle for an attacker who can create/test a Vertex credential.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_notebook.ai.connection_tester import _is_vertex_credentials_file_error
+from open_notebook.ai.connection_tester import (
+    test_individual_model as run_individual_model_test,
+)
+
+
+def real_google_auth_exception(credentials_path: str) -> Exception:
+    """Drives the real google.oauth2.service_account library to get a
+    genuine exception object, rather than guessing at its shape."""
+    from google.oauth2 import service_account
+
+    try:
+        service_account.Credentials.from_service_account_file(
+            credentials_path,
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        raise AssertionError("expected from_service_account_file to raise")
+    except Exception as e:
+        return e
+
+
+class TestIsVertexCredentialsFileError:
+    def test_classifies_missing_file(self, tmp_path):
+        exc = real_google_auth_exception(str(tmp_path / "does-not-exist.json"))
+        assert isinstance(exc, FileNotFoundError)
+        assert _is_vertex_credentials_file_error(exc) is True
+
+    def test_classifies_invalid_json(self, tmp_path):
+        bad_json = tmp_path / "bad.json"
+        bad_json.write_text("not valid json {{{")
+        exc = real_google_auth_exception(str(bad_json))
+        assert _is_vertex_credentials_file_error(exc) is True
+
+    def test_classifies_wrong_shape_json(self, tmp_path):
+        wrong_shape = tmp_path / "wrong_shape.json"
+        wrong_shape.write_text('{"foo": "bar"}')
+        exc = real_google_auth_exception(str(wrong_shape))
+        assert _is_vertex_credentials_file_error(exc) is True
+
+    def test_does_not_misclassify_unrelated_errors(self):
+        assert _is_vertex_credentials_file_error(ValueError("some other error")) is False
+        assert _is_vertex_credentials_file_error(RuntimeError("rate limited")) is False
+
+
+class TestTestCredentialClosesOracle:
+    @pytest.mark.asyncio
+    async def test_missing_and_invalid_json_produce_identical_generic_message(
+        self, tmp_path
+    ):
+        """The core of the fix: two scenarios that used to be
+        distinguishable via the response message must now be identical."""
+        from open_notebook.domain.credential import Credential
+
+        missing_exc = real_google_auth_exception(str(tmp_path / "missing.json"))
+        bad_json = tmp_path / "bad.json"
+        bad_json.write_text("not json {{{")
+        invalid_exc = real_google_auth_exception(str(bad_json))
+
+        cred = MagicMock(spec=Credential)
+        cred.provider = "vertex"
+        cred.to_esperanto_config.return_value = {"project": "p", "location": "us-central1"}
+
+        from api.credentials_service import test_credential
+
+        with patch(
+            "open_notebook.domain.credential.Credential.get",
+            new=AsyncMock(return_value=cred),
+        ):
+            with patch(
+                "esperanto.factory.AIFactory.create_language", side_effect=missing_exc
+            ):
+                result_missing = await test_credential("credential:test")
+            with patch(
+                "esperanto.factory.AIFactory.create_language", side_effect=invalid_exc
+            ):
+                result_invalid = await test_credential("credential:test")
+
+        assert result_missing["message"] == "Invalid or inaccessible credentials file"
+        assert result_invalid["message"] == "Invalid or inaccessible credentials file"
+        assert result_missing["message"] == result_invalid["message"]
+        assert str(tmp_path) not in result_missing["message"]
+
+    @pytest.mark.asyncio
+    async def test_non_vertex_provider_still_gets_detailed_message(self):
+        """Only vertex has this specific file-existence oracle risk - other
+        providers should be unaffected by the generic-message guard."""
+        from open_notebook.domain.credential import Credential
+
+        cred = MagicMock(spec=Credential)
+        cred.provider = "openai"
+        cred.to_esperanto_config.return_value = {"api_key": "sk-fake"}
+
+        from api.credentials_service import test_credential
+
+        with (
+            patch(
+                "open_notebook.domain.credential.Credential.get",
+                new=AsyncMock(return_value=cred),
+            ),
+            patch(
+                "esperanto.factory.AIFactory.create_language",
+                side_effect=FileNotFoundError("unrelated file issue"),
+            ),
+        ):
+            result = await test_credential("credential:test")
+
+        assert result["message"] != "Invalid or inaccessible credentials file"
+
+
+class TestIndividualModelClosesOracle:
+    @pytest.mark.asyncio
+    async def test_missing_credentials_file_returns_generic_message(self, tmp_path):
+        exc = real_google_auth_exception(str(tmp_path / "missing.json"))
+        model = MagicMock(id="model:vertex1", provider="vertex", type="language")
+
+        manager_instance = MagicMock()
+        manager_instance.get_model = AsyncMock(side_effect=exc)
+
+        with patch(
+            "open_notebook.ai.models.ModelManager", return_value=manager_instance
+        ):
+            success, message = await run_individual_model_test(model)
+
+        assert success is False
+        assert message == "Invalid or inaccessible credentials file"
+        assert str(tmp_path) not in message
+
+    @pytest.mark.asyncio
+    async def test_non_vertex_provider_still_gets_detailed_message(self):
+        model = MagicMock(id="model:openai1", provider="openai", type="language")
+
+        manager_instance = MagicMock()
+        manager_instance.get_model = AsyncMock(
+            side_effect=FileNotFoundError("unrelated file issue")
+        )
+
+        with patch(
+            "open_notebook.ai.models.ModelManager", return_value=manager_instance
+        ):
+            success, message = await run_individual_model_test(model)
+
+        assert message != "Invalid or inaccessible credentials file"

--- a/tests/test_vertex_credentials_file_oracle.py
+++ b/tests/test_vertex_credentials_file_oracle.py
@@ -63,6 +63,19 @@ class TestIsVertexCredentialsFileError:
         assert _is_vertex_credentials_file_error(ValueError("some other error")) is False
         assert _is_vertex_credentials_file_error(RuntimeError("rate limited")) is False
 
+    def test_does_not_misclassify_network_errors(self):
+        # ConnectionError/TimeoutError are OSError subclasses and
+        # TransportError is a GoogleAuthError subclass, so without an
+        # explicit exclusion a blocked network would surface as "Invalid or
+        # inaccessible credentials file" - a false lead. They must fall
+        # through to the normal connection-error handling instead.
+        from google.auth.exceptions import TransportError
+
+        assert _is_vertex_credentials_file_error(ConnectionError("connection refused")) is False
+        assert _is_vertex_credentials_file_error(ConnectionRefusedError("refused")) is False
+        assert _is_vertex_credentials_file_error(TimeoutError("timed out")) is False
+        assert _is_vertex_credentials_file_error(TransportError("failed to connect")) is False
+
 
 class TestTestCredentialClosesOracle:
     @pytest.mark.asyncio


### PR DESCRIPTION
Vertex's `credentials_path` is free text with no path validation, and Google's auth library raises distinguishable exceptions for "file missing" (OSError), "not valid JSON" (json.JSONDecodeError), and "valid JSON but wrong shape" (GoogleAuthError). Echoing any of these back to an API caller turns credential/model testing into a filesystem oracle - an attacker who can create/test a Vertex credential could probe for the existence and contents-shape of arbitrary files on the server.

`_is_vertex_credentials_file_error()` catches all three and both call sites (`api/credentials_service.py`'s `test_credential`, `connection_tester`'s `test_individual_model`) return one generic message instead.

**Stacked on #1002-#1009** (unmerged): branched from `main`, which already includes those. `tests/test_vertex_credentials_file_oracle.py` passes (8/8).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

