### PR TITLE
fix: harden source upload path handling and cap array inputs

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -301,7 +301,9 @@ class SourceCreate(BaseModel):
     )
     # New multi-notebook support
     notebooks: Optional[List[str]] = Field(
-        None, description="List of notebook IDs to add the source to"
+        None,
+        max_length=50,
+        description="List of notebook IDs to add the source to (max 50)",
     )
     # Required fields
     type: str = Field(..., description="Source type: link, upload, or text")
@@ -310,7 +312,9 @@ class SourceCreate(BaseModel):
     content: Optional[str] = Field(None, description="Text content for text type")
     title: Optional[str] = Field(None, description="Source title")
     transformations: Optional[List[str]] = Field(
-        default_factory=list, description="Transformation IDs to apply"
+        default_factory=list,
+        max_length=50,
+        description="Transformation IDs to apply (max 50)",
     )
     embed: bool = Field(False, description="Whether to embed content for vector search")
     delete_source: bool = Field(

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -66,7 +66,10 @@ async def _stamp_source_view(source_id: str) -> None:
 
 
 def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
-    """Generate unique filename like Streamlit app (append counter if file exists)."""
+    """Generate unique filename like Streamlit app (append counter if file exists),
+    atomically reserving it so two concurrent uploads that land on the same
+    candidate name can't both pass the check and then clobber each other -
+    the loser's claim attempt fails and moves on to the next candidate."""
     file_path = Path(upload_folder)
     file_path.mkdir(parents=True, exist_ok=True)
 
@@ -78,8 +81,9 @@ def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
     # Split filename and extension
     stem = Path(safe_filename).stem
     suffix = Path(safe_filename).suffix
+    safe_root = file_path.resolve()
 
-    # Check if file exists and generate unique name
+    # Find and atomically claim a unique name
     counter = 0
     while True:
         if counter == 0:
@@ -90,11 +94,17 @@ def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
         full_path = file_path / new_filename
         # Verify resolved path stays within upload folder
         resolved = full_path.resolve()
-        if not str(resolved).startswith(str(file_path.resolve()) + os.sep):
+        if not str(resolved).startswith(str(safe_root) + os.sep):
             raise ValueError("Invalid filename: path traversal detected")
-        if not resolved.exists():
+
+        try:
+            # O_EXCL via touch(exist_ok=False): atomically create-or-fail,
+            # instead of exists() (check) followed by a separate write
+            # (act) elsewhere with a race window in between.
+            resolved.touch(exist_ok=False)
             return str(resolved)
-        counter += 1
+        except FileExistsError:
+            counter += 1
 
 
 def _write_uploaded_file(filename: str, content: bytes) -> str:
@@ -642,7 +652,7 @@ async def _resolve_source_file(source_id: str) -> tuple[str, str]:
     safe_root = os.path.realpath(UPLOADS_FOLDER)
     resolved_path = os.path.realpath(file_path)
 
-    if not resolved_path.startswith(safe_root):
+    if resolved_path != safe_root and not resolved_path.startswith(safe_root + os.sep):
         logger.warning(
             f"Blocked download outside uploads directory for source {source_id}: {resolved_path}"
         )
@@ -663,7 +673,7 @@ def _is_source_file_available(source: Source) -> Optional[bool]:
     safe_root = os.path.realpath(UPLOADS_FOLDER)
     resolved_path = os.path.realpath(file_path)
 
-    if not resolved_path.startswith(safe_root):
+    if resolved_path != safe_root and not resolved_path.startswith(safe_root + os.sep):
         return False
 
     return os.path.exists(resolved_path)

--- a/tests/test_source_create_array_limits.py
+++ b/tests/test_source_create_array_limits.py
@@ -1,0 +1,56 @@
+"""
+Tests for max_length on SourceCreate.notebooks/transformations
+(api/models.py).
+
+Both are iterated with a per-item DB lookup (Notebook.get()/
+Transformation.get()) in api/routers/sources.py's create_source() - an
+unbounded array let a caller amplify a single request into an arbitrarily
+large number of sequential DB round trips.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.models import SourceCreate
+
+
+def make_ids(n, prefix):
+    return [f"{prefix}:{i}" for i in range(n)]
+
+
+class TestNotebooksMaxLength:
+    def test_accepts_up_to_50_notebooks(self):
+        request = SourceCreate(type="text", content="hi", notebooks=make_ids(50, "notebook"))
+        assert len(request.notebooks) == 50
+
+    def test_rejects_51_notebooks(self):
+        with pytest.raises(ValidationError):
+            SourceCreate(type="text", content="hi", notebooks=make_ids(51, "notebook"))
+
+    def test_none_notebooks_still_allowed(self):
+        # Pre-existing behavior (validate_notebook_fields): None normalizes
+        # to an empty list, unrelated to the max_length addition.
+        request = SourceCreate(type="text", content="hi", notebooks=None)
+        assert request.notebooks == []
+
+    def test_empty_list_still_allowed(self):
+        request = SourceCreate(type="text", content="hi", notebooks=[])
+        assert request.notebooks == []
+
+
+class TestTransformationsMaxLength:
+    def test_accepts_up_to_50_transformations(self):
+        request = SourceCreate(
+            type="text", content="hi", transformations=make_ids(50, "transformation")
+        )
+        assert len(request.transformations) == 50
+
+    def test_rejects_51_transformations(self):
+        with pytest.raises(ValidationError):
+            SourceCreate(
+                type="text", content="hi", transformations=make_ids(51, "transformation")
+            )
+
+    def test_default_is_empty_list(self):
+        request = SourceCreate(type="text", content="hi")
+        assert request.transformations == []

--- a/tests/test_source_path_containment.py
+++ b/tests/test_source_path_containment.py
@@ -1,0 +1,177 @@
+"""
+Tests for the sources.py path-containment fix in _resolve_source_file() and
+_is_source_file_available() (api/routers/sources.py).
+
+Both compared `resolved_path.startswith(safe_root)` without a trailing
+separator - a sibling directory that merely starts with the same string
+(e.g. "uploads_evil/") would incorrectly be treated as contained, unlike
+the file's other two path checks (generate_unique_filename(), the inline
+check in create_source()) which already guard with `+ os.sep`. Not
+reachable today (source.asset.file_path is only ever set server-side), but
+these lock in the fix and guard against regressions.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.routers.sources import _is_source_file_available, _resolve_source_file
+from open_notebook.config import UPLOADS_FOLDER
+from open_notebook.domain.notebook import Asset, Source
+
+
+def make_source(file_path=None, **overrides):
+    defaults = dict(
+        id="source:test123",
+        title="Test Source",
+        asset=Asset(file_path=file_path) if file_path else None,
+    )
+    defaults.update(overrides)
+    return Source(**defaults)
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestIsSourceFileAvailableRejectsSiblingDirectoryBypass:
+    def test_sibling_directory_with_matching_prefix_is_not_available(
+        self, tmp_path, monkeypatch
+    ):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        sibling = tmp_path / "uploads_evil"
+        sibling.mkdir()
+        evil_file = sibling / "secret.txt"
+        evil_file.write_bytes(b"not yours")
+
+        source = make_source(file_path=str(evil_file))
+        assert _is_source_file_available(source) is False
+
+    def test_file_genuinely_inside_uploads_folder_is_available(
+        self, tmp_path, monkeypatch
+    ):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        legit_file = real_root / "document.pdf"
+        legit_file.write_bytes(b"pdf bytes")
+
+        source = make_source(file_path=str(legit_file))
+        assert _is_source_file_available(source) is True
+
+    def test_missing_file_inside_uploads_folder_is_unavailable_not_error(
+        self, tmp_path, monkeypatch
+    ):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        missing_file = real_root / "does-not-exist.pdf"
+        source = make_source(file_path=str(missing_file))
+        assert _is_source_file_available(source) is False
+
+    def test_no_asset_returns_none(self):
+        source = make_source(file_path=None)
+        assert _is_source_file_available(source) is None
+
+    def test_path_traversal_outside_root_is_not_available(self, tmp_path, monkeypatch):
+        root = tmp_path / "uploads"
+        root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(root))
+
+        outside = tmp_path / "outside.pdf"
+        outside.write_bytes(b"not yours")
+        traversal_path = str(root / ".." / "outside.pdf")
+
+        source = make_source(file_path=traversal_path)
+        assert _is_source_file_available(source) is False
+
+
+class TestResolveSourceFileRejectsSiblingDirectoryBypass:
+    @pytest.mark.asyncio
+    async def test_sibling_directory_raises_403(self, tmp_path, monkeypatch):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        sibling = tmp_path / "uploads_evil"
+        sibling.mkdir()
+        evil_file = sibling / "secret.txt"
+        evil_file.write_bytes(b"not yours")
+
+        source = make_source(file_path=str(evil_file))
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=source)
+        ):
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException) as exc_info:
+                await _resolve_source_file("source:test123")
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_file_genuinely_inside_uploads_folder_resolves(
+        self, tmp_path, monkeypatch
+    ):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        legit_file = real_root / "document.pdf"
+        legit_file.write_bytes(b"pdf bytes")
+
+        source = make_source(file_path=str(legit_file))
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=source)
+        ):
+            resolved_path, filename = await _resolve_source_file("source:test123")
+
+        assert filename == "document.pdf"
+        assert resolved_path == str(legit_file.resolve())
+
+
+class TestDownloadEndpointRejectsSiblingDirectoryBypass:
+    """End-to-end through the actual HTTP endpoint."""
+
+    def test_download_returns_403_for_sibling_directory_file(
+        self, client, tmp_path, monkeypatch
+    ):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        sibling = tmp_path / "uploads_evil"
+        sibling.mkdir()
+        evil_file = sibling / "secret.txt"
+        evil_file.write_bytes(b"not yours")
+
+        source = make_source(file_path=str(evil_file))
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=source)
+        ):
+            response = client.get("/api/sources/source:test123/download")
+
+        assert response.status_code == 403
+
+
+class TestRealUploadsFolderStillWorks:
+    """Sanity check against the real (non-monkeypatched) UPLOADS_FOLDER."""
+
+    def test_real_uploads_folder_file_is_available(self):
+        from pathlib import Path
+
+        test_file = Path(UPLOADS_FOLDER) / "containment_test_file.txt"
+        test_file.write_bytes(b"test")
+        try:
+            source = make_source(file_path=str(test_file))
+            assert _is_source_file_available(source) is True
+        finally:
+            test_file.unlink(missing_ok=True)

