### PR TITLE
fix: upgrade credential encryption key derivation to PBKDF2

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,3 +1,4 @@
+import secrets
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Request
@@ -67,8 +68,10 @@ class PasswordAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Check password
-        if credentials != self.password:
+        # Check password (constant-time to avoid a timing side-channel)
+        if not secrets.compare_digest(
+            credentials.encode("utf-8"), self.password.encode("utf-8")
+        ):
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Invalid password"},
@@ -108,8 +111,10 @@ def check_api_password(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Check password
-    if credentials.credentials != password:
+    # Check password (constant-time to avoid a timing side-channel)
+    if not secrets.compare_digest(
+        credentials.credentials.encode("utf-8"), password.encode("utf-8")
+    ):
         raise HTTPException(
             status_code=401,
             detail="Invalid password",

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -7,11 +7,8 @@ Extracted from the credentials router to follow the service layer pattern.
 All functions raise ValueError for business errors (router converts to HTTPException).
 """
 
-import ipaddress
 import os
-import socket
 from typing import Dict, List, Optional
-from urllib.parse import urlparse
 
 import httpx
 from loguru import logger
@@ -21,6 +18,7 @@ from api.models import CredentialResponse
 from open_notebook.ai.model_discovery import classify_model_type
 from open_notebook.domain.credential import Credential
 from open_notebook.utils.encryption import get_secret_from_env
+from open_notebook.utils.url_validation import validate_url
 
 # =============================================================================
 # Constants
@@ -82,113 +80,6 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "dashscope": ["language"],
     "minimax": ["language"],
 }
-
-
-# =============================================================================
-# URL Validation (SSRF protection)
-# =============================================================================
-
-
-def validate_url(url: str, provider: str) -> None:
-    """
-    Validate URL format for API endpoints.
-
-    This is a self-hosted application, so we allow:
-    - Private IPs (10.x, 172.16-31.x, 192.168.x) for self-hosted services
-    - Localhost for local services (Ollama, LM Studio, etc.)
-
-    We only block:
-    - Invalid schemes (must be http or https)
-    - Malformed URLs
-    - Link-local addresses (169.254.x.x) - used for cloud metadata endpoints
-    - Hostnames that resolve to link-local addresses
-
-    Args:
-        url: The URL to validate
-        provider: The provider name (for logging/context)
-
-    Raises:
-        ValueError: If the URL is invalid
-    """
-    if not url or not url.strip():
-        return  # Empty URLs handled elsewhere
-
-    try:
-        parsed = urlparse(url.strip())
-
-        # Validate scheme - only http/https allowed
-        if parsed.scheme not in ("http", "https"):
-            raise ValueError(
-                f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
-            )
-
-        # Extract hostname
-        hostname = parsed.hostname
-        if not hostname:
-            raise ValueError("Invalid URL: hostname could not be determined.")
-
-        # Try to parse as IP address to check for dangerous addresses
-        try:
-            ip = ipaddress.ip_address(hostname)
-
-            # Block link-local addresses (169.254.x.x) - used for cloud metadata
-            # These are dangerous as they can expose cloud instance credentials
-            if ip.is_link_local:
-                raise ValueError(
-                    "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
-                    "These addresses are used for cloud metadata endpoints."
-                )
-
-            # Block IPv4-mapped IPv6 addresses pointing to link-local
-            # e.g. ::ffff:169.254.169.254 bypasses IPv6 is_link_local check
-            if hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped and ip.ipv4_mapped.is_link_local:
-                raise ValueError(
-                    "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
-                    "These addresses are used for cloud metadata endpoints."
-                )
-
-        except ValueError as ve:
-            # Re-raise our own ValueErrors
-            if "Link-local" in str(ve) or "Invalid URL" in str(ve):
-                raise
-            # Not an IP address, it's a hostname - need to resolve and check
-            try:
-                # Resolve hostname to IP address
-                resolved_ips = socket.getaddrinfo(hostname, None)
-                for family, _, _, _, sockaddr in resolved_ips:
-                    ip_addr = sockaddr[0]
-                    try:
-                        parsed_ip = ipaddress.ip_address(ip_addr)
-                        if parsed_ip.is_link_local:
-                            raise ValueError(
-                                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) which is not allowed for security reasons. "
-                                "These addresses are used for cloud metadata endpoints."
-                            )
-                        # Block IPv4-mapped IPv6 addresses pointing to link-local
-                        if (
-                            hasattr(parsed_ip, "ipv4_mapped")
-                            and parsed_ip.ipv4_mapped
-                            and parsed_ip.ipv4_mapped.is_link_local
-                        ):
-                            raise ValueError(
-                                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) which is not allowed for security reasons. "
-                                "These addresses are used for cloud metadata endpoints."
-                            )
-                    except ValueError as inner_ve:
-                        if "link-local" in str(inner_ve).lower() or "Link-local" in str(inner_ve):
-                            raise
-                        # Skip non-IP addresses (e.g., IPv6 zones)
-                        continue
-            except socket.gaierror:
-                # Could not resolve hostname - allow it since the URL may be
-                # valid in the deployment environment (e.g., Azure endpoints,
-                # internal DNS names). We only block link-local addresses.
-                pass
-
-    except ValueError:
-        raise
-    except Exception:
-        raise ValueError("Invalid URL format. Check server logs for details.")
 
 
 # =============================================================================
@@ -541,6 +432,10 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
     if provider == "ollama":
         ollama_url = base_url or "http://localhost:11434"
         try:
+            # Re-validate at request time: the base_url may have been saved
+            # against a hostname that only later resolved to an internal
+            # address (DNS rebinding).
+            validate_url(ollama_url, "ollama")
             async with httpx.AsyncClient() as client:
                 response = await client.get(f"{ollama_url}/api/tags", timeout=10.0)
                 response.raise_for_status()
@@ -562,6 +457,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not base_url:
             return []
         try:
+            # Re-validate at request time (see ollama branch above).
+            validate_url(base_url, "openai_compatible")
             headers = {}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
@@ -588,6 +485,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not endpoint or not api_key:
             return []
         try:
+            # Re-validate at request time (see ollama branch above).
+            validate_url(endpoint, "azure")
             url = f"{endpoint.rstrip('/')}/openai/models?api-version={api_version}"
             headers = {"api-key": api_key}
             async with httpx.AsyncClient() as client:

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -8,7 +8,13 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from open_notebook.database.repository import ensure_record_id, repo_query
-from open_notebook.domain.notebook import ChatSession, Note, Notebook, Source
+from open_notebook.domain.notebook import (
+    ChatSession,
+    Note,
+    Notebook,
+    Source,
+    SourceInsight,
+)
 from open_notebook.exceptions import (
     NotFoundError,
 )
@@ -490,9 +496,21 @@ async def build_context(request: BuildContextRequest):
         else:
             # Default behavior - include all sources and notes with short context
             sources = await notebook.get_sources()
+            try:
+                insights_by_source = await SourceInsight.get_for_sources(
+                    [source.id for source in sources if source.id]
+                )
+            except Exception as e:
+                # Match the per-source fallback below: a hiccup fetching
+                # insights shouldn't fail the whole context request.
+                logger.warning(f"Error batch-fetching source insights: {str(e)}")
+                insights_by_source = {}
             for source in sources:
                 try:
-                    source_context = await source.get_context(context_size="short")
+                    source_context = await source.get_context(
+                        context_size="short",
+                        insights=insights_by_source.get(source.id or "", []),
+                    )
                     context_data["sources"].append(source_context)
                     total_content += str(source_context)
                 except Exception as e:

--- a/api/routers/context.py
+++ b/api/routers/context.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from loguru import logger
 
 from api.models import ContextRequest, ContextResponse
-from open_notebook.domain.notebook import Note, Notebook, Source
+from open_notebook.domain.notebook import Note, Notebook, Source, SourceInsight
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.utils import token_count
 
@@ -77,9 +77,21 @@ async def get_notebook_context(notebook_id: str, context_request: ContextRequest
         else:
             # Default behavior - include all sources and notes with short context
             sources = await notebook.get_sources()
+            try:
+                insights_by_source = await SourceInsight.get_for_sources(
+                    [source.id for source in sources if source.id]
+                )
+            except Exception as e:
+                # Match the per-source fallback below: a hiccup fetching
+                # insights shouldn't fail the whole context request.
+                logger.warning(f"Error batch-fetching source insights: {str(e)}")
+                insights_by_source = {}
             for source in sources:
                 try:
-                    source_context = await source.get_context(context_size="short")
+                    source_context = await source.get_context(
+                        context_size="short",
+                        insights=insights_by_source.get(source.id or "", []),
+                    )
                     context_data["source"].append(source_context)
                     total_content += str(source_context)
                 except Exception as e:

--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -3,7 +3,7 @@ from loguru import logger
 
 from api.models import NoteResponse, SaveAsNoteRequest, SourceInsightResponse
 from open_notebook.domain.notebook import SourceInsight
-from open_notebook.exceptions import InvalidInputError
+from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
@@ -73,6 +73,8 @@ async def save_insight_as_note(insight_id: str, request: SaveAsNoteRequest):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except InvalidInputError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -97,18 +97,12 @@ def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
         counter += 1
 
 
-async def save_uploaded_file(upload_file: UploadFile) -> str:
-    """Save uploaded file to uploads folder and return file path."""
-    if not upload_file.filename:
-        raise ValueError("No filename provided")
-
-    # Generate unique filename
-    file_path = generate_unique_filename(upload_file.filename, UPLOADS_FOLDER)
-
+def _write_uploaded_file(filename: str, content: bytes) -> str:
+    """Sync filesystem work for save_uploaded_file() - run via asyncio.to_thread
+    so a large upload doesn't block the event loop for other requests."""
+    file_path = generate_unique_filename(filename, UPLOADS_FOLDER)
     try:
-        # Save file
         with open(file_path, "wb") as f:
-            content = await upload_file.read()
             f.write(content)
 
         logger.info(f"Saved uploaded file to: {file_path}")
@@ -119,6 +113,15 @@ async def save_uploaded_file(upload_file: UploadFile) -> str:
         if os.path.exists(file_path):
             os.unlink(file_path)
         raise
+
+
+async def save_uploaded_file(upload_file: UploadFile) -> str:
+    """Save uploaded file to uploads folder and return file path."""
+    if not upload_file.filename:
+        raise ValueError("No filename provided")
+
+    content = await upload_file.read()
+    return await asyncio.to_thread(_write_uploaded_file, upload_file.filename, content)
 
 
 def parse_source_form_data(

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -17,6 +17,7 @@ from loguru import logger
 from surreal_commands import execute_command_sync, submit_command
 
 from api.command_service import CommandService
+from api.credentials_service import validate_url
 from api.models import (
     AssetModel,
     CreateSourceInsightRequest,
@@ -360,6 +361,12 @@ async def create_source(
                 raise HTTPException(
                     status_code=400, detail="URL is required for link type"
                 )
+            # Block SSRF to internal/metadata addresses before the server ever
+            # fetches this URL (same guard used for provider-credential URLs).
+            try:
+                validate_url(source_data.url, "source")
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
             content_state["url"] = source_data.url
         elif source_data.type == "upload":
             # Use uploaded file path or provided file_path (backward compatibility)

--- a/docs/3-USER-GUIDE/api-configuration.md
+++ b/docs/3-USER-GUIDE/api-configuration.md
@@ -31,7 +31,7 @@ environment:
   - OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-passphrase
 ```
 
-Any string works as a key — it will be securely derived via SHA-256 internally.
+Any string works as a key — it will be securely derived via salted PBKDF2-HMAC-SHA256 (600k iterations) internally.
 
 > **Warning**: If you change or lose the encryption key, **all stored credentials become unreadable**. Back up your encryption key securely and separately from your database backups.
 

--- a/docs/5-CONFIGURATION/security.md
+++ b/docs/5-CONFIGURATION/security.md
@@ -24,7 +24,7 @@ Set the encryption key to any secret string:
 OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-passphrase
 ```
 
-Any string works — it will be securely derived via SHA-256 internally. Use a strong passphrase for production deployments.
+Any string works — it will be securely derived via salted PBKDF2-HMAC-SHA256 (600k iterations) internally. Use a strong passphrase for production deployments.
 
 ### Default Credentials
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
         "rehype-katex": "^7.0.1",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "sonner": "^2.0.6",
@@ -7483,6 +7484,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
@@ -10927,6 +10943,20 @@
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-slug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-katex": "^7.0.1",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "sonner": "^2.0.6",

--- a/frontend/src/components/ui/markdown-editor.test.tsx
+++ b/frontend/src/components/ui/markdown-editor.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownPreview from '@uiw/react-markdown-preview'
+
+import { PREVIEW_OPTIONS } from './markdown-editor'
+
+// MarkdownEditor's live preview renders through @uiw/react-markdown-preview,
+// which parses raw HTML in the markdown source into real elements (its `raw`
+// default). Notes can hold AI-generated content that echoes an indirect
+// prompt injection, so anything rendered here must not let that raw HTML
+// become a live <iframe>/<script>/<style>/javascript: URL - while still
+// preserving math, syntax highlighting, and GFM, which are real features.
+// These tests exercise the actual PREVIEW_OPTIONS MarkdownEditor uses, via
+// the same underlying preview component, rather than a hand-rolled pipeline.
+function renderPreview(source: string) {
+  return render(
+    <MarkdownPreview
+      source={source}
+      remarkPlugins={PREVIEW_OPTIONS.remarkPlugins}
+      rehypePlugins={PREVIEW_OPTIONS.rehypePlugins}
+    />
+  )
+}
+
+describe('MarkdownEditor preview sanitization', () => {
+  it('strips a raw <iframe> to a live, embeddable element', () => {
+    const { container } = renderPreview('before <iframe src="https://evil.example"></iframe> after')
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(container.innerHTML).not.toContain('evil.example')
+  })
+
+  it('strips raw <script> content', () => {
+    const { container } = renderPreview('before <script>window.__pwned = true</script> after')
+    expect(container.innerHTML).not.toContain('__pwned')
+  })
+
+  it('strips a raw <style> element (CSS-based UI redress)', () => {
+    // The style tag itself must not survive as a live element - its text
+    // content becoming inert prose (rather than a stylesheet) is fine.
+    const { container } = renderPreview('before <style>body{display:none}</style> after')
+    expect(container.querySelector('style')).toBeNull()
+  })
+
+  it('strips javascript: URLs from links', () => {
+    const { container } = renderPreview('[click me](javascript:alert(1))')
+    const link = container.querySelector('a')
+    expect(link?.getAttribute('href') ?? '').not.toContain('javascript:')
+  })
+
+  it('does not execute inline event-handler attributes on parsed raw elements', () => {
+    const { container } = renderPreview('<img src="x" onerror="window.__pwned = true">')
+    expect(container.innerHTML).not.toContain('onerror')
+  })
+
+  it('still renders KaTeX math with its classes and MathML intact', () => {
+    const { container } = renderPreview('Inline math $x^2 + y^2 = z^2$')
+    expect(container.querySelector('.katex')).not.toBeNull()
+    expect(container.querySelector('.katex-mathml math')).not.toBeNull()
+  })
+
+  it('still syntax-highlights fenced code blocks', () => {
+    const { container } = renderPreview('```python\ndef hello():\n    return 42\n```')
+    expect(container.querySelectorAll('span[class*="token"]').length).toBeGreaterThan(0)
+  })
+
+  it('still renders GFM tables, task lists, and safe links', () => {
+    const { container } = renderPreview(
+      '| a | b |\n|---|---|\n| 1 | 2 |\n\n- [x] done\n- [ ] todo\n\n[a link](https://example.com)'
+    )
+    expect(container.querySelector('table')).not.toBeNull()
+    expect(container.querySelectorAll('input[type="checkbox"]').length).toBe(2)
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com')
+  })
+})

--- a/frontend/src/components/ui/markdown-editor.tsx
+++ b/frontend/src/components/ui/markdown-editor.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import { forwardRef } from 'react'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
+import rehypeSanitize from 'rehype-sanitize'
 
 const MDEditor = dynamic(
   () => import('@uiw/react-md-editor').then((mod) => mod.default),
@@ -14,9 +15,18 @@ const MDEditor = dynamic(
 // concatenates these with its defaults (gfm, prism, raw), so syntax
 // highlighting and GFM are preserved. KaTeX CSS is loaded globally in
 // app/layout.tsx.
-const PREVIEW_OPTIONS = {
+//
+// The library's own `raw` default lets literal HTML in the markdown source
+// (e.g. pasted content, or an AI-generated note echoing an indirect prompt
+// injection) render as live elements - notably a real <iframe>, not just
+// inert text. rehypeSanitize (default schema) strips that down to safe
+// HTML. It must run *before* rehypeKatex: katex's own generated markup
+// (katex-html spans, MathML) isn't in the default sanitize schema and gets
+// stripped if sanitize runs after it - order here is load-bearing, verified
+// against the actual rendered output for math/code/GFM before changing it.
+export const PREVIEW_OPTIONS = {
   remarkPlugins: [remarkMath],
-  rehypePlugins: [rehypeKatex],
+  rehypePlugins: [rehypeSanitize, rehypeKatex],
 }
 
 export interface MarkdownEditorProps {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,9 +4,17 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  // jsdom doesn't paint, so tests never need real CSS/style computation - and
+  // without this, importing a component that bundles its own .css (e.g.
+  // @uiw/react-markdown-preview) fails to resolve this project's Tailwind v4
+  // postcss.config.mjs (string-form plugin list) outside of Next.js's own
+  // build pipeline. `test.css: false` alone doesn't prevent Vite from trying
+  // to resolve the postcss config; this bypasses it outright.
+  css: { postcss: { plugins: [] } },
   test: {
     environment: 'jsdom',
     globals: true,
+    css: false,
     setupFiles: ['./src/test/setup.ts'],
     alias: {
       '@': path.resolve(__dirname, './src')

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -13,6 +13,8 @@ from typing import Optional, Tuple
 import httpx
 from loguru import logger
 
+from open_notebook.utils.url_validation import validate_url
+
 # Test models for each provider - uses minimal/cheapest models for testing
 # Format: (model_name, model_type)
 TEST_MODELS = {
@@ -61,6 +63,10 @@ async def _test_azure_connection(
     test_endpoint = test_endpoint.rstrip("/")
 
     try:
+        # Re-validate at request time: the endpoint may have been saved
+        # against a hostname that only later resolved to an internal
+        # address (DNS rebinding), so a save-time check alone isn't enough.
+        validate_url(test_endpoint, "azure")
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
                 f"{test_endpoint}/openai/models?api-version={test_api_version}",
@@ -86,6 +92,8 @@ async def _test_azure_connection(
             else:
                 return False, f"Azure returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to Azure endpoint. Check the URL."
     except httpx.TimeoutException:
@@ -97,6 +105,8 @@ async def _test_azure_connection(
 async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
     """Test Ollama server connectivity."""
     try:
+        # Re-validate at request time (see _test_azure_connection for why).
+        validate_url(base_url, "ollama")
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Try /api/tags endpoint (standard Ollama)
             response = await client.get(f"{base_url}/api/tags")
@@ -121,6 +131,8 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
             else:
                 return False, f"Server returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to Ollama. Check if Ollama server is running."
     except httpx.TimeoutException:
@@ -132,6 +144,8 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
 async def _test_openai_compatible_connection(base_url: str, api_key: Optional[str] = None) -> Tuple[bool, str]:
     """Test OpenAI-compatible server connectivity."""
     try:
+        # Re-validate at request time (see _test_azure_connection for why).
+        validate_url(base_url, "openai_compatible")
         headers = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
@@ -160,6 +174,8 @@ async def _test_openai_compatible_connection(base_url: str, api_key: Optional[st
             else:
                 return False, f"Server returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to server. Check the URL is correct."
     except httpx.TimeoutException:

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -12,8 +12,41 @@ from loguru import logger
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.base import ObjectModel, RecordModel
 from open_notebook.exceptions import ConfigurationError
+from open_notebook.utils.url_validation import validate_url
 
 ModelType = Union[LanguageModel, EmbeddingModel, SpeechToTextModel, TextToSpeechModel]
+
+# Config keys from Credential.to_esperanto_config() that may carry a
+# user-configured URL (ollama/azure/openai_compatible/vertex).
+_URL_CONFIG_KEYS = (
+    "base_url",
+    "endpoint",
+    "endpoint_llm",
+    "endpoint_embedding",
+    "endpoint_stt",
+    "endpoint_tts",
+)
+
+
+def _revalidate_config_urls(config: dict, provider: str) -> None:
+    """
+    Re-validate a credential's URL fields immediately before they're used for
+    a real request.
+
+    validate_url() is also enforced when a credential is created/updated, but
+    that alone leaves a DNS-rebinding TOCTOU window: a hostname that resolved
+    to a public IP at save time can later be repointed to an internal/
+    metadata address, and Esperanto/httpx re-resolve DNS fresh on every
+    connection. Re-checking here narrows that window to "this call", instead
+    of "any time after the credential was saved".
+    """
+    for key in _URL_CONFIG_KEYS:
+        value = config.get(key)
+        if value:
+            try:
+                validate_url(value, provider)
+            except ValueError as e:
+                raise ConfigurationError(str(e)) from e
 
 
 class Model(ObjectModel):
@@ -123,6 +156,7 @@ class ModelManager:
             credential = await model.get_credential_obj()
             if credential:
                 config = credential.to_esperanto_config()
+                _revalidate_config_urls(config, model.provider)
                 logger.debug(
                     f"Using credential '{credential.name}' for model {model.name}"
                 )

--- a/open_notebook/database/repository.py
+++ b/open_notebook/database/repository.py
@@ -1,12 +1,28 @@
 import os
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from loguru import logger
 from surrealdb import AsyncSurreal, RecordID  # type: ignore
+from surrealdb.data.types.table import Table  # type: ignore
 
 T = TypeVar("T", Dict[str, Any], List[Dict[str, Any]])
+
+# Bare SurrealDB table/relation identifier: no ':', whitespace, or query
+# syntax. Used to validate the parts of RELATE/UPSERT/UPDATE that name a
+# table or edge-relation and therefore can't be bound as a query parameter
+# (SurrealQL only allows binding record/table *values*, not identifiers in
+# that position).
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _ensure_safe_identifier(value: str, kind: str) -> str:
+    """Validate a table/relationship name before it is interpolated into a query."""
+    if not isinstance(value, str) or not _IDENTIFIER_RE.match(value):
+        raise ValueError(f"Invalid {kind} name: {value!r}")
+    return value
 
 
 def _get_env_or_default(name: str, default: str) -> str:
@@ -117,17 +133,26 @@ async def repo_create(table: str, data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def repo_relate(
-    source: str, relationship: str, target: str, data: Optional[Dict[str, Any]] = None
+    source: Union[str, RecordID],
+    relationship: str,
+    target: Union[str, RecordID],
+    data: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Create a relationship between two records with optional data"""
     if data is None:
         data = {}
-    query = f"RELATE {source}->{relationship}->{target} CONTENT $data;"
+    # relationship is an edge-table name, not a record value, so it can't be
+    # bound as a query parameter; validate it against an identifier allowlist
+    # instead of trusting the caller. source/target are always bound.
+    _ensure_safe_identifier(relationship, "relationship")
+    query = f"RELATE $source->{relationship}->$target CONTENT $data;"
     # logger.debug(f"Relate query: {query}")
 
     return await repo_query(
         query,
         {
+            "source": ensure_record_id(source),
+            "target": ensure_record_id(target),
             "data": data,
         },
     )
@@ -140,27 +165,32 @@ async def repo_upsert(
     data.pop("id", None)
     if add_timestamp:
         data["updated"] = datetime.now(timezone.utc)
-    query = f"UPSERT {id if id else table} MERGE $data;"
-    return await repo_query(query, {"data": data})
+    _ensure_safe_identifier(table, "table")
+    target: Union[RecordID, Table] = ensure_record_id(id) if id else Table(table)
+    query = "UPSERT $target MERGE $data;"
+    return await repo_query(query, {"target": target, "data": data})
 
 
 async def repo_update(
-    table: str, id: str, data: Dict[str, Any]
+    table: str, id: Union[str, RecordID], data: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
     """Update an existing record by table and id"""
     # If id already contains the table name, use it as is
     try:
-        if isinstance(id, RecordID) or (":" in id and id.startswith(f"{table}:")):
-            record_id = id
+        _ensure_safe_identifier(table, "table")
+        if isinstance(id, RecordID):
+            record_id: RecordID = id
+        elif ":" in id and id.startswith(f"{table}:"):
+            record_id = ensure_record_id(id)
         else:
-            record_id = f"{table}:{id}"
+            record_id = RecordID(table, id)
         data.pop("id", None)
         if "created" in data and isinstance(data["created"], str):
             data["created"] = datetime.fromisoformat(data["created"])
         data["updated"] = datetime.now(timezone.utc)
-        query = f"UPDATE {record_id} MERGE $data;"
+        query = "UPDATE $target MERGE $data;"
         # logger.debug(f"Update query: {query}")
-        result = await repo_query(query, {"data": data})
+        result = await repo_query(query, {"target": record_id, "data": data})
         # if isinstance(result, list):
         #     return [_return_data(item) for item in result]
         return parse_record_ids(result)

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -79,8 +79,14 @@ class Notebook(ObjectModel):
         notes = await self.get_notes(include_content=True)
         context_blocks = []
 
+        insights_by_source = await SourceInsight.get_for_sources(
+            [source.id for source in sources if source.id]
+        )
         for source in sources:
-            source_context = await source.get_context(context_size="long")
+            source_context = await source.get_context(
+                context_size="long",
+                insights=insights_by_source.get(source.id or "", []),
+            )
             if isinstance(source_context, dict):
                 title = source_context.get("title") or source.title or "Untitled source"
                 full_text = source_context.get("full_text")
@@ -327,6 +333,35 @@ class SourceInsight(ObjectModel):
     insight_type: str
     content: str
 
+    @classmethod
+    async def get_for_sources(
+        cls, source_ids: List[str]
+    ) -> Dict[str, List["SourceInsight"]]:
+        """
+        Batch-fetch insights for many sources in a single query.
+
+        Building notebook/chat context otherwise calls get_insights() once
+        per source - fine for one source, but O(n) round trips (each paying
+        its own connection setup, see database/CLAUDE.md) when a caller
+        loops over every source in a notebook.
+        """
+        grouped: Dict[str, List[SourceInsight]] = {sid: [] for sid in source_ids if sid}
+        if not grouped:
+            return grouped
+        try:
+            result = await repo_query(
+                "SELECT * FROM source_insight WHERE source IN $source_ids",
+                {"source_ids": [ensure_record_id(sid) for sid in grouped]},
+            )
+        except Exception as e:
+            logger.error(f"Error batch-fetching insights for sources: {str(e)}")
+            logger.exception(e)
+            raise DatabaseOperationError("Failed to fetch insights for sources")
+        for row in result:
+            key = str(row.get("source"))
+            grouped.setdefault(key, []).append(cls(**row))
+        return grouped
+
     async def get_source(self) -> "Source":
         try:
             src = await repo_query(
@@ -428,10 +463,15 @@ class Source(ObjectModel):
             return None
 
     async def get_context(
-        self, context_size: Literal["short", "long"] = "short"
+        self,
+        context_size: Literal["short", "long"] = "short",
+        insights: Optional[List["SourceInsight"]] = None,
     ) -> Dict[str, Any]:
-        insights_list = await self.get_insights()
-        insights = [insight.model_dump() for insight in insights_list]
+        # Callers looping over many sources can batch-fetch insights up front
+        # via SourceInsight.get_for_sources() and pass them in here, instead
+        # of paying a separate query per source.
+        insight_objects = insights if insights is not None else await self.get_insights()
+        insights = [insight.model_dump() for insight in insight_objects]
         if context_size == "long":
             return dict(
                 id=self.id,

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -475,6 +475,7 @@ class Source(ObjectModel):
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
+        await Notebook.get(notebook_id)  # raises NotFoundError if invalid/missing
         return await self.relate("reference", notebook_id)
 
     async def vectorize(self) -> str:
@@ -662,6 +663,7 @@ class Note(ObjectModel):
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
+        await Notebook.get(notebook_id)  # raises NotFoundError if invalid/missing
         return await self.relate("artifact", notebook_id)
 
     def get_context(

--- a/open_notebook/graphs/prompt.py
+++ b/open_notebook/graphs/prompt.py
@@ -19,8 +19,12 @@ class PatternChainState(TypedDict):
 
 async def call_model(state: dict, config: RunnableConfig) -> dict:
     content = state["input_text"]
+    # state["prompt"] is caller-supplied free text. Never compile it as Jinja
+    # template *source* (Prompter(template_text=...)) - pass it as a plain
+    # render variable into a fixed, developer-authored template instead.
+    # See docs/7-DEVELOPMENT/security.md (GHSA-f35w-wx37-26q7).
     system_prompt = Prompter(
-        template_text=state["prompt"], parser=state.get("parser")
+        prompt_template="pattern/generic", parser=state.get("parser")
     ).render(data=state)
     payload = [SystemMessage(content=system_prompt)] + [HumanMessage(content=content)]
     chain = await provision_langchain_model(

--- a/open_notebook/graphs/transformation.py
+++ b/open_notebook/graphs/transformation.py
@@ -30,15 +30,17 @@ async def run_transformation(state: dict, config: RunnableConfig) -> dict:
     try:
         if not content:
             content = source.full_text
-        transformation_template_text = transformation.prompt
+        # transformation.prompt is user-controlled free text. Never compile it as
+        # Jinja template *source* (Prompter(template_text=...)) - pass it as a
+        # plain render variable into a fixed, developer-authored template instead.
+        # See docs/7-DEVELOPMENT/security.md (GHSA-f35w-wx37-26q7).
+        instructions = transformation.prompt
         default_prompts: DefaultPrompts = DefaultPrompts(transformation_instructions=None)
         if default_prompts.transformation_instructions:
-            transformation_template_text = f"{default_prompts.transformation_instructions}\n\n{transformation_template_text}"
+            instructions = f"{default_prompts.transformation_instructions}\n\n{instructions}"
 
-        transformation_template_text = f"{transformation_template_text}\n\n# INPUT"
-
-        system_prompt = Prompter(template_text=transformation_template_text).render(
-            data=state
+        system_prompt = Prompter(prompt_template="transformation/execute").render(
+            data={**state, "instructions": instructions}
         )
         content_str = str(content) if content else ""
         payload = [SystemMessage(content=system_prompt), HumanMessage(content=content_str)]

--- a/open_notebook/utils/CLAUDE.md
+++ b/open_notebook/utils/CLAUDE.md
@@ -203,15 +203,17 @@ for item in context_items:
 
 **Key behavior**:
 - Key source: OPEN_NOTEBOOK_ENCRYPTION_KEY_FILE (Docker secrets) → OPEN_NOTEBOOK_ENCRYPTION_KEY (env var)
-- Accepts **any string**: always derived to a Fernet key via SHA-256
+- Accepts **any string**: derived to a Fernet key via salted PBKDF2-HMAC-SHA256 (600k iterations)
 - No default key — encryption is unavailable until the env var is set
-- Graceful fallback on decryption: InvalidToken errors (legacy unencrypted data) return the original value
+- Graceful fallback on decryption: tries the current PBKDF2 derivation, then the legacy pre-PBKDF2 unsalted-SHA-256 derivation (so ciphertext written before that upgrade keeps decrypting), then falls back to the original value for legacy unencrypted data. `InvalidToken` under both derivations + doesn't look like a Fernet token → treated as legacy plaintext
+- Both derived keys are cached lazily per process (the PBKDF2 step is deliberately expensive, ~50ms)
 - Lazy-loaded key: initialized on first use, not at import time
 
 **Security considerations**:
 - OPEN_NOTEBOOK_ENCRYPTION_KEY must be set explicitly (no default)
 - Docker secrets pattern supported for secure key injection in containerized environments
-- Key rotation would require re-encrypting all stored keys (not currently implemented)
+- Key *derivation* upgrades (e.g. the PBKDF2 migration) are transparent and self-healing: old ciphertext decrypts via the legacy-scheme fallback and gets re-encrypted under the current scheme the next time the owning record is saved — no migration script needed
+- Key *rotation* (changing OPEN_NOTEBOOK_ENCRYPTION_KEY itself) would still require re-encrypting all stored values (not currently implemented) — the fallback only covers derivation-scheme changes, not a genuinely different passphrase
 - Encryption is transparent to callers; unencrypted legacy data continues to work
 
 **Usage Example**:

--- a/open_notebook/utils/encryption.py
+++ b/open_notebook/utils/encryption.py
@@ -5,8 +5,12 @@ This module provides encryption/decryption for API keys stored in the database.
 Fernet uses AES-128-CBC with HMAC-SHA256 for authenticated encryption.
 
 OPEN_NOTEBOOK_ENCRYPTION_KEY accepts **any string**. A Fernet key is derived
-from it via SHA-256, so users can set a simple passphrase like
-``OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret`` and it will work.
+from it via PBKDF2-HMAC-SHA256 (salted, 600k iterations), so users can set a
+simple passphrase like ``OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret`` and it will
+work. Values encrypted under the older unsalted-single-round-SHA-256 scheme
+(pre-PBKDF2) still decrypt via an automatic fallback - see `decrypt_value` -
+and get re-encrypted under the current scheme the next time the owning record
+is saved. No migration step is required to upgrade.
 
 Usage:
     # Encrypt before storing
@@ -92,6 +96,20 @@ def _get_or_create_encryption_key() -> str:
 # when other modules import from this file.
 _ENCRYPTION_KEY: Optional[str] = None
 
+# Fixed, non-secret domain-separation salt for the PBKDF2 derivation below.
+# It doesn't need to be random or per-install (there's nowhere durable to
+# store a random one without a migration) - its job is just to stop
+# precomputed hash tables from unrelated contexts from applying here.
+# Actual brute-force resistance comes from the iteration count.
+_KDF_SALT = b"open-notebook:credential-encryption:v2"
+_KDF_ITERATIONS = 600_000  # OWASP 2023 guidance for PBKDF2-HMAC-SHA256
+
+# Both derived Fernet keys are cached lazily: the PBKDF2 derivation below is
+# deliberately expensive (~50ms), so paying that cost once per process
+# instead of on every encrypt/decrypt call matters.
+_FERNET_KEY: Optional[bytes] = None
+_LEGACY_FERNET_KEY: Optional[bytes] = None
+
 
 def _get_encryption_key() -> str:
     """Get the encryption key, initializing lazily on first call."""
@@ -101,12 +119,24 @@ def _get_encryption_key() -> str:
     return _ENCRYPTION_KEY
 
 
-def _ensure_fernet_key(key: str) -> str:
+def _derive_fernet_key(key: str) -> str:
     """
-    Derive a valid Fernet key from an arbitrary string via SHA-256.
+    Derive a valid Fernet key from an arbitrary string via PBKDF2-HMAC-SHA256.
 
-    Any string is accepted as input. The key is derived by hashing it with
-    SHA-256 and encoding the result as URL-safe base64.
+    Any string is accepted as input. Salted and stretched so a weak/short
+    passphrase is expensive to brute-force offline.
+    """
+    derived = hashlib.pbkdf2_hmac(
+        "sha256", key.encode(), _KDF_SALT, _KDF_ITERATIONS
+    )
+    return base64.urlsafe_b64encode(derived).decode()
+
+
+def _derive_legacy_fernet_key(key: str) -> str:
+    """
+    Derive a Fernet key using the original (pre-PBKDF2) scheme: a single
+    unsalted SHA-256 round. Only used as a fallback so ciphertext written
+    before the PBKDF2 upgrade keeps decrypting - see `decrypt_value`.
     """
     derived = hashlib.sha256(key.encode()).digest()
     return base64.urlsafe_b64encode(derived).decode()
@@ -122,7 +152,18 @@ def get_fernet() -> Fernet:
     Raises:
         ValueError: If encryption key is not configured.
     """
-    return Fernet(_ensure_fernet_key(_get_encryption_key()).encode())
+    global _FERNET_KEY
+    if _FERNET_KEY is None:
+        _FERNET_KEY = _derive_fernet_key(_get_encryption_key()).encode()
+    return Fernet(_FERNET_KEY)
+
+
+def _get_legacy_fernet() -> Fernet:
+    """Fernet instance derived via the legacy unsalted-SHA-256 scheme."""
+    global _LEGACY_FERNET_KEY
+    if _LEGACY_FERNET_KEY is None:
+        _LEGACY_FERNET_KEY = _derive_legacy_fernet_key(_get_encryption_key()).encode()
+    return Fernet(_LEGACY_FERNET_KEY)
 
 
 def encrypt_value(value: str) -> str:
@@ -168,7 +209,11 @@ def decrypt_value(value: str) -> str:
     """
     Decrypt a Fernet-encrypted string value.
 
-    Handles graceful fallback for legacy unencrypted data.
+    Tries the current (PBKDF2) key derivation first, then falls back to the
+    legacy unsalted-SHA-256 derivation so ciphertext written before that
+    upgrade keeps decrypting - it gets transparently re-encrypted under the
+    current scheme the next time the owning record is saved. Finally falls
+    back to treating the value as legacy unencrypted plaintext.
 
     Args:
         value: The encrypted string (or plain text for legacy data).
@@ -180,18 +225,25 @@ def decrypt_value(value: str) -> str:
         ValueError: If encryption is not configured or if decryption fails
             for what appears to be encrypted data (wrong key).
     """
-    fernet = get_fernet()
+    try:
+        return get_fernet().decrypt(value.encode()).decode()
+    except InvalidToken:
+        pass
+    except Exception as e:
+        logger.error(f"Decryption failed: {e}")
+        raise ValueError(f"Decryption failed: {str(e)}")
 
     try:
-        return fernet.decrypt(value.encode()).decode()
+        return _get_legacy_fernet().decrypt(value.encode()).decode()
     except InvalidToken:
         if looks_like_fernet_token(value):
-            # Looks like encrypted data but failed to decrypt - likely wrong key
+            # Looks like encrypted data but failed under both key derivations
+            # - likely wrong key rather than a legacy-scheme mismatch.
             raise ValueError(
                 "Decryption failed: data appears to be encrypted but key is incorrect. "
                 "Check OPEN_NOTEBOOK_ENCRYPTION_KEY configuration."
             )
-        # Not a valid token - treat as legacy plaintext
+        # Not a valid token under either scheme - treat as legacy plaintext
         return value
     except Exception as e:
         logger.error(f"Decryption failed: {e}")

--- a/open_notebook/utils/url_validation.py
+++ b/open_notebook/utils/url_validation.py
@@ -1,0 +1,131 @@
+"""
+URL validation shared by the credentials API and the AI provisioning layer.
+
+Lives in open_notebook.utils (not api/) so it can be imported both by the API
+layer (credential create/update, source-URL ingestion) and by open_notebook's
+own AI layer (connection_tester.py, ModelManager) to re-validate a
+provider-configured URL immediately before it is actually used - closing most
+of the DNS-rebinding TOCTOU window left by validating only once, at save time.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# AWS's IMDSv6 metadata endpoint. Unlike the IPv4 metadata address
+# (169.254.169.254), this is a Unique Local Address, not link-local, so it is
+# not caught by ip.is_link_local and must be checked explicitly.
+_AWS_IMDS_V6_ADDRESS = ipaddress.ip_address("fd00:ec2::254")
+
+
+def validate_url(url: str, provider: str) -> None:
+    """
+    Validate URL format for API endpoints.
+
+    This is a self-hosted application, so we allow:
+    - Private IPs (10.x, 172.16-31.x, 192.168.x) for self-hosted services
+    - Localhost for local services (Ollama, LM Studio, etc.)
+
+    We only block:
+    - Invalid schemes (must be http or https)
+    - Malformed URLs
+    - Link-local addresses (169.254.x.x) - used for cloud metadata endpoints
+    - AWS's IPv6 metadata address (fd00:ec2::254)
+    - Hostnames that resolve to any of the above
+
+    Args:
+        url: The URL to validate
+        provider: The provider name (for logging/context)
+
+    Raises:
+        ValueError: If the URL is invalid
+    """
+    if not url or not url.strip():
+        return  # Empty URLs handled elsewhere
+
+    try:
+        parsed = urlparse(url.strip())
+
+        # Validate scheme - only http/https allowed
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
+            )
+
+        # Extract hostname
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("Invalid URL: hostname could not be determined.")
+
+        # Try to parse as IP address to check for dangerous addresses
+        try:
+            ip = ipaddress.ip_address(hostname)
+            _reject_dangerous_ip(ip, hostname)
+
+        except ValueError as ve:
+            # Re-raise our own ValueErrors
+            if "Link-local" in str(ve) or "Invalid URL" in str(ve) or "metadata" in str(ve):
+                raise
+            # Not an IP address, it's a hostname - need to resolve and check
+            try:
+                # Resolve hostname to IP address
+                resolved_ips = socket.getaddrinfo(hostname, None)
+                for family, _, _, _, sockaddr in resolved_ips:
+                    ip_addr = sockaddr[0]
+                    try:
+                        parsed_ip = ipaddress.ip_address(ip_addr)
+                        _reject_dangerous_ip(parsed_ip, hostname, resolved=True)
+                    except ValueError as inner_ve:
+                        if "link-local" in str(inner_ve).lower() or "metadata" in str(inner_ve).lower():
+                            raise
+                        # Skip non-IP addresses (e.g., IPv6 zones)
+                        continue
+            except socket.gaierror:
+                # Could not resolve hostname - allow it since the URL may be
+                # valid in the deployment environment (e.g., Azure endpoints,
+                # internal DNS names). We only block link-local addresses.
+                pass
+
+    except ValueError:
+        raise
+    except Exception:
+        raise ValueError("Invalid URL format. Check server logs for details.")
+
+
+def _reject_dangerous_ip(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+    hostname: str,
+    resolved: bool = False,
+) -> None:
+    """Raise ValueError if `ip` is a link-local or cloud-metadata address."""
+    is_ipv4_mapped_link_local = (
+        hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped and ip.ipv4_mapped.is_link_local
+    )
+
+    # Block link-local addresses (169.254.x.x / fe80::/10) - used for cloud
+    # metadata - including IPv4-mapped IPv6 addresses pointing to link-local
+    # (e.g. ::ffff:169.254.169.254 bypasses IPv6 is_link_local check).
+    if ip.is_link_local or is_ipv4_mapped_link_local:
+        if resolved:
+            raise ValueError(
+                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) "
+                "which is not allowed for security reasons. These addresses are used "
+                "for cloud metadata endpoints."
+            )
+        raise ValueError(
+            "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
+            "These addresses are used for cloud metadata endpoints."
+        )
+
+    # Block AWS's IMDSv6 metadata address - a Unique Local Address, not
+    # link-local, so it needs its own explicit check.
+    if ip == _AWS_IMDS_V6_ADDRESS:
+        if resolved:
+            raise ValueError(
+                f"Hostname '{hostname}' resolves to the AWS IMDSv6 metadata address "
+                "(fd00:ec2::254), which is not allowed for security reasons."
+            )
+        raise ValueError(
+            "The AWS IMDSv6 metadata address (fd00:ec2::254) is not allowed for "
+            "security reasons."
+        )

--- a/prompts/pattern/generic.jinja
+++ b/prompts/pattern/generic.jinja
@@ -1,0 +1,5 @@
+{{ prompt }}
+{%- if format_instructions %}
+
+{{ format_instructions }}
+{%- endif %}

--- a/prompts/transformation/execute.jinja
+++ b/prompts/transformation/execute.jinja
@@ -1,0 +1,3 @@
+{{ instructions }}
+
+# INPUT

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -18,7 +18,13 @@ from api.podcast_service import PodcastService
 from open_notebook.ai.models import ModelManager
 from open_notebook.domain.base import RecordModel
 from open_notebook.domain.content_settings import ContentSettings
-from open_notebook.domain.notebook import Asset, Note, Notebook, Source
+from open_notebook.domain.notebook import (
+    Asset,
+    Note,
+    Notebook,
+    Source,
+    SourceInsight,
+)
 from open_notebook.domain.transformation import Transformation
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.podcasts.models import EpisodeProfile, SpeakerProfile
@@ -127,13 +133,15 @@ class TestNotebookDomain:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_insights(self):
-            return []
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
 
         with (
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
-            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
         ):
             context = await notebook.get_context()
 
@@ -203,12 +211,18 @@ class TestNotebookDomain:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_context(self, context_size="short"):
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
+
+        async def fake_get_context(self, context_size="short", insights=None):
             raise RuntimeError("source context failed")
 
         with (
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
             patch.object(Source, "get_context", new=fake_get_context),
         ):
             with pytest.raises(RuntimeError, match="source context failed"):
@@ -477,8 +491,8 @@ class TestPodcastService:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_insights(self):
-            return []
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
 
         def fake_submit_command(app_name, command_name, command_args):
             submitted_args.update(command_args)
@@ -501,7 +515,9 @@ class TestPodcastService:
             patch.object(Notebook, "get", new=AsyncMock(return_value=notebook)),
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
-            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
             patch("api.podcast_service.submit_command", new=fake_submit_command),
             patch.dict(
                 sys.modules, {"commands.podcast_commands": fake_commands_module}

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,119 @@
+"""
+Unit tests for open_notebook.utils.encryption.
+
+Covers the PBKDF2 key derivation and, most importantly, the backward-compat
+fallback that lets ciphertext written under the older unsalted-SHA-256
+derivation keep decrypting after the upgrade.
+"""
+
+import base64
+import hashlib
+
+import pytest
+from cryptography.fernet import Fernet
+
+from open_notebook.utils import encryption
+
+
+@pytest.fixture(autouse=True)
+def reset_encryption_state(monkeypatch):
+    """Each test gets its own key and a clean set of lazily-cached globals."""
+    monkeypatch.setenv("OPEN_NOTEBOOK_ENCRYPTION_KEY", "test-passphrase")
+    monkeypatch.delenv("OPEN_NOTEBOOK_ENCRYPTION_KEY_FILE", raising=False)
+    encryption._ENCRYPTION_KEY = None
+    encryption._FERNET_KEY = None
+    encryption._LEGACY_FERNET_KEY = None
+    yield
+    encryption._ENCRYPTION_KEY = None
+    encryption._FERNET_KEY = None
+    encryption._LEGACY_FERNET_KEY = None
+
+
+def legacy_encrypt(passphrase: str, value: str) -> str:
+    """Reproduce the pre-PBKDF2 encryption scheme (unsalted single-round SHA-256)."""
+    derived = hashlib.sha256(passphrase.encode()).digest()
+    key = base64.urlsafe_b64encode(derived)
+    return Fernet(key).encrypt(value.encode()).decode()
+
+
+class TestKeyDerivation:
+    def test_current_derivation_is_salted_pbkdf2_not_plain_sha256(self):
+        current = encryption._derive_fernet_key("test-passphrase")
+        legacy = encryption._derive_legacy_fernet_key("test-passphrase")
+        assert current != legacy
+
+    def test_derivation_is_deterministic(self):
+        assert encryption._derive_fernet_key("abc") == encryption._derive_fernet_key(
+            "abc"
+        )
+
+    def test_fernet_key_is_cached_across_calls(self):
+        f1 = encryption.get_fernet()
+        cached_key = encryption._FERNET_KEY
+        f2 = encryption.get_fernet()
+        assert encryption._FERNET_KEY == cached_key
+        # Both instances must still decrypt each other's ciphertext.
+        assert f2.decrypt(f1.encrypt(b"x")) == b"x"
+
+
+class TestEncryptDecryptRoundTrip:
+    def test_round_trip(self):
+        encrypted = encryption.encrypt_value("sk-my-secret-api-key")
+        assert encryption.decrypt_value(encrypted) == "sk-my-secret-api-key"
+
+    def test_new_ciphertext_uses_current_scheme_directly(self):
+        encrypted = encryption.encrypt_value("sk-another-key")
+        # Should decrypt under the *current* Fernet without needing fallback.
+        assert encryption.get_fernet().decrypt(encrypted.encode()).decode() == (
+            "sk-another-key"
+        )
+
+
+class TestLegacyFallback:
+    def test_legacy_sha256_ciphertext_still_decrypts(self):
+        legacy_ciphertext = legacy_encrypt("test-passphrase", "sk-old-key")
+        assert encryption.decrypt_value(legacy_ciphertext) == "sk-old-key"
+
+    def test_legacy_ciphertext_does_not_decrypt_under_current_scheme_directly(self):
+        """Sanity check that the fallback path is actually being exercised."""
+        legacy_ciphertext = legacy_encrypt("test-passphrase", "sk-old-key")
+        with pytest.raises(Exception):
+            encryption.get_fernet().decrypt(legacy_ciphertext.encode())
+
+    def test_legacy_plaintext_passes_through_unchanged(self):
+        assert encryption.decrypt_value("plain-unencrypted-value") == (
+            "plain-unencrypted-value"
+        )
+
+    def test_wrong_key_raises_for_current_scheme_ciphertext(self, monkeypatch):
+        encrypted = encryption.encrypt_value("sk-secret")
+        monkeypatch.setenv("OPEN_NOTEBOOK_ENCRYPTION_KEY", "a-different-passphrase")
+        encryption._ENCRYPTION_KEY = None
+        encryption._FERNET_KEY = None
+        encryption._LEGACY_FERNET_KEY = None
+        with pytest.raises(ValueError, match="key is incorrect"):
+            encryption.decrypt_value(encrypted)
+
+    def test_wrong_key_raises_for_legacy_scheme_ciphertext(self, monkeypatch):
+        legacy_ciphertext = legacy_encrypt("test-passphrase", "sk-old-key")
+        monkeypatch.setenv("OPEN_NOTEBOOK_ENCRYPTION_KEY", "a-different-passphrase")
+        encryption._ENCRYPTION_KEY = None
+        encryption._FERNET_KEY = None
+        encryption._LEGACY_FERNET_KEY = None
+        with pytest.raises(ValueError, match="key is incorrect"):
+            encryption.decrypt_value(legacy_ciphertext)
+
+    def test_reencrypting_a_legacy_value_upgrades_it_to_current_scheme(self):
+        """Simulates a record being loaded (legacy ciphertext) then re-saved."""
+        legacy_ciphertext = legacy_encrypt("test-passphrase", "sk-old-key")
+        decrypted = encryption.decrypt_value(legacy_ciphertext)
+        re_encrypted = encryption.encrypt_value(decrypted)
+
+        assert re_encrypted != legacy_ciphertext
+        # New ciphertext must decrypt directly under the current scheme -
+        # no fallback needed anymore.
+        assert (
+            encryption.get_fernet().decrypt(re_encrypted.encode()).decode()
+            == "sk-old-key"
+        )
+        assert encryption.decrypt_value(re_encrypted) == "sk-old-key"


### PR DESCRIPTION
`OPEN_NOTEBOOK_ENCRYPTION_KEY` was derived to a Fernet key via a single unsalted SHA-256 round - fast to compute, which is exactly the wrong property for a key derivation function: it makes offline brute-forcing a weak/short passphrase cheap.

Derive via PBKDF2-HMAC-SHA256 with a fixed domain-separation salt and 600k iterations (OWASP 2023 guidance) instead. Ciphertext written under the old scheme still decrypts via an automatic fallback to the legacy derivation, and gets transparently re-encrypted under the new scheme the next time the owning record is saved - no migration step required. Both derived keys are cached lazily per process since PBKDF2 at this iteration count is deliberately expensive (~50ms).

**Stacked on #1002-#1009** (unmerged). `tests/test_encryption.py` passes (11/11).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

