### PR TITLE
fix: don't leak internal exception text in API error responses

### DIFF
--- a/api/podcast_service.py
+++ b/api/podcast_service.py
@@ -108,7 +108,7 @@ class PodcastService:
             logger.error(f"Failed to submit podcast generation job: {e}")
             raise HTTPException(
                 status_code=500,
-                detail=f"Failed to submit podcast generation job: {str(e)}",
+                detail="Failed to submit podcast generation job",
             )
 
     @staticmethod
@@ -133,9 +133,7 @@ class PodcastService:
             }
         except Exception as e:
             logger.error(f"Failed to get podcast job status: {e}")
-            raise HTTPException(
-                status_code=500, detail=f"Failed to get job status: {str(e)}"
-            )
+            raise HTTPException(status_code=500, detail="Failed to get job status")
 
     @staticmethod
     async def list_episodes() -> list:
@@ -145,9 +143,7 @@ class PodcastService:
             return episodes
         except Exception as e:
             logger.error(f"Failed to list podcast episodes: {e}")
-            raise HTTPException(
-                status_code=500, detail=f"Failed to list episodes: {str(e)}"
-            )
+            raise HTTPException(status_code=500, detail="Failed to list episodes")
 
     @staticmethod
     async def get_episode(episode_id: str) -> PodcastEpisode:
@@ -157,7 +153,7 @@ class PodcastService:
             return episode
         except Exception as e:
             logger.error(f"Failed to get podcast episode {episode_id}: {e}")
