### PR TITLE
fix: reject oversized request bodies before auth/routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@ SURREAL_DATABASE=open_notebook
 # CHUNK_SIZE=1500
 # CHUNK_OVERLAP=150
 
+# Maximum upload/request body size in MB (default: 100). Raise this if you
+# need to upload larger audio/video files. A fronting reverse proxy's own
+# limit (e.g. nginx client_max_body_size) still applies and should be raised
+# to match.
+# OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB=100
+
 # Security
 # BASIC_AUTH_USERNAME=admin
 # BASIC_AUTH_PASSWORD=secret

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -35,6 +35,7 @@ FastAPI application serving three architectural layers: routes (HTTP endpoints),
 - **main.py**: FastAPI app initialization, CORS setup, auth middleware, lifespan event, router registration
 - **Lifespan handler**: Runs AsyncMigrationManager on startup (database schema migration)
 - **Auth middleware**: PasswordAuthMiddleware protects endpoints (password-based access control)
+- **Body size middleware**: `MaxBodySizeMiddleware` (`api/middleware.py`) rejects requests over `OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB` (default 100MB) before auth/routing - both via `Content-Length` pre-check and by counting bytes as the body streams in, so it also catches chunked requests with no `Content-Length`. Registered inside `CORSMiddleware` so a rejected upload still gets CORS headers.
 
 ### Services (Business Logic)
 - **chat_service.py**: Invokes chat.py graph; handles message history via SqliteSaver

--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,7 @@ from loguru import logger
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from api.auth import PasswordAuthMiddleware
+from api.middleware import MaxBodySizeMiddleware, get_max_upload_size_bytes
 from api.routers import (
     auth,
     chat,
@@ -68,6 +69,9 @@ CORS_IS_DEFAULT_WILDCARD = _cors_origins_raw is None
 # the default, or credentials would combine with a wildcard origin - the
 # exact reflect-any-Origin behavior this flag exists to prevent.
 CORS_ALLOW_CREDENTIALS = "*" not in CORS_ALLOWED_ORIGINS
+
+# Parsed once at module load; OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB changes require a restart.
+MAX_UPLOAD_SIZE_BYTES = get_max_upload_size_bytes()
 
 DATABASE_STARTUP_RETRY_ATTEMPTS = 12
 DATABASE_STARTUP_RETRY_INITIAL_DELAY_SECONDS = 1
@@ -243,18 +247,27 @@ app.add_middleware(
     ],
 )
 
-# Add CORS middleware last (so it processes first)
+# Reject oversized request bodies before they reach auth or routing - added
+# after PasswordAuthMiddleware (so it wraps around it) so a too-large request
+# is rejected before spending any work checking credentials.
+logger.info(
+    f"Max request body size: {MAX_UPLOAD_SIZE_BYTES / (1024 * 1024):g}MB "
+    "(set OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB to change)"
+)
+app.add_middleware(MaxBodySizeMiddleware, max_body_size=MAX_UPLOAD_SIZE_BYTES)
+
+# Add CORS middleware last (so it processes first, and so it can attach
+# CORS headers to a 413 raised by MaxBodySizeMiddleware)
 #