--- a/tests/test_upload_toctou_race.py
+++ b/tests/test_upload_toctou_race.py
@@ -1,0 +1,127 @@
+"""
+Tests for the TOCTOU race fix in generate_unique_filename()
+(api/routers/sources.py).
+
+The old implementation checked `if not resolved.exists(): return path` and
+left the actual write to a *separate* open(path, "wb") call in
+_write_uploaded_file() - "wb" truncates rather than failing, so two
+concurrent uploads that computed the same candidate name could both pass
+the check and then clobber each other, silently losing one upload.
+
+generate_unique_filename() now atomically claims the name via
+Path.touch(exist_ok=False) (O_EXCL under the hood) as part of the search
+loop itself, so a losing concurrent caller gets FileExistsError and moves
+on to the next candidate instead of racing.
+
+These tests use real OS threads (not asyncio) since the race requires
+actual kernel-level interleaving of filesystem syscalls, which release the
+GIL - asyncio's single-threaded cooperative concurrency wouldn't exercise it.
+"""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from api.routers.sources import generate_unique_filename
+
+
+def old_racy_pattern(upload_folder, original_filename, content, delay=0.02):
+    """Standalone repro of the pre-fix check-then-act pattern, with an
+    injected delay to reliably widen the race window for testing (real
+    concurrent uploads don't need an artificial delay to lose the race -
+    this just makes the demonstration deterministic instead of flaky)."""
+    file_path = Path(upload_folder)
+    stem = Path(original_filename).stem
+    suffix = Path(original_filename).suffix
+    counter = 0
+    while True:
+        candidate = (
+            original_filename if counter == 0 else f"{stem} ({counter}){suffix}"
+        )
+        full_path = file_path / candidate
+        if not full_path.exists():
+            break
+        counter += 1
+    time.sleep(delay)  # the race window
+    with open(full_path, "wb") as f:
+        f.write(content)
+    return str(full_path)
+
+
+def new_fixed_pattern(upload_folder, original_filename, content):
+    file_path = generate_unique_filename(original_filename, upload_folder)
+    with open(file_path, "wb") as f:
+        f.write(content)
+    return file_path
+
+
+def run_concurrent_uploads(write_fn, upload_folder, n=8):
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        futures = [
+            pool.submit(
+                write_fn, upload_folder, "report.pdf", f"content-{i}".encode()
+            )
+            for i in range(n)
+        ]
+        return [f.result() for f in futures]
+
+
+def distinct_payloads_on_disk(upload_folder):
+    return {f.read_bytes() for f in Path(upload_folder).iterdir()}
+
+
+class TestOldPatternLosesWritesUnderRace:
+    """Confirms the vulnerability this fix addresses is real, using a
+    standalone repro of the old code (not the current, fixed source)."""
+
+    def test_concurrent_uploads_to_same_name_lose_data(self, tmp_path):
+        n = 8
+        run_concurrent_uploads(old_racy_pattern, str(tmp_path), n=n)
+        payloads = distinct_payloads_on_disk(tmp_path)
+        assert len(payloads) < n, (
+            "expected the old check-then-act pattern to lose at least one "
+            "concurrent write to a real race"
+        )
+
+
+class TestFixedGenerateUniqueFilenameSurvivesRace:
+    def test_concurrent_uploads_to_same_name_all_survive(self, tmp_path):
+        n = 8
+        run_concurrent_uploads(new_fixed_pattern, str(tmp_path), n=n)
+        files = list(tmp_path.iterdir())
+        payloads = distinct_payloads_on_disk(tmp_path)
+        assert len(files) == n, f"expected {n} files, got {len(files)}"
+        assert len(payloads) == n, (
+            f"expected all {n} distinct payloads preserved, got {len(payloads)}"
+        )
+
+    def test_claimed_path_exists_and_is_empty_immediately(self, tmp_path):
+        """The function itself must create the file (not just check for
+        its absence) - proving the claim is atomic with the check."""
+        path = generate_unique_filename("doc.txt", str(tmp_path))
+        assert Path(path).exists()
+        assert Path(path).stat().st_size == 0
+
+    def test_sequential_calls_still_increment_correctly(self, tmp_path):
+        path1 = generate_unique_filename("doc.txt", str(tmp_path))
+        Path(path1).write_bytes(b"first")
+        path2 = generate_unique_filename("doc.txt", str(tmp_path))
+        Path(path2).write_bytes(b"second")
+        path3 = generate_unique_filename("doc.txt", str(tmp_path))
+
+        assert Path(path1).name == "doc.txt"
+        assert Path(path2).name == "doc (1).txt"
+        assert Path(path3).name == "doc (2).txt"
+
+    def test_pre_existing_file_is_skipped(self, tmp_path):
+        (tmp_path / "existing.txt").write_bytes(b"already here")
+        path = generate_unique_filename("existing.txt", str(tmp_path))
+        assert Path(path).name == "existing (1).txt"
+
+    def test_directory_components_are_stripped_not_traversed(self, tmp_path):
+        """os.path.basename() strips directory components from the
+        original filename before the traversal check ever runs - e.g.
+        "../../etc/passwd" becomes just "passwd", confined to tmp_path."""
+        path = generate_unique_filename("../../etc/passwd", str(tmp_path))
+        assert Path(path).parent == tmp_path.resolve()
+        assert Path(path).name == "passwd"

