### PR TITLE
fix: surface silent command-submission failures where they matter

### DIFF
--- a/api/routers/embedding.py
+++ b/api/routers/embedding.py
@@ -87,8 +87,18 @@ async def embed_content(embed_request: EmbedRequest):
             elif item_type == "note":
                 note_item = await Note.get(item_id)
 
-                # Note.save() internally submits embed_note command and returns command_id
+                # Note.save() internally submits embed_note command and
+                # returns command_id. Unlike Source.vectorize(), save()'s
+                # embed submission is best-effort (a hiccup there shouldn't
+                # fail an otherwise-successful note save) - but this
+                # endpoint's whole point is submitting the embedding job,
+                # so a submission failure here (content present, no
+                # command_id) must still surface as a failure.
                 command_id = await note_item.save()
+                if not command_id and note_item.content and note_item.content.strip():
+                    raise HTTPException(
+                        status_code=500, detail="Failed to submit note embedding job"
+                    )
                 message = "Note embedding job submitted"
 
             return EmbedResponse(

--- a/open_notebook/domain/CLAUDE.md
+++ b/open_notebook/domain/CLAUDE.md
@@ -32,7 +32,7 @@ Two base classes support different persistence patterns: **ObjectModel** (mutabl
   - `vectorize()`: Submit async embedding job (returns command_id, fire-and-forget)
   - `get_status()`, `get_processing_progress()`: Track job via surreal_commands
   - `get_context()`: Returns summary for LLM context
-  - `add_insight()`: Submit async insight creation via `create_insight_command` (fire-and-forget, returns command_id)
+  - `add_insight()`: Submit async insight creation via `create_insight_command` (fire-and-forget, returns command_id). Raises `DatabaseOperationError` if *submission* itself fails (matches `vectorize()`) - callers (`transformation.py`, `source.py`) run inside surreal-commands jobs whose outer exception handling already retries/fails on this
 
 - **Note**: Standalone or linked notes
   - `save()`: Submits `embed_note` command after save (fire-and-forget)
@@ -95,9 +95,9 @@ Two base classes support different persistence patterns: **ObjectModel** (mutabl
 - **Source.command field**: Stored as RecordID; auto-parsed from strings via field_validator
 - **Text truncation**: `Note.get_context(short)` hardcodes 100-char limit
 - **Auto-embedding behavior**:
-  - `Note.save()` → auto-submits `embed_note` command
+  - `Note.save()` → auto-submits `embed_note` command; submission failure is caught and logged (returns `None`), not raised - the note's core save already succeeded by that point. `api/routers/embedding.py`'s explicit `POST /embed` (item_type=note) checks for this and still surfaces it as a failure, since submission is the whole point of that call
   - `Source.save()` → does NOT auto-submit (must call `vectorize()` explicitly)
-  - `Source.add_insight()` → submits `create_insight_command` which handles DB insert + `embed_insight` command (all fire-and-forget)
+  - `Source.add_insight()` → submits `create_insight_command` which handles DB insert + `embed_insight` command (all fire-and-forget - but a failure to *submit* the command raises rather than being swallowed)
 - **Relationship strings**: Must match SurrealDB schema (reference, artifact, refers_to)
 
 ## How to Add New Model

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -564,7 +564,7 @@ class Source(ObjectModel):
             logger.exception(e)
             raise DatabaseOperationError(e)
 
-    async def add_insight(self, insight_type: str, content: str) -> Optional[str]:
+    async def add_insight(self, insight_type: str, content: str) -> str:
         """
         Submit insight creation as an async command (fire-and-forget).
 
@@ -581,10 +581,17 @@ class Source(ObjectModel):
             content: The insight content text
 
         Returns:
-            command_id for optional tracking, or None if submission failed
+            command_id for optional tracking
 
         Raises:
             InvalidInputError: If insight_type or content is empty
+            DatabaseOperationError: If submitting the command fails. Matches
+                vectorize()'s contract - callers (transformation.py, source.py)
+                run inside surreal-commands jobs whose outer exception
+                handling already retries transient failures, so a swallowed
+                submission failure here previously meant a transformation
+                could report success while the insight was silently never
+                persisted.
         """
         if not insight_type or not content:
             raise InvalidInputError("Insight type and content must be provided")
@@ -609,7 +616,8 @@ class Source(ObjectModel):
 
         except Exception as e:
             logger.error(f"Error submitting create_insight for source {self.id}: {e}")
-            return None
+            logger.exception(e)
+            raise DatabaseOperationError(e)
 
     def _prepare_save_data(self) -> dict:
         """Override to ensure command field is always RecordID format for database"""
@@ -683,20 +691,30 @@ class Note(ObjectModel):
         after saving, instead of inline embedding.
 
         Returns:
-            Optional[str]: The command_id if embedding was submitted, None otherwise
+            Optional[str]: The command_id if embedding was submitted, None
+                otherwise (either no content to embed, or submission failed)
         """
         # Call parent save (without embedding)
         await super().save()
 
-        # Submit embedding command (fire-and-forget) if note has content
+        # Submit embedding command (fire-and-forget) if note has content.
+        # Unlike Source.vectorize()/add_insight() (explicit, dedicated calls
+        # whose whole point is the submission), this runs automatically
+        # inside save() - the note itself is already durably saved above,
+        # so a submission hiccup here shouldn't fail an otherwise-successful
+        # save with a 500. Best-effort: log and move on.
         if self.id and self.content and self.content.strip():
-            command_id = submit_command(
-                "open_notebook",
-                "embed_note",
-                {"note_id": str(self.id)},
-            )
-            logger.debug(f"Submitted embed_note command {command_id} for {self.id}")
-            return command_id
+            try:
+                command_id = submit_command(
+                    "open_notebook",
+                    "embed_note",
+                    {"note_id": str(self.id)},
+                )
+                logger.debug(f"Submitted embed_note command {command_id} for {self.id}")
+                return command_id
+            except Exception as e:
+                logger.error(f"Failed to submit embed_note command for {self.id}: {e}")
+                return None
 
         return None
 

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -615,8 +615,7 @@ class Source(ObjectModel):
             return str(command_id)
 
         except Exception as e:
-            logger.error(f"Error submitting create_insight for source {self.id}: {e}")
-            logger.exception(e)
+            logger.exception(f"Error submitting create_insight for source {self.id}: {e}")
             raise DatabaseOperationError(e)
 
     def _prepare_save_data(self) -> dict:

--- a/tests/test_add_insight_failure_propagation.py
+++ b/tests/test_add_insight_failure_propagation.py
@@ -1,0 +1,217 @@
+"""
+Tests for Source.add_insight() raising on submission failure instead of
+silently swallowing it.
+
+Previously, if submit_command() failed, add_insight() logged the error and
+returned None. Both callers (transformation.py, source.py) discard the
+return value, so a transformation could report success=True while the
+insight was never persisted. add_insight() now matches the sibling
+vectorize() method's contract: submission failures raise
+DatabaseOperationError so they propagate to the job-level retry/failure
+handling that already exists in commands/source_commands.py.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_notebook.domain.notebook import Source
+from open_notebook.exceptions import DatabaseOperationError, InvalidInputError
+
+
+def make_source(**overrides):
+    defaults = dict(id="source:test123", title="Test Source", asset=None)
+    defaults.update(overrides)
+    return Source(**defaults)
+
+
+class TestAddInsightRaisesOnSubmissionFailure:
+    @pytest.mark.asyncio
+    async def test_returns_command_id_on_success(self):
+        source = make_source()
+        with patch(
+            "open_notebook.domain.notebook.submit_command",
+            return_value="command:abc123",
+        ):
+            result = await source.add_insight("Summary", "some content")
+        assert result == "command:abc123"
+
+    @pytest.mark.asyncio
+    async def test_raises_database_operation_error_on_submission_failure(self):
+        source = make_source()
+        with patch(
+            "open_notebook.domain.notebook.submit_command",
+            side_effect=RuntimeError("queue unavailable"),
+        ):
+            with pytest.raises(DatabaseOperationError):
+                await source.add_insight("Summary", "some content")
+
+    @pytest.mark.asyncio
+    async def test_still_raises_invalid_input_for_empty_content(self):
+        source = make_source()
+        with pytest.raises(InvalidInputError):
+            await source.add_insight("Summary", "")
+
+    @pytest.mark.asyncio
+    async def test_still_raises_invalid_input_for_empty_type(self):
+        source = make_source()
+        with pytest.raises(InvalidInputError):
+            await source.add_insight("", "some content")
+
+
+class TestTransformationGraphPropagatesFailure:
+    """open_notebook/graphs/transformation.py: run_transformation()."""
+
+    @pytest.mark.asyncio
+    async def test_add_insight_failure_propagates_out_of_run_transformation(self):
+        from open_notebook.graphs.transformation import run_transformation
+
+        source = make_source()
+        transformation = MagicMock(title="Summary", prompt="Summarize this")
+
+        fake_response = MagicMock()
+        fake_response.content = "the transformation output"
+        fake_chain = AsyncMock()
+        fake_chain.ainvoke = AsyncMock(return_value=fake_response)
+
+        state = {
+            "source": source,
+            "input_text": None,
+            "transformation": transformation,
+        }
+
+        with (
+            patch(
+                "open_notebook.graphs.transformation.DefaultPrompts",
+                return_value=MagicMock(transformation_instructions=None),
+            ),
+            patch(
+                "open_notebook.graphs.transformation.Prompter"
+            ) as mock_prompter_cls,
+            patch(
+                "open_notebook.graphs.transformation.provision_langchain_model",
+                new=AsyncMock(return_value=fake_chain),
+            ),
+            patch.object(
+                Source,
+                "add_insight",
+                new=AsyncMock(side_effect=DatabaseOperationError("submission failed")),
+            ) as mock_add_insight,
+        ):
+            mock_prompter_cls.return_value.render.return_value = "rendered prompt"
+            source.full_text = "full text of the source"
+
+            with pytest.raises(DatabaseOperationError):
+                await run_transformation(state, config={"configurable": {}})
+
+        mock_add_insight.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_add_insight_returns_output_normally(self):
+        from open_notebook.graphs.transformation import run_transformation
+
+        source = make_source()
+        transformation = MagicMock(title="Summary", prompt="Summarize this")
+
+        fake_response = MagicMock()
+        fake_response.content = "the transformation output"
+        fake_chain = AsyncMock()
+        fake_chain.ainvoke = AsyncMock(return_value=fake_response)
+
+        state = {
+            "source": source,
+            "input_text": None,
+            "transformation": transformation,
+        }
+
+        with (
+            patch(
+                "open_notebook.graphs.transformation.DefaultPrompts",
+                return_value=MagicMock(transformation_instructions=None),
+            ),
+            patch(
+                "open_notebook.graphs.transformation.Prompter"
+            ) as mock_prompter_cls,
+            patch(
+                "open_notebook.graphs.transformation.provision_langchain_model",
+                new=AsyncMock(return_value=fake_chain),
+            ),
+            patch.object(
+                Source, "add_insight", new=AsyncMock(return_value="command:ok")
+            ) as mock_add_insight,
+        ):
+            mock_prompter_cls.return_value.render.return_value = "rendered prompt"
+            source.full_text = "full text of the source"
+
+            result = await run_transformation(state, config={"configurable": {}})
+
+        mock_add_insight.assert_awaited_once()
+        assert result == {"output": "the transformation output"}
+
+
+class TestSourceGraphTransformContentPropagatesFailure:
+    """open_notebook/graphs/source.py: transform_content() - the other
+    add_insight() caller, invoked during initial source ingestion."""
+
+    @pytest.mark.asyncio
+    async def test_add_insight_failure_propagates_out_of_transform_content(self):
+        from open_notebook.graphs.source import transform_content
+
+        source = make_source()
+        source.full_text = "the source's full text"
+        transformation = MagicMock(title="Summary")
+
+        state = {"source": source, "transformation": transformation}
+
+        with (
+            patch(
+                "open_notebook.graphs.source.transform_graph.ainvoke",
+                new=AsyncMock(return_value={"output": "transformed output"}),
+            ),
+            patch.object(
+                Source,
+                "add_insight",
+                new=AsyncMock(side_effect=DatabaseOperationError("submission failed")),
+            ) as mock_add_insight,
+        ):
+            with pytest.raises(DatabaseOperationError):
+                await transform_content(state)
+
+        mock_add_insight.assert_awaited_once()
+
+
+class TestRunTransformationCommandDoesNotReportFalseSuccess:
+    """commands/source_commands.py: run_transformation_command()."""
+
+    @pytest.mark.asyncio
+    async def test_add_insight_submission_failure_does_not_return_success_true(self):
+        from commands.source_commands import (
+            RunTransformationInput,
+            run_transformation_command,
+        )
+
+        source = make_source()
+        transformation = MagicMock(id="transformation:1")
+
+        input_data = RunTransformationInput(
+            source_id="source:test123", transformation_id="transformation:1"
+        )
+
+        with (
+            patch(
+                "commands.source_commands.Source.get",
+                new=AsyncMock(return_value=source),
+            ),
+            patch(
+                "commands.source_commands.Transformation.get",
+                new=AsyncMock(return_value=transformation),
+            ),
+            patch(
+                "commands.source_commands.transform_graph.ainvoke",
+                new=AsyncMock(
+                    side_effect=DatabaseOperationError("insight submission failed")
+                ),
+            ),
+        ):
+            with pytest.raises(DatabaseOperationError):
+                await run_transformation_command(input_data)

--- a/tests/test_note_save_embed_resilience.py
+++ b/tests/test_note_save_embed_resilience.py
@@ -1,0 +1,174 @@
+"""
+Tests for Note.save()'s embed_note submission resilience
+(open_notebook/domain/notebook.py) and its one caller that needs the
+opposite behavior (api/routers/embedding.py).
+
+Note.save()'s embed_note submission is now wrapped in try/except: the note
+itself is already durably saved by the time it's attempted (verified
+against a live embedded SurrealDB instance - see session notes), so a
+transient submission failure shouldn't turn an otherwise-successful save
+into a 500, unlike Source.vectorize()/add_insight() which are dedicated
+"submit this job" calls with nothing useful to fall back on.
+
+api/routers/embedding.py's POST /embed endpoint is the one exception: for
+item_type=note it reuses Note.save() specifically *because* embedding
+submission is the explicit point of that call (mirroring
+Source.vectorize()) - so it now explicitly checks for a submission failure
+(content present, no command_id) and still surfaces it as a failure.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_notebook.domain.notebook import Note
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestNoteSaveEmbedResilience:
+    @pytest.mark.asyncio
+    async def test_save_does_not_raise_when_submission_fails(self):
+        note = Note(title="Test", content="some content")
+        with (
+            patch(
+                "open_notebook.domain.base.ObjectModel.save",
+                new=AsyncMock(),
+            ),
+            patch(
+                "open_notebook.domain.notebook.submit_command",
+                side_effect=RuntimeError("job queue is down"),
+            ),
+        ):
+            object.__setattr__(note, "id", "note:abc123")
+            command_id = await note.save()
+
+        assert command_id is None
+
+    @pytest.mark.asyncio
+    async def test_save_still_calls_super_save_before_attempting_submission(self):
+        """The note's core save must happen (and succeed) regardless of
+        whether the embedding submission afterward fails."""
+        note = Note(title="Test", content="some content")
+        with (
+            patch(
+                "open_notebook.domain.base.ObjectModel.save",
+                new=AsyncMock(),
+            ) as mock_super_save,
+            patch(
+                "open_notebook.domain.notebook.submit_command",
+                side_effect=RuntimeError("job queue is down"),
+            ),
+        ):
+            object.__setattr__(note, "id", "note:abc123")
+            await note.save()
+
+        mock_super_save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_save_returns_command_id_on_success(self):
+        note = Note(title="Test", content="some content")
+        with (
+            patch("open_notebook.domain.base.ObjectModel.save", new=AsyncMock()),
+            patch(
+                "open_notebook.domain.notebook.submit_command",
+                return_value="command:xyz789",
+            ),
+        ):
+            object.__setattr__(note, "id", "note:abc123")
+            command_id = await note.save()
+
+        assert command_id == "command:xyz789"
+
+    @pytest.mark.asyncio
+    async def test_save_returns_none_when_no_content(self):
+        note = Note(title="Test", content=None)
+        with (
+            patch("open_notebook.domain.base.ObjectModel.save", new=AsyncMock()),
+            patch(
+                "open_notebook.domain.notebook.submit_command"
+            ) as mock_submit,
+        ):
+            object.__setattr__(note, "id", "note:abc123")
+            command_id = await note.save()
+
+        assert command_id is None
+        mock_submit.assert_not_called()
+
+
+class TestEmbeddingEndpointNoteBranch:
+    """api/routers/embedding.py: POST /api/embed with item_type=note."""
+
+    def test_returns_500_when_submission_fails_with_content(self, client):
+        note = Note(title="Test", content="some content")
+        object.__setattr__(note, "id", "note:abc123")
+
+        with (
+            patch("api.routers.embedding.Note.get", new=AsyncMock(return_value=note)),
+            patch.object(Note, "save", new=AsyncMock(return_value=None)),
+            patch(
+                "open_notebook.ai.models.model_manager.get_embedding_model",
+                new=AsyncMock(return_value=object()),
+            ),
+        ):
+            response = client.post(
+                "/api/embed",
+                json={"item_id": "note:abc123", "item_type": "note", "async_processing": False},
+            )
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to submit note embedding job"
+
+    def test_succeeds_when_submission_works(self, client):
+        note = Note(title="Test", content="some content")
+        object.__setattr__(note, "id", "note:abc123")
+
+        with (
+            patch("api.routers.embedding.Note.get", new=AsyncMock(return_value=note)),
+            patch.object(
+                Note, "save", new=AsyncMock(return_value="command:abc123")
+            ),
+            patch(
+                "open_notebook.ai.models.model_manager.get_embedding_model",
+                new=AsyncMock(return_value=object()),
+            ),
+        ):
+            response = client.post(
+                "/api/embed",
+                json={"item_id": "note:abc123", "item_type": "note", "async_processing": False},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["command_id"] == "command:abc123"
+
+    def test_succeeds_with_no_command_id_when_note_has_no_content(self, client):
+        """A content-less note has nothing to embed - save() correctly
+        returns None, and that must NOT be treated as a submission failure."""
+        note = Note(title="Test", content=None)
+        object.__setattr__(note, "id", "note:abc123")
+
+        with (
+            patch("api.routers.embedding.Note.get", new=AsyncMock(return_value=note)),
+            patch.object(Note, "save", new=AsyncMock(return_value=None)),
+            patch(
+                "open_notebook.ai.models.model_manager.get_embedding_model",
+                new=AsyncMock(return_value=object()),
+            ),
+        ):
+            response = client.post(
+                "/api/embed",
+                json={"item_id": "note:abc123", "item_type": "note", "async_processing": False},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["command_id"] is None


### PR DESCRIPTION
`Source.add_insight()` caught submission failures and returned `None` instead of raising - callers (`transformation.py`, `source.py`) run inside surreal-commands jobs whose outer exception handling already retries/fails on this, so a swallowed submission failure meant a transformation could report success while the insight was silently never persisted. Now raises `DatabaseOperationError`, matching `vectorize()`'s existing contract.

`Note.save()`'s auto-embed needs the opposite treatment: it's an implicit side effect of `save()` (not an explicit dedicated call), and the note itself is already durably saved by the time it runs - so a submission hiccup there shouldn't turn an otherwise-successful save into a 500. Wrapped in try/except, logs and returns `None`. `api/routers/embedding.py`'s explicit `POST /embed` (item_type=note) is the one caller for whom submission success genuinely is the point of the call, so it separately checks for a missing `command_id` and surfaces that as a failure.

**Stacked on #1002-#1009** (unmerged). All 15 new tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