-# allow_credentials is tied to whether CORS_ORIGINS was explicitly scoped:
-# combining allow_origins=["*"] with allow_credentials=True makes Starlette
-# reflect the request's Origin header verbatim (browsers reject a literal
-# "*" alongside credentials), which defeats the origin allowlist. The
-# frontend never sends credentialed requests (withCredentials: false) and
-# auth is a Bearer header, not a cookie, so this isn't independently
-# exploitable today - but there's no reason to allow it for the default
-# wildcard case. Once an operator explicitly scopes CORS_ORIGINS to real
-# origins, credentialed cross-origin requests to those origins are safe to
-# allow again.
+# allow_credentials is tied to whether CORS_ORIGINS resolves to specific
+# origins: combining allow_origins=["*"] with allow_credentials=True makes
+# Starlette reflect the request's Origin header verbatim (browsers reject a
+# literal "*" alongside credentials), which defeats the origin allowlist.
+# The frontend never sends credentialed requests (withCredentials: false)
+# and auth is a Bearer header, not a cookie, so this isn't independently
+# exploitable today - but there's no reason to allow it for any wildcard
+# case. Once an operator explicitly scopes CORS_ORIGINS to real origins,
+# credentialed cross-origin requests to those origins are safe to allow.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ALLOWED_ORIGINS,

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,0 +1,105 @@
+import os
+
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Matches the file-size guidance already documented in
+# docs/3-USER-GUIDE/adding-sources.md ("Very large files (>100MB) - Timeout").
+DEFAULT_MAX_UPLOAD_SIZE_MB = 100
+
+
+def get_max_upload_size_bytes() -> int:
+    """Read the configured max request body size, in bytes.
+
+    Configurable via OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB for deployments that
+    need larger audio/video uploads; falls back to the default on unset or
+    malformed values.
+    """
+    raw = os.environ.get("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "").strip()
+    try:
+        mb = float(raw) if raw else DEFAULT_MAX_UPLOAD_SIZE_MB
+    except ValueError:
+        mb = DEFAULT_MAX_UPLOAD_SIZE_MB
+    return int(mb * 1024 * 1024)
+
+
+class _RequestBodyTooLarge(Exception):
+    pass
+
+
+class MaxBodySizeMiddleware:
+    """
+    Raw ASGI middleware rejecting requests whose body exceeds a configured
+    maximum, so a large upload can't exhaust memory/disk on a deployment
+    with no fronting proxy enforcing its own limit (e.g. the shipped
+    docker-compose.yml, which exposes the API directly).
+
+    Implemented at the raw ASGI level (not BaseHTTPMiddleware) so the check
+    can run ahead of FastAPI's own body/form parsing instead of after it.
+    Rejects on the `Content-Length` header up front when present (the common
+    case, and cheap), and also counts bytes as the body streams in - a
+    client can lie about Content-Length or omit it entirely with chunked
+    transfer-encoding.
+    """
+
+    def __init__(self, app: ASGIApp, max_body_size: int) -> None:
+        self.app = app
+        self.max_body_size = max_body_size
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        content_length = headers.get("content-length")
+        if content_length is not None:
+            try:
+                if int(content_length) > self.max_body_size:
+                    await _send_413(send)
+                    return
+            except ValueError:
+                pass  # malformed header - fall through to streaming enforcement
+
+        total_size = 0
+        response_started = False
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        async def receive_wrapper() -> Message:
+            nonlocal total_size
+            message = await receive()
+            if message["type"] == "http.request":
+                total_size += len(message.get("body") or b"")
+                if total_size > self.max_body_size:
+                    raise _RequestBodyTooLarge()
+            return message
+
+        try:
+            await self.app(scope, receive_wrapper, send_wrapper)
+        except _RequestBodyTooLarge:
+            if not response_started:
+                await _send_413(send)
+            # Else the app already started responding - nothing safe to send;
+            # let the connection drop rather than violate the ASGI protocol
+            # with a second response.start.
+
+
+async def _send_413(send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [(b"content-type", b"application/json")],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": b'{"detail":"Request body exceeds the maximum allowed upload size"}',
+        }
+    )

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,5 +1,6 @@
 import os
 
