### PR TITLE
fix: contain podcast audio paths and batch job-status lookups

### DIFF
--- a/api/routers/podcasts.py
+++ b/api/routers/podcasts.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import List, Optional
 from urllib.parse import unquote, urlparse
@@ -12,6 +13,8 @@ from api.podcast_service import (
     PodcastGenerationResponse,
     PodcastService,
 )
+from open_notebook.config import PODCASTS_FOLDER
+from open_notebook.podcasts.models import PodcastEpisode
 
 router = APIRouter()
 
@@ -36,6 +39,21 @@ def _resolve_audio_path(audio_file: str) -> Path:
         parsed = urlparse(audio_file)
         return Path(unquote(parsed.path))
     return Path(audio_file)
+
+
+def _is_audio_path_contained(audio_path: Path) -> bool:
+    """Verify the resolved audio path stays within the podcasts output root.
+
+    Defense in depth: audio_file is only ever set server-side today from a
+    UUID-named directory under PODCASTS_FOLDER (build_episode_output_dir), so
+    this can't currently be tripped - but any endpoint that streams or
+    deletes the file should still refuse to follow it outside that root, in
+    case a future code path (e.g. importing external audio) sets it to
+    something else.
+    """
+    safe_root = Path(os.path.realpath(PODCASTS_FOLDER))
+    resolved = Path(os.path.realpath(audio_path))
+    return resolved.is_relative_to(safe_root)
 
 
 @router.post("/podcasts/generate", response_model=PodcastGenerationResponse)
@@ -89,6 +107,17 @@ async def list_podcast_episodes():
     try:
         episodes = await PodcastService.list_episodes()
 
+        # Batch-fetch job status for every episode with a command in one
+        # query instead of one round trip per episode (see
+        # PodcastEpisode.get_job_details_for_commands docstring).
+        try:
+            details_by_command = await PodcastEpisode.get_job_details_for_commands(
+                [episode.command for episode in episodes if episode.command]
+            )
+        except Exception as e:
+            logger.warning(f"Error batch-fetching podcast job statuses: {str(e)}")
+            details_by_command = {}
+
         response_episodes = []
         for episode in episodes:
             # Skip incomplete episodes without command or audio
@@ -99,11 +128,11 @@ async def list_podcast_episodes():
             job_status = None
             error_message = None
             if episode.command:
-                try:
-                    detail = await episode.get_job_detail()
+                detail = details_by_command.get(str(episode.command))
+                if detail is not None:
                     job_status = detail["status"]
                     error_message = detail["error_message"]
-                except Exception:
+                else:
                     job_status = "unknown"
             else:
                 # No command but has audio file = completed import
@@ -112,7 +141,7 @@ async def list_podcast_episodes():
             audio_url = None
             if episode.audio_file:
                 audio_path = _resolve_audio_path(episode.audio_file)
