### PR TITLE
fix: don't combine wildcard CORS origins with allow_credentials

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -99,7 +99,7 @@ FastAPI application serving three architectural layers: routes (HTTP endpoints),
 - **Graph invocation is blocking**: chat/podcast workflows may take minutes; no timeout handling in services
 - **Command job fire-and-forget**: podcast_service.py submits jobs but doesn't wait (async job queue pattern)
 - **Model override scoping**: Model config override via RunnableConfig is per-request only (not persistent)
-- **CORS open by default**: main.py CORS settings allow all origins (restrict before production)
+- **CORS open by default**: main.py CORS settings allow all origins (restrict before production) via `CORS_ORIGINS`. `allow_credentials` is tied to that: `False` for the default wildcard (combining wildcard + credentials would make Starlette reflect any Origin), automatically `True` once `CORS_ORIGINS` is scoped to explicit origins
 - **No OpenAPI security scheme**: API docs available without auth (disable before production)
 - **Services don't validate user permission**: All endpoints trust authentication layer; no per-notebook permission checks
 

--- a/api/main.py
+++ b/api/main.py
@@ -82,13 +82,17 @@ def _cors_headers(request: Request) -> dict[str, str]:
     browsers reject `Access-Control-Allow-Origin: *` combined with
     credentials). Omits `Access-Control-Allow-Origin` for disallowed
     origins so the browser blocks the error body from leaking cross-origin.
+    Only claims Access-Control-Allow-Credentials when the real CORSMiddleware
+    would (see its allow_credentials comment above) - otherwise error
+    responses would grant credentialed access the success path doesn't.
     """
     origin = request.headers.get("origin")
     headers: dict[str, str] = {
-        "Access-Control-Allow-Credentials": "true",
         "Access-Control-Allow-Methods": "*",
         "Access-Control-Allow-Headers": "*",
     }
+    if not CORS_IS_DEFAULT_WILDCARD:
+        headers["Access-Control-Allow-Credentials"] = "true"
 
     if origin and ("*" in CORS_ALLOWED_ORIGINS or origin in CORS_ALLOWED_ORIGINS):
         headers["Access-Control-Allow-Origin"] = origin
@@ -235,10 +239,21 @@ app.add_middleware(
 )
 
 # Add CORS middleware last (so it processes first)
+#
+# allow_credentials is tied to whether CORS_ORIGINS was explicitly scoped:
+# combining allow_origins=["*"] with allow_credentials=True makes Starlette
+# reflect the request's Origin header verbatim (browsers reject a literal
+# "*" alongside credentials), which defeats the origin allowlist. The
+# frontend never sends credentialed requests (withCredentials: false) and
+# auth is a Bearer header, not a cookie, so this isn't independently
+# exploitable today - but there's no reason to allow it for the default
+# wildcard case. Once an operator explicitly scopes CORS_ORIGINS to real
+# origins, credentialed cross-origin requests to those origins are safe to
+# allow again.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ALLOWED_ORIGINS,
-    allow_credentials=True,
+    allow_credentials=not CORS_IS_DEFAULT_WILDCARD,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/api/main.py
+++ b/api/main.py
@@ -63,6 +63,11 @@ def _parse_cors_origins(raw: str) -> list[str]:
 _cors_origins_raw = os.getenv("CORS_ORIGINS")
 CORS_ALLOWED_ORIGINS = _parse_cors_origins(_cors_origins_raw or "*")
 CORS_IS_DEFAULT_WILDCARD = _cors_origins_raw is None
+# Keyed on the parsed list, not on whether the env var was set: an operator
+# who explicitly sets CORS_ORIGINS=* must get the same wildcard treatment as
+# the default, or credentials would combine with a wildcard origin - the
+# exact reflect-any-Origin behavior this flag exists to prevent.
+CORS_ALLOW_CREDENTIALS = "*" not in CORS_ALLOWED_ORIGINS
 
 DATABASE_STARTUP_RETRY_ATTEMPTS = 12
 DATABASE_STARTUP_RETRY_INITIAL_DELAY_SECONDS = 1
@@ -91,7 +96,7 @@ def _cors_headers(request: Request) -> dict[str, str]:
         "Access-Control-Allow-Methods": "*",
         "Access-Control-Allow-Headers": "*",
     }
-    if not CORS_IS_DEFAULT_WILDCARD:
+    if CORS_ALLOW_CREDENTIALS:
         headers["Access-Control-Allow-Credentials"] = "true"
 
     if origin and ("*" in CORS_ALLOWED_ORIGINS or origin in CORS_ALLOWED_ORIGINS):
@@ -253,7 +258,7 @@ app.add_middleware(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ALLOWED_ORIGINS,
-    allow_credentials=not CORS_IS_DEFAULT_WILDCARD,
+    allow_credentials=CORS_ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/docs/7-DEVELOPMENT/security.md
+++ b/docs/7-DEVELOPMENT/security.md
@@ -146,7 +146,7 @@ Open Notebook currently uses simple password-based middleware (`PasswordAuthMidd
 
 ### CORS
 
-The default CORS configuration allows all origins (`allow_origins=["*"]`). This is tracked for improvement in [#730](https://github.com/lfnovo/open-notebook/issues/730). For production deployments, restrict origins to only the frontend URL.
+The default CORS configuration allows all origins (`allow_origins=["*"]`). `allow_credentials` is tied to that: `False` for the default wildcard (avoids Starlette reflecting any Origin alongside credentials), automatically `True` once `CORS_ORIGINS` is explicitly scoped to specific origins. For production deployments, still restrict `CORS_ORIGINS` to only the frontend URL.
 
 ---
 

--- a/tests/test_cors_credentials.py
+++ b/tests/test_cors_credentials.py
@@ -5,9 +5,9 @@ Combining allow_origins=["*"] with allow_credentials=True makes Starlette's
 CORSMiddleware reflect the request's Origin header verbatim instead of
 returning a literal "*" (browsers reject a literal wildcard alongside
 credentials) - defeating the origin allowlist for any credentialed request.
-allow_credentials is now tied to whether CORS_ORIGINS was explicitly scoped:
-False for the default wildcard, True once an operator opts into specific
-origins.
+allow_credentials is now keyed on the parsed origins list: False whenever it
+contains "*" (whether from the unset default or an explicit CORS_ORIGINS=*),
+True once an operator scopes CORS_ORIGINS to specific origins.
 """
 
 from starlette.middleware.cors import CORSMiddleware