--- a/tests/test_upload_type_mitigations.py
+++ b/tests/test_upload_type_mitigations.py
@@ -1,0 +1,94 @@
+"""
+Regression tests documenting why the "no file type/content allowlist on
+uploads" finding is low-risk without adding one.
+
+Investigated adding an extension/MIME allowlist and decided against it:
+- Downloads are always served as application/octet-stream regardless of
+  the uploaded file's actual type (locked in below) - the classic "upload
+  HTML/SVG, victim opens it, browser renders/executes it" vector is closed
+  independent of any allowlist.
+- Uploaded files are never executed server-side; content-core only reads
+  and extracts text/media from them.
+- content_core.content.identification.file_detector.FileDetector already
+  does its own content-sniffing (magic bytes, not just extension) and
+  raises UnsupportedTypeException for content it can't classify -
+  duplicating that as a hand-maintained extension allowlist at the API
+  layer would drift out of sync with content-core's 50+ supported types
+  and either give false confidence or block legitimate uploads.
+- Upload size is already bounded (see api/middleware.py).
+
+So arbitrary bytes can still be written to disk under a
+server-controlled filename (a generically accepted property of file
+upload services), but not served in a way a browser would render/execute,
+and not executed server-side either.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_notebook.domain.notebook import Asset, Source
+
+
+def make_source(file_path, **overrides):
+    defaults = dict(id="source:test123", title="Test Source", asset=Asset(file_path=file_path))
+    defaults.update(overrides)
+    return Source(**defaults)
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestDownloadsAlwaysServedAsOctetStream:
+    def test_html_file_download_is_octet_stream_not_text_html(self, client, tmp_path, monkeypatch):
+        """Even if an attacker got an .html file stored, downloading it
+        must never come back as text/html (which a browser would render)."""
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        malicious_html = real_root / "innocuous.html"
+        malicious_html.write_text("<script>alert(document.cookie)</script>")
+
+        source = make_source(file_path=str(malicious_html))
+        with patch("api.routers.sources.Source.get", new=AsyncMock(return_value=source)):
+            response = client.get("/api/sources/source:test123/download")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/octet-stream"
+
+    def test_svg_file_download_is_octet_stream_not_svg_xml(self, client, tmp_path, monkeypatch):
+        real_root = tmp_path / "uploads"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(real_root))
+
+        malicious_svg = real_root / "image.svg"
+        malicious_svg.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+        )
+
+        source = make_source(file_path=str(malicious_svg))
+        with patch("api.routers.sources.Source.get", new=AsyncMock(return_value=source)):
+            response = client.get("/api/sources/source:test123/download")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/octet-stream"
+
+
+class TestContentCoreRejectsUnrecognizedContent:
+    @pytest.mark.asyncio
+    async def test_file_detector_raises_for_unrecognized_content(self, tmp_path):
+        from content_core.common.exceptions import UnsupportedTypeException
+        from content_core.content.identification.file_detector import FileDetector
+
+        garbage = tmp_path / "garbage.bin"
+        garbage.write_bytes(bytes(range(256)) * 4)  # not any recognized signature/text pattern
+
+        detector = FileDetector()
+        with pytest.raises(UnsupportedTypeException):
+            await detector.detect(str(garbage))


### PR DESCRIPTION
Three small, independent hardening fixes to source ingestion:

- `generate_unique_filename()` checked `if not resolved.exists()` then let a separate write happen later - two concurrent uploads landing on the same candidate name could both pass the check and clobber each other. Now atomically claims the name via `Path.touch(exist_ok=False)` (O_EXCL) as part of the search loop itself.
- `_resolve_source_file()` and `_is_source_file_available()` compared `resolved_path.startswith(safe_root)` without a trailing separator - a sibling directory that merely starts with the same string (e.g. `uploads_evil/`) would incorrectly be treated as contained, unlike this file's other two path checks which already guard with `+ os.sep`. Not reachable today (`source.asset.file_path` is only ever set server-side), but this closes the gap and matches the existing pattern.
- `SourceCreate.notebooks`/`transformations` had no length limit; both are iterated with a per-item DB lookup in `create_source()`, so an unbounded array let a single request trigger an unbounded number of sequential DB round trips. Capped at 50.

`tests/test_upload_type_mitigations.py` adds no code change - it documents why the adjacent "no file type allowlist on uploads" finding was investigated and judged low-risk without one (downloads are already served as `application/octet-stream` regardless of actual file type).

**Stacked on #1002-#1009** (unmerged): this branch's base includes those, notably #1009 which restructured `save_uploaded_file()`. All 25 new tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