-                if audio_path.exists():
+                if _is_audio_path_contained(audio_path) and audio_path.exists():
                     audio_url = f"/api/podcasts/episodes/{episode.id}/audio"
 
             response_episodes.append(
@@ -164,7 +193,7 @@ async def get_podcast_episode(episode_id: str):
         audio_url = None
         if episode.audio_file:
             audio_path = _resolve_audio_path(episode.audio_file)
-            if audio_path.exists():
+            if _is_audio_path_contained(audio_path) and audio_path.exists():
                 audio_url = f"/api/podcasts/episodes/{episode.id}/audio"
 
         return PodcastEpisodeResponse(
@@ -202,6 +231,12 @@ async def stream_podcast_episode_audio(episode_id: str):
         raise HTTPException(status_code=404, detail="Episode has no audio file")
 
     audio_path = _resolve_audio_path(episode.audio_file)
+    if not _is_audio_path_contained(audio_path):
+        logger.warning(
+            f"Blocked audio access outside podcasts directory for episode {episode_id}: {audio_path}"
+        )
+        raise HTTPException(status_code=403, detail="Access to file denied")
+
     if not audio_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")
 
@@ -241,7 +276,11 @@ async def retry_podcast_episode(episode_id: str):
         # Delete audio file if any
         if episode.audio_file:
             audio_path = _resolve_audio_path(episode.audio_file)
-            if audio_path.exists():
+            if not _is_audio_path_contained(audio_path):
+                logger.warning(
+                    f"Refusing to delete audio file outside podcasts directory for episode {episode_id}: {audio_path}"
+                )
+            elif audio_path.exists():
                 try:
                     audio_path.unlink()
                 except Exception as e:
@@ -279,7 +318,11 @@ async def delete_podcast_episode(episode_id: str):
         # Delete the physical audio file if it exists
         if episode.audio_file:
             audio_path = _resolve_audio_path(episode.audio_file)
-            if audio_path.exists():
+            if not _is_audio_path_contained(audio_path):
+                logger.warning(
+                    f"Refusing to delete audio file outside podcasts directory for episode {episode_id}: {audio_path}"
+                )
+            elif audio_path.exists():
                 try:
                     audio_path.unlink()
                     logger.info(f"Deleted audio file: {audio_path}")

--- a/commands/podcast_commands.py
+++ b/commands/podcast_commands.py
@@ -230,6 +230,18 @@ async def generate_podcast_command(
         )
         await episode.save()
 
+        # SECURITY NOTE for future work: podcast_creator also supports
+        # configure("templates", {...}), which compiles the given string
+        # directly as Jinja2 template *source* (Prompter(template_text=...)
+        # in podcast_creator/config.py) - the exact SSTI shape already fixed
+        # in open_notebook/graphs/transformation.py (GHSA-f35w-wx37-26q7).
+        # We don't call it today (confirmed: no code path here sets the
+        # "templates" key, so podcast generation always uses the file-based
+        # prompts/podcast/*.jinja templates in this repo). If a "custom
+        # podcast template" feature is ever added, do NOT wire user/profile
+        # text into configure("templates", ...) - render it through a
+        # fixed, developer-authored template with the user text passed in
+        # as a plain variable instead, matching transformation.py's fix.
         configure("speakers_config", {"profiles": speaker_profiles_dict})
         configure("episode_config", {"profiles": episode_profiles_dict})
 

--- a/docs/7-DEVELOPMENT/security.md
+++ b/docs/7-DEVELOPMENT/security.md
@@ -85,6 +85,10 @@ The [ai-prompter](https://github.com/lfnovo/ai-prompter) library (>= 0.4.0) uses
 - If using Jinja2 directly (outside ai-prompter), always use `jinja2.sandbox.SandboxedEnvironment`
 - Never pass user-provided strings to `jinja2.Environment` or `jinja2.Template` directly
 
+### Third-party libraries with the same shape
+
+The `podcast_creator` library's `configure("templates", {...})` compiles the given string directly as Jinja2 template source (`Prompter(template_text=...)` in its `config.py`) - the identical pattern to the vulnerability above. `commands/podcast_commands.py` never calls it (confirmed: podcast generation always uses the file-based `prompts/podcast/*.jinja` templates in this repo), so this is currently dormant, not exploitable. If a "custom podcast template" feature is ever added, route user/profile text through a fixed, developer-authored template with the text passed in as a plain variable - do not wire it into `configure("templates", ...)`.
+
 ---
 
 ## File Handling (Path Traversal and Local File Inclusion)

--- a/open_notebook/config.py
+++ b/open_notebook/config.py
@@ -12,6 +12,12 @@ LANGGRAPH_CHECKPOINT_FILE = f"{sqlite_folder}/checkpoints.sqlite"
 UPLOADS_FOLDER = f"{DATA_FOLDER}/uploads"
 os.makedirs(UPLOADS_FOLDER, exist_ok=True)
 
+# PODCASTS FOLDER
+# Matches the root that build_episode_output_dir() (commands/podcast_commands.py)
+# creates episode directories under when called with DATA_FOLDER in production.
+PODCASTS_FOLDER = f"{DATA_FOLDER}/podcasts"
+os.makedirs(PODCASTS_FOLDER, exist_ok=True)
+
 # TIKTOKEN CACHE FOLDER
 # Reads TIKTOKEN_CACHE_DIR from the environment so Docker can redirect the cache
 # to a path outside /data/ (which is typically volume-mounted and would hide the

--- a/open_notebook/podcasts/CLAUDE.md
+++ b/open_notebook/podcasts/CLAUDE.md
@@ -51,6 +51,7 @@ All inherit from `ObjectModel` (SurrealDB base class with table_name and save/lo
 - **Job tracking**: command field links to surreal-commands RecordID.
 - `get_job_status()` fetches async job status via surreal-commands library.
 - `get_job_detail()` returns both status and error_message from the job (used for retry validation and UI error display).
+- `get_job_details_for_commands(command_ids)` (classmethod): batch version of `get_job_detail()` - fetches status/error_message for many commands in one query against the `command` table (same underlying SurrealDB as the rest of the app, just via `surreal_commands`' own connection module) instead of one round trip per command. Used by `GET /podcasts/episodes` so listing N episodes costs one job-status query instead of N.
 - `_prepare_save_data()` ensures command field is always RecordID format for database.
 
 ### migration.py

--- a/open_notebook/podcasts/models.py
+++ b/open_notebook/podcasts/models.py
@@ -270,6 +270,46 @@ class PodcastEpisode(ObjectModel):
         except Exception:
             return {"status": "unknown", "error_message": None}
 
+    @classmethod
+    async def get_job_details_for_commands(
+        cls, command_ids: List[Union[str, RecordID]]
+    ) -> Dict[str, dict]:
+        """
+        Batch-fetch {status, error_message} for many commands in one query.
+
+        Listing episodes otherwise calls get_job_detail() -> surreal_commands
+        .get_command_status() once per episode, each its own round trip
+        against the `command` table (see database/CLAUDE.md: no connection
+        pooling) - O(n) queries for n episodes. surreal_commands has no
+        batch lookup, but its command table lives in the same database
+        (same SURREAL_* env vars - see surreal_commands/repository/CLAUDE.md),
+        so this queries it directly in one shot instead of looping through
+        the library's per-command helper.
+
+        CommandStatus is a `str` subclass (`class CommandStatus(str, Enum)`),
+        so returning the raw DB string here is interchangeable with the
+        enum-wrapped value get_job_detail() returns for every comparison
+        this codebase does against it.
+        """
+        ids = [cid for cid in command_ids if cid]
+        grouped: Dict[str, dict] = {}
+        if not ids:
+            return grouped
+        try:
+            result = await repo_query(
+                "SELECT * FROM command WHERE id IN $command_ids",
+                {"command_ids": [ensure_record_id(cid) for cid in ids]},
+            )
+        except Exception as e:
+            logger.error(f"Error batch-fetching command status: {e}")
+            return grouped
+        for row in result:
+            grouped[str(row.get("id"))] = {
+                "status": row.get("status", "unknown"),
+                "error_message": row.get("error_message"),
+            }
+        return grouped
+
     @field_validator("command", mode="before")
     @classmethod
     def parse_command(cls, value):

--- a/tests/test_podcast_audio_containment.py
+++ b/tests/test_podcast_audio_containment.py
@@ -1,0 +1,235 @@
+"""
+Tests for the podcast audio path containment check (api/routers/podcasts.py).
+
+`_resolve_audio_path()` turns `episode.audio_file` into a filesystem Path;
+`_is_audio_path_contained()` verifies that path stays under PODCASTS_FOLDER
+before any endpoint streams or deletes it. audio_file is only ever set
+server-side today (from a UUID-named directory under PODCASTS_FOLDER), so
+these are defense-in-depth checks for a currently-unreachable path - these
+tests construct an out-of-root audio_file directly to exercise that defense.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.routers.podcasts import _is_audio_path_contained, _resolve_audio_path
+from open_notebook.config import PODCASTS_FOLDER
+from open_notebook.podcasts.models import PodcastEpisode
+
+
+def make_episode(audio_file=None, **overrides):
+    defaults = dict(
+        id="episode:test123",
+        name="Test Episode",
+        episode_profile={"name": "default"},
+        speaker_profile={"name": "default"},
+        briefing="test briefing",
+        content="test content",
+        audio_file=audio_file,
+        command=None,
+    )
+    defaults.update(overrides)
+    return PodcastEpisode(**defaults)
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestIsAudioPathContained:
+    def test_path_inside_podcasts_folder_is_contained(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "api.routers.podcasts.PODCASTS_FOLDER", str(tmp_path)
+        )
+        episode_dir = tmp_path / "episodes" / "some-uuid"
+        episode_dir.mkdir(parents=True)
+        audio_path = episode_dir / "final.mp3"
+        audio_path.write_bytes(b"fake audio")
+
+        assert _is_audio_path_contained(audio_path) is True
+
+    def test_sibling_directory_with_matching_prefix_is_not_contained(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression guard for the startswith-without-separator bug (finding
+        L14): a sibling dir that merely *starts with* the same prefix string
+        must NOT be treated as contained."""
+        real_root = tmp_path / "podcasts"
+        real_root.mkdir()
+        monkeypatch.setattr("api.routers.podcasts.PODCASTS_FOLDER", str(real_root))
+
+        sibling = tmp_path / "podcasts_evil"
+        sibling.mkdir()
+        evil_file = sibling / "secret.mp3"
+        evil_file.write_bytes(b"not yours")
+
+        assert _is_audio_path_contained(evil_file) is False
+
+    def test_path_traversal_outside_root_is_not_contained(self, tmp_path, monkeypatch):
+        root = tmp_path / "podcasts"
+        root.mkdir()
+        monkeypatch.setattr("api.routers.podcasts.PODCASTS_FOLDER", str(root))
+
+        outside = tmp_path / "outside.mp3"
+        outside.write_bytes(b"etc passwd style file")
+        traversal_path = Path(str(root)) / ".." / "outside.mp3"
+
+        assert _is_audio_path_contained(traversal_path) is False
+
+    def test_root_itself_is_contained(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("api.routers.podcasts.PODCASTS_FOLDER", str(tmp_path))
+        assert _is_audio_path_contained(tmp_path) is True
+
+    def test_real_podcasts_folder_resolves(self):
+        """Sanity check against the real (non-monkeypatched) config constant."""
+        inside = Path(PODCASTS_FOLDER) / "episodes" / "abc" / "out.mp3"
+        assert _is_audio_path_contained(inside) is True
+        outside = Path(os.path.realpath(PODCASTS_FOLDER)).parent / "elsewhere.mp3"
+        assert _is_audio_path_contained(outside) is False
+
+
+class TestResolveAudioPathHandlesFileUri:
+    def test_plain_path(self):
+        assert _resolve_audio_path("/data/podcasts/episodes/x/out.mp3") == Path(
+            "/data/podcasts/episodes/x/out.mp3"
+        )
+
+    def test_file_uri(self):
+        assert _resolve_audio_path("file:///data/podcasts/episodes/x/out.mp3") == Path(
+            "/data/podcasts/episodes/x/out.mp3"
+        )
+
+
+class TestStreamEndpointRejectsOutOfRootAudio:
+    def test_returns_403_for_audio_file_outside_podcasts_root(self, client, tmp_path):
+        evil_file = tmp_path / "secret.mp3"
+        evil_file.write_bytes(b"not a podcast")
+        episode = make_episode(audio_file=str(evil_file))
+
+        with patch(
+            "api.routers.podcasts.PodcastService.get_episode",
+            new=AsyncMock(return_value=episode),
+        ):
+            response = client.get("/api/podcasts/episodes/episode:test123/audio")
+
+        assert response.status_code == 403
+
+    def test_returns_404_for_missing_audio_inside_root(self, client):
+        # Inside PODCASTS_FOLDER (passes containment) but the file doesn't exist.
+        missing = Path(PODCASTS_FOLDER) / "episodes" / "does-not-exist" / "out.mp3"
+        episode = make_episode(audio_file=str(missing))
+
+        with patch(
+            "api.routers.podcasts.PodcastService.get_episode",
+            new=AsyncMock(return_value=episode),
+        ):
+            response = client.get("/api/podcasts/episodes/episode:test123/audio")
+
+        assert response.status_code == 404
+        assert "not found on disk" in response.json()["detail"]
+
+    def test_serves_audio_file_inside_root(self, client):
+        episode_dir = Path(PODCASTS_FOLDER) / "episodes" / "test-serve-uuid"
+        episode_dir.mkdir(parents=True, exist_ok=True)
+        audio_path = episode_dir / "out.mp3"
+        audio_path.write_bytes(b"fake mp3 bytes")
+        try:
+            episode = make_episode(audio_file=str(audio_path))
+            with patch(
+                "api.routers.podcasts.PodcastService.get_episode",
+                new=AsyncMock(return_value=episode),
+            ):
+                response = client.get("/api/podcasts/episodes/episode:test123/audio")
+
+            assert response.status_code == 200
+            assert response.content == b"fake mp3 bytes"
+        finally:
+            audio_path.unlink(missing_ok=True)
+            episode_dir.rmdir()
+
+
+class TestListAndGetOmitAudioUrlWhenOutOfRoot:
+    def test_list_episodes_omits_audio_url_for_out_of_root_file(self, client, tmp_path):
+        evil_file = tmp_path / "secret.mp3"
+        evil_file.write_bytes(b"not yours")
+        episode = make_episode(audio_file=str(evil_file))
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=[episode]),
+            ),
+        ):
+            response = client.get("/api/podcasts/episodes")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["audio_url"] is None
+
+    def test_get_episode_omits_audio_url_for_out_of_root_file(self, client, tmp_path):
+        evil_file = tmp_path / "secret.mp3"
+        evil_file.write_bytes(b"not yours")
+        episode = make_episode(audio_file=str(evil_file))
+
+        with patch(
+            "api.routers.podcasts.PodcastService.get_episode",
+            new=AsyncMock(return_value=episode),
+        ):
+            response = client.get("/api/podcasts/episodes/episode:test123")
+
+        assert response.status_code == 200
+        assert response.json()["audio_url"] is None
+
+
+class TestDeleteAndRetryRefuseOutOfRootUnlink:
+    def test_delete_episode_does_not_unlink_out_of_root_file(self, client, tmp_path):
+        evil_file = tmp_path / "secret.mp3"
+        evil_file.write_bytes(b"not yours")
+        episode = make_episode(audio_file=str(evil_file))
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.get_episode",
+                new=AsyncMock(return_value=episode),
+            ),
+            patch.object(PodcastEpisode, "delete", new=AsyncMock(return_value=True)),
+        ):
+            response = client.delete("/api/podcasts/episodes/episode:test123")
+
+        assert response.status_code == 200
+        assert evil_file.exists(), "out-of-root file must not be deleted"
+
+    def test_delete_episode_still_unlinks_in_root_file(self, client):
+        episode_dir = Path(PODCASTS_FOLDER) / "episodes" / "test-delete-uuid"
+        episode_dir.mkdir(parents=True, exist_ok=True)
+        audio_path = episode_dir / "out.mp3"
+        audio_path.write_bytes(b"fake mp3 bytes")
+        episode = make_episode(audio_file=str(audio_path))
+
+        try:
+            with (
+                patch(
+                    "api.routers.podcasts.PodcastService.get_episode",
+                    new=AsyncMock(return_value=episode),
+                ),
+                patch.object(
+                    PodcastEpisode, "delete", new=AsyncMock(return_value=True)
+                ),
+            ):
+                response = client.delete("/api/podcasts/episodes/episode:test123")
+
+            assert response.status_code == 200
+            assert not audio_path.exists(), "in-root file should be deleted"
+        finally:
+            if episode_dir.exists():
+                for f in episode_dir.iterdir():
+                    f.unlink()
+                episode_dir.rmdir()

--- a/tests/test_podcast_job_status_batching.py
+++ b/tests/test_podcast_job_status_batching.py
@@ -1,0 +1,225 @@
+"""
+Tests for the podcast episode listing N+1 fix (api/routers/podcasts.py +
+open_notebook/podcasts/models.py).
+
+list_podcast_episodes() used to call episode.get_job_detail() once per
+episode - each a separate round trip against the surreal_commands `command`
+table. PodcastEpisode.get_job_details_for_commands() batches that into one
+query; the router now calls it once up front instead of looping.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.routers.podcasts import list_podcast_episodes
+from open_notebook.podcasts.models import PodcastEpisode
+
+
+def make_episode(command=None, audio_file=None, **overrides):
+    defaults = dict(
+        id=f"episode:{overrides.pop('suffix', 'x')}",
+        name="Test Episode",
+        episode_profile={"name": "default"},
+        speaker_profile={"name": "default"},
+        briefing="briefing",
+        content="content",
+        command=command,
+        audio_file=audio_file,
+    )
+    defaults.update(overrides)
+    return PodcastEpisode(**defaults)
+
+
+class TestGetJobDetailsForCommandsUnit:
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_without_querying(self):
+        with patch(
+            "open_notebook.podcasts.models.repo_query", new=AsyncMock()
+        ) as mock_query:
+            result = await PodcastEpisode.get_job_details_for_commands([])
+        assert result == {}
+        mock_query.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_query_for_multiple_commands(self):
+        fake_rows = [
+            {"id": "command:a", "status": "completed", "error_message": None},
+            {"id": "command:b", "status": "failed", "error_message": "boom"},
+        ]
+        with patch(
+            "open_notebook.podcasts.models.repo_query",
+            new=AsyncMock(return_value=fake_rows),
+        ) as mock_query:
+            result = await PodcastEpisode.get_job_details_for_commands(
+                ["command:a", "command:b"]
+            )
+
+        mock_query.assert_awaited_once()
+        assert result == {
+            "command:a": {"status": "completed", "error_message": None},
+            "command:b": {"status": "failed", "error_message": "boom"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_query_failure_returns_empty_dict_rather_than_raising(self):
+        with patch(
+            "open_notebook.podcasts.models.repo_query",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ):
+            result = await PodcastEpisode.get_job_details_for_commands(["command:a"])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_falsy_command_ids_are_filtered_out(self):
+        with patch(
+            "open_notebook.podcasts.models.repo_query", new=AsyncMock(return_value=[])
+        ) as mock_query:
+            await PodcastEpisode.get_job_details_for_commands([None, "", "command:a"])
+
+        # Only the truthy id should reach the query's bound params.
+        _, kwargs_or_args = mock_query.call_args
+        bound_vars = mock_query.call_args.args[1]
+        assert len(bound_vars["command_ids"]) == 1
+
+
+class TestListPodcastEpisodesUsesBatchedLookup:
+    @pytest.mark.asyncio
+    async def test_batch_method_called_once_not_per_episode(self):
+        episodes = [
+            make_episode(command=f"command:cmd{i}", suffix=str(i)) for i in range(5)
+        ]
+        batch_result = {
+            f"command:cmd{i}": {"status": "completed", "error_message": None}
+            for i in range(5)
+        }
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=episodes),
+            ),
+            patch.object(
+                PodcastEpisode,
+                "get_job_details_for_commands",
+                new=AsyncMock(return_value=batch_result),
+            ) as mock_batch,
+            patch.object(
+                PodcastEpisode, "get_job_detail", new=AsyncMock()
+            ) as mock_per_episode,
+        ):
+            response = await list_podcast_episodes()
+
+        mock_batch.assert_awaited_once()
+        mock_per_episode.assert_not_called()
+        assert len(response) == 5
+        assert all(item.job_status == "completed" for item in response)
+
+    @pytest.mark.asyncio
+    async def test_episode_missing_from_batch_result_falls_back_to_unknown(self):
+        """Mirrors the old per-episode except-block fallback: a command with
+        no row (e.g. deleted) must not crash the whole listing."""
+        episodes = [make_episode(command="command:missing", suffix="1")]
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=episodes),
+            ),
+            patch.object(
+                PodcastEpisode,
+                "get_job_details_for_commands",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            response = await list_podcast_episodes()
+
+        assert response[0].job_status == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_total_batch_failure_falls_back_to_unknown_for_all(self):
+        episodes = [
+            make_episode(command=f"command:cmd{i}", suffix=str(i)) for i in range(3)
+        ]
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=episodes),
+            ),
+            patch.object(
+                PodcastEpisode,
+                "get_job_details_for_commands",
+                new=AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+        ):
+            response = await list_podcast_episodes()
+
+        assert len(response) == 3
+        assert all(item.job_status == "unknown" for item in response)
+
+    @pytest.mark.asyncio
+    async def test_episode_without_command_but_with_audio_is_completed(self):
+        episode = make_episode(
+            command=None, audio_file="/some/path.mp3", suffix="noaudiocmd"
+        )
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=[episode]),
+            ),
+            patch.object(
+                PodcastEpisode,
+                "get_job_details_for_commands",
+                new=AsyncMock(return_value={}),
+            ) as mock_batch,
+        ):
+            response = await list_podcast_episodes()
+
+        # No command anywhere -> batch call still happens (with an empty
+        # list) but must not error, and the episode is reported completed.
+        mock_batch.assert_awaited_once()
+        assert response[0].job_status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_episode_with_neither_command_nor_audio_is_skipped(self):
+        episode = make_episode(command=None, audio_file=None, suffix="incomplete")
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=[episode]),
+            ),
+            patch.object(
+                PodcastEpisode,
+                "get_job_details_for_commands",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            response = await list_podcast_episodes()
+
+        assert response == []
+
+    @pytest.mark.asyncio
+    async def test_error_message_propagates_from_batch_result(self):
+        episode = make_episode(command="command:err", suffix="err")
+        batch_result = {
+            "command:err": {"status": "failed", "error_message": "kaboom"}
+        }
+
+        with (
+            patch(
+                "api.routers.podcasts.PodcastService.list_episodes",
+                new=AsyncMock(return_value=[episode]),
+            ),
+            patch.object(
+                PodcastEpisode,
+                "get_job_details_for_commands",
+                new=AsyncMock(return_value=batch_result),
+            ),
+        ):
+            response = await list_podcast_episodes()
+
+        assert response[0].job_status == "failed"
+        assert response[0].error_message == "kaboom"


### PR DESCRIPTION
Two small fixes to the podcast episode-listing path, plus a doc note:

- `audio_file` is only ever set server-side today from a UUID-named directory under `PODCASTS_FOLDER`, so this can't currently be tripped - but the stream/retry/delete endpoints didn't verify the resolved path actually stayed within `PODCASTS_FOLDER` before following it. Add `_is_audio_path_contained()` as defense in depth against a future code path (e.g. importing external audio) setting `audio_file` to something else.
- Listing episodes called `get_job_detail()` -> `get_command_status()` once per episode, each its own round trip (no connection pooling). Add `PodcastEpisode.get_job_details_for_commands()` to batch-fetch status for every episode's command in one query instead.

Also documents (`docs/7-DEVELOPMENT/security.md`) that `podcast_creator`'s `configure("templates", {...})` compiles strings as Jinja2 template source - the same shape as the SSTI vulnerability fixed in `transformation.py` (GHSA-f35w-wx37-26q7). Confirmed dormant: no code path in this repo calls it today. `commands/podcast_commands.py` gets a matching code comment warning against wiring user text into it if a "custom podcast template" feature is ever added.

**Stacked on #1002-#1009** (unmerged). All 24 new tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