@@ -23,6 +23,7 @@ class TestRealAppDefaultsToNoCredentialsWithWildcard:
     def test_default_test_environment_is_wildcard(self):
         assert api_main.CORS_IS_DEFAULT_WILDCARD is True
         assert api_main.CORS_ALLOWED_ORIGINS == ["*"]
+        assert api_main.CORS_ALLOW_CREDENTIALS is False
 
     def test_cors_middleware_registered_with_credentials_disabled(self):
         matches = [
@@ -45,22 +46,28 @@ class TestRealAppDefaultsToNoCredentialsWithWildcard:
         assert response.headers.get("access-control-allow-origin") in ("*", "https://evil.example.com")
 
 
-class TestAllowCredentialsFormula:
-    """Direct check of the allow_credentials = not CORS_IS_DEFAULT_WILDCARD
-    formula for the case the live test environment can't easily cover
-    in-process (CORS_ORIGINS explicitly set) - CORS_IS_DEFAULT_WILDCARD is
-    fixed at api.main import time from the environment, so this proves the
-    formula's behavior directly rather than reloading the module."""
+class TestExplicitWildcardAlsoDisablesCredentials:
+    """An operator who sets CORS_ORIGINS=* explicitly must get the same
+    treatment as the unset default. The predicate keys on the parsed list
+    containing "*", not on whether the env var was set - keying on the env
+    var would reintroduce the exact reflect-any-Origin behavior this fix
+    prevents. CORS_ALLOW_CREDENTIALS is fixed at api.main import time, so
+    these exercise the real parser plus the same expression used there."""
 
-    def test_wildcard_default_disables_credentials(self):
-        cors_origins_raw = None  # CORS_ORIGINS unset
-        is_default_wildcard = cors_origins_raw is None
-        assert (not is_default_wildcard) is False
+    def test_explicit_wildcard_disables_credentials(self):
+        origins = api_main._parse_cors_origins("*")
+        assert origins == ["*"]
+        assert ("*" not in origins) is False
 
-    def test_explicit_origins_enables_credentials(self):
-        cors_origins_raw = "https://notebook.example.com"
-        is_default_wildcard = cors_origins_raw is None
-        assert (not is_default_wildcard) is True
+    def test_explicit_origins_enable_credentials(self):
+        origins = api_main._parse_cors_origins(
+            "https://notebook.example.com, https://other.example.com"
+        )
+        assert origins == [
+            "https://notebook.example.com",
+            "https://other.example.com",
+        ]
+        assert ("*" not in origins) is True
 
 
 class TestCorsHeadersHelperMatchesMiddlewarePolicy:
@@ -68,8 +75,8 @@ class TestCorsHeadersHelperMatchesMiddlewarePolicy:
     responses (for errors raised before CORSMiddleware runs) - it must not
     grant credentials the real middleware wouldn't."""
 
-    def test_omits_allow_credentials_header_for_wildcard_default(self, monkeypatch):
-        monkeypatch.setattr(api_main, "CORS_IS_DEFAULT_WILDCARD", True)
+    def test_omits_allow_credentials_header_for_wildcard(self, monkeypatch):
+        monkeypatch.setattr(api_main, "CORS_ALLOW_CREDENTIALS", False)
         monkeypatch.setattr(api_main, "CORS_ALLOWED_ORIGINS", ["*"])
 
         class FakeRequest:
@@ -79,7 +86,7 @@ class TestCorsHeadersHelperMatchesMiddlewarePolicy:
         assert "Access-Control-Allow-Credentials" not in headers
 
     def test_includes_allow_credentials_header_for_explicit_origins(self, monkeypatch):
-        monkeypatch.setattr(api_main, "CORS_IS_DEFAULT_WILDCARD", False)
+        monkeypatch.setattr(api_main, "CORS_ALLOW_CREDENTIALS", True)
         monkeypatch.setattr(
             api_main, "CORS_ALLOWED_ORIGINS", ["https://notebook.example.com"]
         )
@@ -91,7 +98,7 @@ class TestCorsHeadersHelperMatchesMiddlewarePolicy:
         assert headers["Access-Control-Allow-Credentials"] == "true"
 
     def test_disallowed_origin_still_gets_no_allow_origin_header(self, monkeypatch):
-        monkeypatch.setattr(api_main, "CORS_IS_DEFAULT_WILDCARD", False)
+        monkeypatch.setattr(api_main, "CORS_ALLOW_CREDENTIALS", True)
         monkeypatch.setattr(
             api_main, "CORS_ALLOWED_ORIGINS", ["https://notebook.example.com"]
         )

--- a/tests/test_cors_credentials.py
+++ b/tests/test_cors_credentials.py
@@ -1,0 +1,103 @@
+"""
+Tests for the CORS wildcard + allow_credentials fix (api/main.py).
+
+Combining allow_origins=["*"] with allow_credentials=True makes Starlette's
+CORSMiddleware reflect the request's Origin header verbatim instead of
+returning a literal "*" (browsers reject a literal wildcard alongside
+credentials) - defeating the origin allowlist for any credentialed request.
+allow_credentials is now tied to whether CORS_ORIGINS was explicitly scoped:
+False for the default wildcard, True once an operator opts into specific
+origins.
+"""
+
+from starlette.middleware.cors import CORSMiddleware
+from starlette.testclient import TestClient
+
+from api import main as api_main
+
+
+class TestRealAppDefaultsToNoCredentialsWithWildcard:
+    """The test environment has no CORS_ORIGINS set, matching the shipped
+    default - this validates the actual registered app, not a simulation."""
+
+    def test_default_test_environment_is_wildcard(self):
+        assert api_main.CORS_IS_DEFAULT_WILDCARD is True
+        assert api_main.CORS_ALLOWED_ORIGINS == ["*"]
+
+    def test_cors_middleware_registered_with_credentials_disabled(self):
+        matches = [
+            m for m in api_main.app.user_middleware if m.cls is CORSMiddleware
+        ]
+        assert len(matches) == 1
+        assert matches[0].kwargs["allow_credentials"] is False
+
+    def test_real_response_does_not_claim_allow_credentials(self):
+        client = TestClient(api_main.app)
+        response = client.get(
+            "/health", headers={"Origin": "https://evil.example.com"}
+        )
+        assert response.status_code == 200
+        assert "access-control-allow-credentials" not in {
+            k.lower() for k in response.headers.keys()
+        }
+        # Still reflects the origin (wildcard-equivalent), just without
+        # granting credentialed access.
+        assert response.headers.get("access-control-allow-origin") in ("*", "https://evil.example.com")
+
+
+class TestAllowCredentialsFormula:
+    """Direct check of the allow_credentials = not CORS_IS_DEFAULT_WILDCARD
+    formula for the case the live test environment can't easily cover
+    in-process (CORS_ORIGINS explicitly set) - CORS_IS_DEFAULT_WILDCARD is
+    fixed at api.main import time from the environment, so this proves the
+    formula's behavior directly rather than reloading the module."""
+
+    def test_wildcard_default_disables_credentials(self):
+        cors_origins_raw = None  # CORS_ORIGINS unset
+        is_default_wildcard = cors_origins_raw is None
+        assert (not is_default_wildcard) is False
+
+    def test_explicit_origins_enables_credentials(self):
+        cors_origins_raw = "https://notebook.example.com"
+        is_default_wildcard = cors_origins_raw is None
+        assert (not is_default_wildcard) is True
+
+
+class TestCorsHeadersHelperMatchesMiddlewarePolicy:
+    """api/main.py's _cors_headers() manually builds CORS headers for error
+    responses (for errors raised before CORSMiddleware runs) - it must not
+    grant credentials the real middleware wouldn't."""
+
+    def test_omits_allow_credentials_header_for_wildcard_default(self, monkeypatch):
+        monkeypatch.setattr(api_main, "CORS_IS_DEFAULT_WILDCARD", True)
+        monkeypatch.setattr(api_main, "CORS_ALLOWED_ORIGINS", ["*"])
+
+        class FakeRequest:
+            headers = {"origin": "https://evil.example.com"}
+
+        headers = api_main._cors_headers(FakeRequest())
+        assert "Access-Control-Allow-Credentials" not in headers
+
+    def test_includes_allow_credentials_header_for_explicit_origins(self, monkeypatch):
+        monkeypatch.setattr(api_main, "CORS_IS_DEFAULT_WILDCARD", False)
+        monkeypatch.setattr(
+            api_main, "CORS_ALLOWED_ORIGINS", ["https://notebook.example.com"]
+        )
+
+        class FakeRequest:
+            headers = {"origin": "https://notebook.example.com"}
+
+        headers = api_main._cors_headers(FakeRequest())
+        assert headers["Access-Control-Allow-Credentials"] == "true"
+
+    def test_disallowed_origin_still_gets_no_allow_origin_header(self, monkeypatch):
+        monkeypatch.setattr(api_main, "CORS_IS_DEFAULT_WILDCARD", False)
+        monkeypatch.setattr(
+            api_main, "CORS_ALLOWED_ORIGINS", ["https://notebook.example.com"]
+        )
+
+        class FakeRequest:
+            headers = {"origin": "https://evil.example.com"}
+
+        headers = api_main._cors_headers(FakeRequest())
+        assert "Access-Control-Allow-Origin" not in headers


### PR DESCRIPTION
Combining `allow_origins=["*"]` with `allow_credentials=True` makes Starlette's CORSMiddleware reflect the request's Origin header verbatim instead of returning a literal `*` (browsers reject a literal wildcard alongside credentials) - defeating the origin allowlist for any credentialed request.

`allow_credentials` is now tied to whether `CORS_ORIGINS` was explicitly scoped: `False` for the default wildcard, `True` once an operator opts into specific origins. `_cors_headers()` (the manual CORS builder for error responses raised before CORSMiddleware runs) is updated to match, so it can't grant credentials the real middleware wouldn't.

Not independently exploitable today (the frontend never sends credentialed requests, and auth is a Bearer header, not a cookie), but there's no reason to allow it for the default wildcard case.

**Stacked on #1002-#1009** (unmerged). `tests/test_cors_credentials.py` passes (8/8).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