+from loguru import logger
 from starlette.datastructures import Headers
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -12,13 +13,20 @@ def get_max_upload_size_bytes() -> int:
     """Read the configured max request body size, in bytes.
 
     Configurable via OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB for deployments that
-    need larger audio/video uploads; falls back to the default on unset or
-    malformed values.
+    need larger audio/video uploads; falls back to the default on unset,
+    malformed, or non-positive values (a zero/negative limit would reject
+    every request that has a body).
     """
     raw = os.environ.get("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "").strip()
     try:
         mb = float(raw) if raw else DEFAULT_MAX_UPLOAD_SIZE_MB
     except ValueError:
+        mb = DEFAULT_MAX_UPLOAD_SIZE_MB
+    if mb <= 0:
+        logger.warning(
+            f"OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB={raw!r} is not a positive size; "
+            f"using the default of {DEFAULT_MAX_UPLOAD_SIZE_MB}MB"
+        )
         mb = DEFAULT_MAX_UPLOAD_SIZE_MB
     return int(mb * 1024 * 1024)
 
@@ -56,6 +64,11 @@ class MaxBodySizeMiddleware:
         if content_length is not None:
             try:
                 if int(content_length) > self.max_body_size:
+                    logger.warning(
+                        f"Rejected {scope.get('method', '?')} {scope.get('path', '?')}: "
+                        f"declared body of {content_length} bytes exceeds the "
+                        f"{self.max_body_size}-byte limit"
+                    )
                     await _send_413(send)
                     return
             except ValueError:
@@ -82,6 +95,10 @@ class MaxBodySizeMiddleware:
         try:
             await self.app(scope, receive_wrapper, send_wrapper)
         except _RequestBodyTooLarge:
+            logger.warning(
+                f"Rejected {scope.get('method', '?')} {scope.get('path', '?')}: "
+                f"streamed body exceeded the {self.max_body_size}-byte limit"
+            )
             if not response_started:
                 await _send_413(send)
             # Else the app already started responding - nothing safe to send;

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -15,6 +15,7 @@ Comprehensive list of all environment variables available in Open Notebook.
 | `OPEN_NOTEBOOK_ENCRYPTION_KEY` | **Yes** | None | Secret string to encrypt credentials stored in database (any string works). **Required** for the credential system. Supports Docker secrets via `_FILE` suffix. |
 | `HOSTNAME` | No | `0.0.0.0` (in Docker) | Network interface for Next.js to bind to. Default `0.0.0.0` ensures accessibility from reverse proxies |
 | `API_HOST` | No | `0.0.0.0` (in Docker) | Network interface for the API (uvicorn) to bind to. Set to `::` for IPv6 dual-stack environments (listens on IPv6 and, on Linux defaults, IPv4 too) |
+| `OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB` | No | 100 | Maximum request body size (in MB) the API will accept, enforced before auth/routing. Raise this if you need to upload larger audio/video files. A fronting reverse proxy's own limit (e.g. nginx `client_max_body_size`) still applies and should be raised to match. |
 
 > **Important**: `OPEN_NOTEBOOK_ENCRYPTION_KEY` is required for storing AI provider credentials via the Settings UI. Without it, you cannot save credentials. If you change or lose this key, all stored credentials become unreadable.
 

--- a/tests/test_max_body_size_middleware.py
+++ b/tests/test_max_body_size_middleware.py
@@ -1,0 +1,249 @@
+"""
+Tests for api.middleware.MaxBodySizeMiddleware.
+
+Covers the raw-ASGI unit behavior (Content-Length pre-check, streaming
+enforcement for chunked/no-Content-Length requests, CORS interaction) plus
+integration through a real FastAPI app and the actual registered app.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware
+
+from api.middleware import (
+    DEFAULT_MAX_UPLOAD_SIZE_MB,
+    MaxBodySizeMiddleware,
+    get_max_upload_size_bytes,
+)
+
+
+async def _echo_body_app(scope, receive, send):
+    """Minimal ASGI app that reads the full body then returns 200."""
+    body = b""
+    more_body = True
+    while more_body:
+        message = await receive()
+        body += message.get("body", b"")
+        more_body = message.get("more_body", False)
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send(
+        {"type": "http.response.body", "body": f"received {len(body)} bytes".encode()}
+    )
+
+
+def make_scope(headers=None, method="POST", path="/upload"):
+    raw_headers = [
+        (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
+    ]
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": raw_headers,
+    }
+
+
+class FakeReceiveStream:
+    """Feeds a list of body chunks as successive http.request ASGI messages."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    async def __call__(self):
+        if not self._chunks:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        chunk = self._chunks.pop(0)
+        return {
+            "type": "http.request",
+            "body": chunk,
+            "more_body": bool(self._chunks),
+        }
+
+
+class CollectingSend:
+    def __init__(self):
+        self.messages = []
+
+    async def __call__(self, message):
+        self.messages.append(message)
+
+    @property
+    def status(self):
+        for m in self.messages:
+            if m["type"] == "http.response.start":
+                return m["status"]
+        return None
+
+    @property
+    def body(self):
+        return b"".join(
+            m.get("body", b"")
+            for m in self.messages
+            if m["type"] == "http.response.body"
+        )
+
+    def header(self, name: bytes):
+        for m in self.messages:
+            if m["type"] == "http.response.start":
+                for k, v in m["headers"]:
+                    if k.lower() == name.lower():
+                        return v.decode()
+        return None
+
+
+class TestConfig:
+    def test_default_is_100mb(self, monkeypatch):
+        monkeypatch.delenv("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", raising=False)
+        assert DEFAULT_MAX_UPLOAD_SIZE_MB == 100
+        assert get_max_upload_size_bytes() == 100 * 1024 * 1024
+
+    def test_reads_env_override(self, monkeypatch):
+        monkeypatch.setenv("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "5")
+        assert get_max_upload_size_bytes() == 5 * 1024 * 1024
+
+    def test_malformed_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "not-a-number")
+        assert get_max_upload_size_bytes() == 100 * 1024 * 1024
+
+
+class TestMiddlewareAsgiLevel:
+    @pytest.mark.asyncio
+    async def test_content_length_precheck_rejects_before_app_runs(self):
+        app_called = False
+
+        async def inner_app(scope, receive, send):
+            nonlocal app_called
+            app_called = True
+            await _echo_body_app(scope, receive, send)
+
+        middleware = MaxBodySizeMiddleware(inner_app, max_body_size=10)
+        scope = make_scope(headers={"content-length": "1000"})
+        send = CollectingSend()
+        await middleware(scope, FakeReceiveStream([b"x" * 1000]), send)
+
+        assert not app_called, "inner app must not run when Content-Length exceeds the limit"
+        assert send.status == 413
+
+    @pytest.mark.asyncio
+    async def test_small_body_passes_through(self):
+        middleware = MaxBodySizeMiddleware(_echo_body_app, max_body_size=1000)
+        scope = make_scope(headers={"content-length": "5"})
+        send = CollectingSend()
+        await middleware(scope, FakeReceiveStream([b"hello"]), send)
+
+        assert send.status == 200
+        assert send.body == b"received 5 bytes"
+
+    @pytest.mark.asyncio
+    async def test_streaming_body_without_content_length_is_still_enforced(self):
+        """A client can omit Content-Length (chunked transfer-encoding) - the
+        middleware must still catch an oversized body as it streams in."""
+        middleware = MaxBodySizeMiddleware(_echo_body_app, max_body_size=10)
+        scope = make_scope(headers={})  # no content-length
+        send = CollectingSend()
+        chunks = [b"a" * 5, b"b" * 5, b"c" * 5]  # totals 15 > 10
+        await middleware(scope, FakeReceiveStream(chunks), send)
+
+        assert send.status == 413
+
+    @pytest.mark.asyncio
+    async def test_malformed_content_length_falls_back_to_streaming_check(self):
+        middleware = MaxBodySizeMiddleware(_echo_body_app, max_body_size=10)
+        scope = make_scope(headers={"content-length": "not-a-number"})
+        send = CollectingSend()
+        await middleware(scope, FakeReceiveStream([b"x" * 1000]), send)
+
+        assert send.status == 413  # caught by streaming enforcement instead
+
+    @pytest.mark.asyncio
+    async def test_non_http_scope_passes_through_untouched(self):
+        calls = []
+
+        async def inner_app(scope, receive, send):
+            calls.append(scope["type"])
+
+        middleware = MaxBodySizeMiddleware(inner_app, max_body_size=10)
+        await middleware({"type": "lifespan"}, FakeReceiveStream([]), CollectingSend())
+        assert calls == ["lifespan"]
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_limit_passes(self):
+        middleware = MaxBodySizeMiddleware(_echo_body_app, max_body_size=10)
+        scope = make_scope(headers={"content-length": "10"})
+        send = CollectingSend()
+        await middleware(scope, FakeReceiveStream([b"x" * 10]), send)
+        assert send.status == 200
+
+    @pytest.mark.asyncio
+    async def test_one_byte_over_limit_rejected(self):
+        middleware = MaxBodySizeMiddleware(_echo_body_app, max_body_size=10)
+        scope = make_scope(headers={"content-length": "11"})
+        send = CollectingSend()
+        await middleware(scope, FakeReceiveStream([b"x" * 11]), send)
+        assert send.status == 413
+
+
+class TestCorsInteraction:
+    @pytest.mark.asyncio
+    async def test_cors_headers_present_on_413_when_wrapped_by_cors_middleware(self):
+        """MaxBodySizeMiddleware must sit *inside* CORSMiddleware so a
+        rejected upload still gets CORS headers (mirrors the ordering used
+        in api/main.py)."""
+        app = CORSMiddleware(
+            MaxBodySizeMiddleware(_echo_body_app, max_body_size=10),
+            allow_origins=["http://example.com"],
+            allow_credentials=True,
+        )
+        scope = make_scope(
+            headers={"content-length": "1000", "origin": "http://example.com"}
+        )
+        send = CollectingSend()
+        await app(scope, FakeReceiveStream([b"x" * 1000]), send)
+
+        assert send.status == 413
+        assert send.header(b"access-control-allow-origin") == "http://example.com"
+
+
+class TestFastApiIntegration:
+    """Drives the middleware through a real FastAPI app + TestClient (real
+    HTTP-shaped requests via httpx), not just hand-rolled ASGI messages."""
+
+    @pytest.fixture
+    def small_limit_app(self):
+        app = FastAPI()
+
+        @app.post("/echo")
+        async def echo():
+            return {"ok": True}
+
+        app.add_middleware(MaxBodySizeMiddleware, max_body_size=100)
+        return app
+
+    def test_small_request_passes(self, small_limit_app):
+        client = TestClient(small_limit_app)
+        response = client.post("/echo", content=b"x" * 50)
+        assert response.status_code == 200
+
+    def test_oversized_request_rejected_with_413(self, small_limit_app):
+        client = TestClient(small_limit_app)
+        response = client.post("/echo", content=b"x" * 1000)
+        assert response.status_code == 413
+        assert "exceeds the maximum" in response.json()["detail"]
+
+
+class TestRealAppWiring:
+    def test_real_app_registers_middleware_with_configured_size(self):
+        from api.main import MAX_UPLOAD_SIZE_BYTES, app
+
+        matches = [m for m in app.user_middleware if m.cls is MaxBodySizeMiddleware]
+        assert len(matches) == 1
+        assert matches[0].kwargs["max_body_size"] == MAX_UPLOAD_SIZE_BYTES
+
+    def test_real_app_wraps_it_inside_cors(self):
+        """CORS must be outermost so it can attach headers to a 413 from
+        MaxBodySizeMiddleware - i.e. CORSMiddleware must be added *after* it."""
+        from api.main import app
+
+        classes = [m.cls.__name__ for m in app.user_middleware]
+        assert classes.index("CORSMiddleware") < classes.index("MaxBodySizeMiddleware")

--- a/tests/test_max_body_size_middleware.py
+++ b/tests/test_max_body_size_middleware.py
@@ -106,6 +106,13 @@ class TestConfig:
         monkeypatch.setenv("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "not-a-number")
         assert get_max_upload_size_bytes() == 100 * 1024 * 1024
 
+    def test_non_positive_env_falls_back_to_default(self, monkeypatch):
+        # A zero/negative limit would 413 every request that has a body.
+        monkeypatch.setenv("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "0")
+        assert get_max_upload_size_bytes() == 100 * 1024 * 1024
+        monkeypatch.setenv("OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB", "-5")
+        assert get_max_upload_size_bytes() == 100 * 1024 * 1024
+
 
 class TestMiddlewareAsgiLevel:
     @pytest.mark.asyncio


### PR DESCRIPTION
No limit existed on request body size, so a single upload could exhaust memory/disk before any validation ran. `MaxBodySizeMiddleware` (`api/middleware.py`) rejects requests over `OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB` (default 100MB) via both a `Content-Length` pre-check and by counting bytes as the body streams in, so it also catches chunked requests with no `Content-Length` header.

Registered after `PasswordAuthMiddleware` (wrapping it) so oversized requests are rejected before spending any work on credential checks, and inside `CORSMiddleware` so a rejected upload still gets CORS headers.

**Stacked on #1002-#1009** (unmerged). `tests/test_max_body_size_middleware.py` passes (15/15).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