-            raise HTTPException(status_code=404, detail=f"Episode not found: {str(e)}")
+            raise HTTPException(status_code=404, detail="Episode not found")
 
 
 class DefaultProfiles:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -332,7 +332,7 @@ async def get_sources(
         raise
     except Exception as e:
         logger.error(f"Error fetching sources: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error fetching sources: {str(e)}")
+        raise HTTPException(status_code=500, detail="Error fetching sources")
 
 
 @router.post("/sources", response_model=SourceResponse)
@@ -362,9 +362,7 @@ async def create_source(
                 file_path = await save_uploaded_file(upload_file)
             except Exception as e:
                 logger.error(f"File upload failed: {e}")
-                raise HTTPException(
-                    status_code=400, detail=f"File upload failed: {str(e)}"
-                )
+                raise HTTPException(status_code=400, detail="File upload failed")
 
         # Prepare content_state for processing
         content_state: dict[str, Any] = {}
@@ -502,7 +500,7 @@ async def create_source(
                     except Exception:
                         pass
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to queue processing: {str(e)}"
+                    status_code=500, detail="Failed to queue processing"
                 )
 
         else:
@@ -629,7 +627,7 @@ async def create_source(
                 os.unlink(file_path)
             except Exception:
                 pass
-        raise HTTPException(status_code=500, detail=f"Error creating source: {str(e)}")
+        raise HTTPException(status_code=500, detail="Error creating source")
 
 
 @router.post("/sources/json", response_model=SourceResponse)
@@ -740,7 +738,7 @@ async def get_source(source_id: str):
         raise HTTPException(status_code=404, detail="Source not found")
     except Exception as e:
         logger.error(f"Error fetching source {source_id}: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error fetching source: {str(e)}")
+        raise HTTPException(status_code=500, detail="Error fetching source")
 
 
 @router.head("/sources/{source_id}/download")
@@ -830,9 +828,7 @@ async def get_source_status(source_id: str):
         raise
     except Exception as e:
         logger.error(f"Error fetching status for source {source_id}: {str(e)}")
-        raise HTTPException(
-            status_code=500, detail=f"Error fetching source status: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail="Error fetching source status")
 
 
 @router.put("/sources/{source_id}", response_model=SourceResponse)
@@ -874,7 +870,7 @@ async def update_source(source_id: str, source_update: SourceUpdate):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Error updating source {source_id}: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error updating source: {str(e)}")
+        raise HTTPException(status_code=500, detail="Error updating source")
 
 
 @router.post("/sources/{source_id}/retry", response_model=SourceResponse)
@@ -996,16 +992,14 @@ async def retry_source_processing(source_id: str):
                 f"Failed to submit retry processing command for source {source_id}: {e}"
             )
             raise HTTPException(
-                status_code=500, detail=f"Failed to queue retry processing: {str(e)}"
+                status_code=500, detail="Failed to queue retry processing"
             )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error retrying source processing for {source_id}: {str(e)}")
-        raise HTTPException(
-            status_code=500, detail=f"Error retrying source processing: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail="Error retrying source processing")
 
 
 @router.delete("/sources/{source_id}")
@@ -1023,7 +1017,7 @@ async def delete_source(source_id: str):
         raise
     except Exception as e:
         logger.error(f"Error deleting source {source_id}: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error deleting source: {str(e)}")
+        raise HTTPException(status_code=500, detail="Error deleting source")
 
 
 @router.get("/sources/{source_id}/insights", response_model=List[SourceInsightResponse])
@@ -1050,9 +1044,7 @@ async def get_source_insights(source_id: str):
         raise
     except Exception as e:
         logger.error(f"Error fetching insights for source {source_id}: {str(e)}")
-        raise HTTPException(
-            status_code=500, detail=f"Error fetching insights: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail="Error fetching insights")
 
 
 @router.post(
@@ -1105,6 +1097,4 @@ async def create_source_insight(source_id: str, request: CreateSourceInsightRequ
         raise
     except Exception as e:
         logger.error(f"Error starting insight generation for source {source_id}: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Error starting insight generation: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail="Error starting insight generation")

--- a/tests/test_config_endpoint_no_leak.py
+++ b/tests/test_config_endpoint_no_leak.py
@@ -1,0 +1,76 @@
+"""
+Regression test for GET /api/config (api/routers/config.py) - an
+unauthenticated endpoint (listed in PasswordAuthMiddleware's
+excluded_paths).
+
+An earlier audit flagged check_database_health() as leaking raw exception
+text to unauthenticated callers. Reading the current code: the exception
+string does get put into check_database_health()'s internal return dict
+(`error` key), but get_config() only logs that value server-side
+(logger.warning) - it never includes it in the JSON response, which
+carries just `dbStatus` ("online"/"offline"). This test locks that
+contract in so a future edit can't reintroduce the leak by, e.g., adding
+`"error": db_health.get("error")` to the response dict.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+SENSITIVE_MESSAGE = "connection refused to internal-db-host.corp.local:8000: password auth failed for user 'root'"
+
+
+class TestConfigEndpointDoesNotLeakDbErrors:
+    def test_db_failure_does_not_include_raw_error_in_response(self, client):
+        with patch(
+            "api.routers.config.repo_query",
+            new=AsyncMock(side_effect=RuntimeError(SENSITIVE_MESSAGE)),
+        ):
+            response = client.get("/api/config")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert SENSITIVE_MESSAGE not in response.text
+        assert "error" not in body
+        assert body["dbStatus"] == "offline"
+        assert set(body.keys()) == {"version", "latestVersion", "hasUpdate", "dbStatus"}
+
+    def test_db_timeout_does_not_include_raw_error_in_response(self, client):
+        import asyncio
+
+        with patch(
+            "api.routers.config.repo_query",
+            new=AsyncMock(side_effect=asyncio.TimeoutError()),
+        ):
+            response = client.get("/api/config")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "error" not in body
+        assert body["dbStatus"] == "offline"
+
+    def test_healthy_db_reports_online(self, client):
+        with patch(
+            "api.routers.config.repo_query",
+            new=AsyncMock(return_value=[{"result": 1}]),
+        ):
+            response = client.get("/api/config")
+
+        assert response.status_code == 200
+        assert response.json()["dbStatus"] == "online"
+
+    def test_config_endpoint_is_unauthenticated(self, client):
+        """Sanity check that this endpoint really is reachable without a
+        password - the scenario the finding's "unauthenticated" framing
+        depends on."""
+        response = client.get("/api/config")
+        assert response.status_code != 401

--- a/tests/test_error_message_sanitization.py
+++ b/tests/test_error_message_sanitization.py
@@ -1,0 +1,182 @@
+"""
+Tests that internal exception text is never leaked to API clients in
+api/routers/sources.py and api/podcast_service.py.
+
+These previously interpolated the raw exception (`detail=f"...: {str(e)}"`)
+into the client-facing error response - inconsistent with the safer pattern
+already used elsewhere in the same files (e.g. the download handlers),
+which log the raw exception server-side but return a fixed generic
+message. Every occurrence already had a matching logger.error() call, so
+this was a client-facing message change only, not a logging change.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+SECRET = "connection to db-primary-7f3a.internal:5432 refused: password authentication failed"
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestSourcesRouterDoesNotLeakExceptionText:
+    def test_list_sources_failure_returns_generic_message(self, client):
+        with patch(
+            "api.routers.sources.repo_query",
+            new=AsyncMock(side_effect=RuntimeError(SECRET)),
+        ):
+            response = client.get("/api/sources")
+
+        assert response.status_code == 500
+        assert SECRET not in response.text
+        assert response.json()["detail"] == "Error fetching sources"
+
+    def test_delete_source_failure_returns_generic_message(self, client):
+        mock_source = AsyncMock()
+        mock_source.delete = AsyncMock(side_effect=RuntimeError(SECRET))
+
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=mock_source)
+        ):
+            response = client.delete("/api/sources/source:abc123")
+
+        assert response.status_code == 500
+        assert SECRET not in response.text
+        assert response.json()["detail"] == "Error deleting source"
+
+    def test_get_source_insights_failure_returns_generic_message(self, client):
+        mock_source = AsyncMock()
+        mock_source.get_insights = AsyncMock(side_effect=RuntimeError(SECRET))
+
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=mock_source)
+        ):
+            response = client.get("/api/sources/source:abc123/insights")
+
+        assert response.status_code == 500
+        assert SECRET not in response.text
+        assert response.json()["detail"] == "Error fetching insights"
+
+    def test_update_source_failure_returns_generic_message(self, client):
+        mock_source = AsyncMock()
+        mock_source.save = AsyncMock(side_effect=RuntimeError(SECRET))
+        mock_source.asset = None
+
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=mock_source)
+        ):
+            response = client.put(
+                "/api/sources/source:abc123", json={"title": "New Title"}
+            )
+
+        assert response.status_code == 500
+        assert SECRET not in response.text
+        assert response.json()["detail"] == "Error updating source"
+
+
+class TestInvalidInputErrorsStillReturnTheirOwnSafeMessage:
+    """InvalidInputError is a distinct, deliberate pattern (app-authored,
+    user-facing validation text) - not the raw-exception-leak pattern this
+    fix targets, and must be untouched."""
+
+    def test_update_source_invalid_input_still_returns_its_message(self, client):
+        from open_notebook.exceptions import InvalidInputError
+
+        mock_source = AsyncMock()
+        mock_source.save = AsyncMock(
+            side_effect=InvalidInputError("Title cannot be empty")
+        )
+        mock_source.asset = None
+
+        with patch(
+            "api.routers.sources.Source.get", new=AsyncMock(return_value=mock_source)
+        ):
+            response = client.put(
+                "/api/sources/source:abc123", json={"title": "x"}
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Title cannot be empty"
+
+
+class TestPodcastServiceDoesNotLeakExceptionText:
+    @pytest.mark.asyncio
+    async def test_get_job_status_failure_returns_generic_message(self):
+        from fastapi import HTTPException
+
+        from api.podcast_service import PodcastService
+
+        with patch(
+            "api.podcast_service.get_command_status",
+            new=AsyncMock(side_effect=RuntimeError(SECRET)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await PodcastService.get_job_status("command:abc123")
+
+        assert exc_info.value.status_code == 500
+        assert SECRET not in exc_info.value.detail
+        assert exc_info.value.detail == "Failed to get job status"
+
+    @pytest.mark.asyncio
+    async def test_list_episodes_failure_returns_generic_message(self):
+        from fastapi import HTTPException
+
+        from api.podcast_service import PodcastService
+        from open_notebook.podcasts.models import PodcastEpisode
+
+        with patch.object(
+            PodcastEpisode,
+            "get_all",
+            new=AsyncMock(side_effect=RuntimeError(SECRET)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await PodcastService.list_episodes()
+
+        assert exc_info.value.status_code == 500
+        assert SECRET not in exc_info.value.detail
+        assert exc_info.value.detail == "Failed to list episodes"
+
+    @pytest.mark.asyncio
+    async def test_get_episode_failure_returns_generic_not_found(self):
+        from fastapi import HTTPException
+
+        from api.podcast_service import PodcastService
+        from open_notebook.podcasts.models import PodcastEpisode
+
+        with patch.object(
+            PodcastEpisode, "get", new=AsyncMock(side_effect=RuntimeError(SECRET))
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await PodcastService.get_episode("episode:missing")
+
+        assert exc_info.value.status_code == 404
+        assert SECRET not in exc_info.value.detail
+        assert exc_info.value.detail == "Episode not found"
+
+    @pytest.mark.asyncio
+    async def test_submit_generation_job_failure_returns_generic_message(self):
+        from fastapi import HTTPException
+
+        from api.podcast_service import PodcastService
+
+        with patch(
+            "api.podcast_service.EpisodeProfile.get_by_name",
+            new=AsyncMock(side_effect=RuntimeError(SECRET)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await PodcastService.submit_generation_job(
+                    episode_profile_name="default",
+                    speaker_profile_name="default",
+                    episode_name="Test Episode",
+                    content="some content",
+                )
+
+        assert exc_info.value.status_code == 500
+        assert SECRET not in exc_info.value.detail
+        assert exc_info.value.detail == "Failed to submit podcast generation job"


### PR DESCRIPTION
`api/routers/sources.py` and `api/podcast_service.py` interpolated the raw exception (`detail=f"...: {str(e)}"`) into client-facing error responses - inconsistent with the safer pattern already used elsewhere in the same files (e.g. the download handlers), which log the raw exception server-side but return a fixed generic message. Internal details (DB hostnames, connection errors, stack-trace fragments) could leak to any API caller through a 500 response.

Every occurrence already had a matching `logger.error()` call, so this is a client-facing message change only, not a logging change. Deliberate app-authored messages (`InvalidInputError` text, "Notebook X not found", `result.error_message`) are untouched - only raw `f"{str(e)}"` interpolation is affected.

`tests/test_config_endpoint_no_leak.py` is a regression lock for `api/routers/config.py` (already correct, not touched by this diff) rather than a fix - added since it shares the same "unauthenticated endpoint, don't leak exception text" concern.

**Stacked on #1002-#1009** (unmerged). All 13 new tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

