### PR TITLE
fix: correct SurrealQL syntax in embedding-rebuild estimate query

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,3 +1,4 @@
+import secrets
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Request
@@ -67,8 +68,10 @@ class PasswordAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Check password
-        if credentials != self.password:
+        # Check password (constant-time to avoid a timing side-channel)
+        if not secrets.compare_digest(
+            credentials.encode("utf-8"), self.password.encode("utf-8")
+        ):
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Invalid password"},
@@ -108,8 +111,10 @@ def check_api_password(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Check password
-    if credentials.credentials != password:
+    # Check password (constant-time to avoid a timing side-channel)
+    if not secrets.compare_digest(
+        credentials.credentials.encode("utf-8"), password.encode("utf-8")
+    ):
         raise HTTPException(
             status_code=401,
             detail="Invalid password",

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -7,11 +7,8 @@ Extracted from the credentials router to follow the service layer pattern.
 All functions raise ValueError for business errors (router converts to HTTPException).
 """
 
-import ipaddress
 import os
-import socket
 from typing import Dict, List, Optional
-from urllib.parse import urlparse
 
 import httpx
 from loguru import logger
@@ -21,6 +18,7 @@ from api.models import CredentialResponse
 from open_notebook.ai.model_discovery import classify_model_type
 from open_notebook.domain.credential import Credential
 from open_notebook.utils.encryption import get_secret_from_env
+from open_notebook.utils.url_validation import validate_url
 
 # =============================================================================
 # Constants
@@ -82,113 +80,6 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "dashscope": ["language"],
     "minimax": ["language"],
 }
-
-
-# =============================================================================
-# URL Validation (SSRF protection)
-# =============================================================================
-
-
-def validate_url(url: str, provider: str) -> None:
-    """
-    Validate URL format for API endpoints.
-
-    This is a self-hosted application, so we allow:
-    - Private IPs (10.x, 172.16-31.x, 192.168.x) for self-hosted services
-    - Localhost for local services (Ollama, LM Studio, etc.)
-
-    We only block:
-    - Invalid schemes (must be http or https)
-    - Malformed URLs
-    - Link-local addresses (169.254.x.x) - used for cloud metadata endpoints
-    - Hostnames that resolve to link-local addresses
-
-    Args:
-        url: The URL to validate
-        provider: The provider name (for logging/context)
-
-    Raises:
-        ValueError: If the URL is invalid
-    """
-    if not url or not url.strip():
-        return  # Empty URLs handled elsewhere
-
-    try:
-        parsed = urlparse(url.strip())
-
-        # Validate scheme - only http/https allowed
-        if parsed.scheme not in ("http", "https"):
-            raise ValueError(
-                f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
-            )
-
-        # Extract hostname
-        hostname = parsed.hostname
-        if not hostname:
-            raise ValueError("Invalid URL: hostname could not be determined.")
-
-        # Try to parse as IP address to check for dangerous addresses
-        try:
-            ip = ipaddress.ip_address(hostname)
-
-            # Block link-local addresses (169.254.x.x) - used for cloud metadata
-            # These are dangerous as they can expose cloud instance credentials
-            if ip.is_link_local:
-                raise ValueError(
-                    "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
-                    "These addresses are used for cloud metadata endpoints."
-                )
-
-            # Block IPv4-mapped IPv6 addresses pointing to link-local
-            # e.g. ::ffff:169.254.169.254 bypasses IPv6 is_link_local check
-            if hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped and ip.ipv4_mapped.is_link_local:
-                raise ValueError(
-                    "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
-                    "These addresses are used for cloud metadata endpoints."
-                )
-
-        except ValueError as ve:
-            # Re-raise our own ValueErrors
-            if "Link-local" in str(ve) or "Invalid URL" in str(ve):
-                raise
-            # Not an IP address, it's a hostname - need to resolve and check
-            try:
-                # Resolve hostname to IP address
-                resolved_ips = socket.getaddrinfo(hostname, None)
-                for family, _, _, _, sockaddr in resolved_ips:
-                    ip_addr = sockaddr[0]
-                    try:
-                        parsed_ip = ipaddress.ip_address(ip_addr)
-                        if parsed_ip.is_link_local:
-                            raise ValueError(
-                                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) which is not allowed for security reasons. "
-                                "These addresses are used for cloud metadata endpoints."
-                            )
-                        # Block IPv4-mapped IPv6 addresses pointing to link-local
-                        if (
-                            hasattr(parsed_ip, "ipv4_mapped")
-                            and parsed_ip.ipv4_mapped
-                            and parsed_ip.ipv4_mapped.is_link_local
-                        ):
-                            raise ValueError(
-                                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) which is not allowed for security reasons. "
-                                "These addresses are used for cloud metadata endpoints."
-                            )
-                    except ValueError as inner_ve:
-                        if "link-local" in str(inner_ve).lower() or "Link-local" in str(inner_ve):
-                            raise
-                        # Skip non-IP addresses (e.g., IPv6 zones)
-                        continue
-            except socket.gaierror:
-                # Could not resolve hostname - allow it since the URL may be
-                # valid in the deployment environment (e.g., Azure endpoints,
-                # internal DNS names). We only block link-local addresses.
-                pass
-
-    except ValueError:
-        raise
-    except Exception:
-        raise ValueError("Invalid URL format. Check server logs for details.")
 
 
 # =============================================================================
@@ -541,6 +432,10 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
     if provider == "ollama":
         ollama_url = base_url or "http://localhost:11434"
         try:
+            # Re-validate at request time: the base_url may have been saved
+            # against a hostname that only later resolved to an internal
+            # address (DNS rebinding).
+            validate_url(ollama_url, "ollama")
             async with httpx.AsyncClient() as client:
                 response = await client.get(f"{ollama_url}/api/tags", timeout=10.0)
                 response.raise_for_status()
@@ -562,6 +457,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not base_url:
             return []
         try:
+            # Re-validate at request time (see ollama branch above).
+            validate_url(base_url, "openai_compatible")
             headers = {}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
@@ -588,6 +485,8 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not endpoint or not api_key:
             return []
         try:
+            # Re-validate at request time (see ollama branch above).
+            validate_url(endpoint, "azure")
             url = f"{endpoint.rstrip('/')}/openai/models?api-version={api_version}"
             headers = {"api-key": api_key}
             async with httpx.AsyncClient() as client:

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -8,7 +8,13 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from open_notebook.database.repository import ensure_record_id, repo_query
-from open_notebook.domain.notebook import ChatSession, Note, Notebook, Source
+from open_notebook.domain.notebook import (
+    ChatSession,
+    Note,
+    Notebook,
+    Source,
+    SourceInsight,
+)
 from open_notebook.exceptions import (
     NotFoundError,
 )
@@ -490,9 +496,21 @@ async def build_context(request: BuildContextRequest):
         else:
             # Default behavior - include all sources and notes with short context
             sources = await notebook.get_sources()
+            try:
+                insights_by_source = await SourceInsight.get_for_sources(
+                    [source.id for source in sources if source.id]
+                )
+            except Exception as e:
+                # Match the per-source fallback below: a hiccup fetching
+                # insights shouldn't fail the whole context request.
+                logger.warning(f"Error batch-fetching source insights: {str(e)}")
+                insights_by_source = {}
             for source in sources:
                 try:
-                    source_context = await source.get_context(context_size="short")
+                    source_context = await source.get_context(
+                        context_size="short",
+                        insights=insights_by_source.get(source.id or "", []),
+                    )
                     context_data["sources"].append(source_context)
                     total_content += str(source_context)
                 except Exception as e:

--- a/api/routers/context.py
+++ b/api/routers/context.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from loguru import logger
 
 from api.models import ContextRequest, ContextResponse
-from open_notebook.domain.notebook import Note, Notebook, Source
+from open_notebook.domain.notebook import Note, Notebook, Source, SourceInsight
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.utils import token_count
 
@@ -77,9 +77,21 @@ async def get_notebook_context(notebook_id: str, context_request: ContextRequest
         else:
             # Default behavior - include all sources and notes with short context
             sources = await notebook.get_sources()
+            try:
+                insights_by_source = await SourceInsight.get_for_sources(
+                    [source.id for source in sources if source.id]
+                )
+            except Exception as e:
+                # Match the per-source fallback below: a hiccup fetching
+                # insights shouldn't fail the whole context request.
+                logger.warning(f"Error batch-fetching source insights: {str(e)}")
+                insights_by_source = {}
             for source in sources:
                 try:
-                    source_context = await source.get_context(context_size="short")
+                    source_context = await source.get_context(
+                        context_size="short",
+                        insights=insights_by_source.get(source.id or "", []),
+                    )
                     context_data["source"].append(source_context)
                     total_content += str(source_context)
                 except Exception as e:

--- a/api/routers/embedding_rebuild.py
+++ b/api/routers/embedding_rebuild.py
@@ -39,14 +39,19 @@ async def start_rebuild(request: RebuildRequest):
 
         if request.include_sources:
             if request.mode == "existing":
-                # Count sources with embeddings
+                # Count sources with embeddings. SurrealQL requires a FROM
+                # clause on SELECT, but this is a single self-contained
+                # aggregate expression with nothing to iterate over - RETURN
+                # is the correct idiom for that (wrapped in [] to match the
+                # list-of-one-value shape the branch below expects, same as
+                # every other query in this function).
                 result = await repo_query(
                     """
-                    SELECT VALUE count(array::distinct(
+                    RETURN [count(array::distinct(
                         SELECT VALUE source.id
                         FROM source_embedding
                         WHERE embedding != none AND array::len(embedding) > 0
-                    )) as count FROM {}
+                    ))];
                     """
                 )
             else:

--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -3,7 +3,7 @@ from loguru import logger
 
 from api.models import NoteResponse, SaveAsNoteRequest, SourceInsightResponse
 from open_notebook.domain.notebook import SourceInsight
-from open_notebook.exceptions import InvalidInputError
+from open_notebook.exceptions import InvalidInputError, NotFoundError
 
 router = APIRouter()
 
@@ -73,6 +73,8 @@ async def save_insight_as_note(insight_id: str, request: SaveAsNoteRequest):
         )
     except HTTPException:
         raise
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     except InvalidInputError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -97,18 +97,12 @@ def generate_unique_filename(original_filename: str, upload_folder: str) -> str:
         counter += 1
 
 
-async def save_uploaded_file(upload_file: UploadFile) -> str:
-    """Save uploaded file to uploads folder and return file path."""
-    if not upload_file.filename:
-        raise ValueError("No filename provided")
-
-    # Generate unique filename
-    file_path = generate_unique_filename(upload_file.filename, UPLOADS_FOLDER)
-
+def _write_uploaded_file(filename: str, content: bytes) -> str:
+    """Sync filesystem work for save_uploaded_file() - run via asyncio.to_thread
+    so a large upload doesn't block the event loop for other requests."""
+    file_path = generate_unique_filename(filename, UPLOADS_FOLDER)
     try:
-        # Save file
         with open(file_path, "wb") as f:
-            content = await upload_file.read()
             f.write(content)
 
         logger.info(f"Saved uploaded file to: {file_path}")
@@ -119,6 +113,15 @@ async def save_uploaded_file(upload_file: UploadFile) -> str:
         if os.path.exists(file_path):
             os.unlink(file_path)
         raise
+
+
+async def save_uploaded_file(upload_file: UploadFile) -> str:
+    """Save uploaded file to uploads folder and return file path."""
+    if not upload_file.filename:
+        raise ValueError("No filename provided")
+
+    content = await upload_file.read()
+    return await asyncio.to_thread(_write_uploaded_file, upload_file.filename, content)
 
 
 def parse_source_form_data(

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -17,6 +17,7 @@ from loguru import logger
 from surreal_commands import execute_command_sync, submit_command
 
 from api.command_service import CommandService
+from api.credentials_service import validate_url
 from api.models import (
     AssetModel,
     CreateSourceInsightRequest,
@@ -360,6 +361,12 @@ async def create_source(
                 raise HTTPException(
                     status_code=400, detail="URL is required for link type"
                 )
+            # Block SSRF to internal/metadata addresses before the server ever
+            # fetches this URL (same guard used for provider-credential URLs).
+            try:
+                validate_url(source_data.url, "source")
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
             content_state["url"] = source_data.url
         elif source_data.type == "upload":
             # Use uploaded file path or provided file_path (backward compatibility)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
         "rehype-katex": "^7.0.1",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "sonner": "^2.0.6",
@@ -7483,6 +7484,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
@@ -10927,6 +10943,20 @@
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-slug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-katex": "^7.0.1",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "sonner": "^2.0.6",

--- a/frontend/src/components/ui/markdown-editor.test.tsx
+++ b/frontend/src/components/ui/markdown-editor.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownPreview from '@uiw/react-markdown-preview'
+
+import { PREVIEW_OPTIONS } from './markdown-editor'
+
+// MarkdownEditor's live preview renders through @uiw/react-markdown-preview,
+// which parses raw HTML in the markdown source into real elements (its `raw`
+// default). Notes can hold AI-generated content that echoes an indirect
+// prompt injection, so anything rendered here must not let that raw HTML
+// become a live <iframe>/<script>/<style>/javascript: URL - while still
+// preserving math, syntax highlighting, and GFM, which are real features.
+// These tests exercise the actual PREVIEW_OPTIONS MarkdownEditor uses, via
+// the same underlying preview component, rather than a hand-rolled pipeline.
+function renderPreview(source: string) {
+  return render(
+    <MarkdownPreview
+      source={source}
+      remarkPlugins={PREVIEW_OPTIONS.remarkPlugins}
+      rehypePlugins={PREVIEW_OPTIONS.rehypePlugins}
+    />
+  )
+}
+
+describe('MarkdownEditor preview sanitization', () => {
+  it('strips a raw <iframe> to a live, embeddable element', () => {
+    const { container } = renderPreview('before <iframe src="https://evil.example"></iframe> after')
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(container.innerHTML).not.toContain('evil.example')
+  })
+
+  it('strips raw <script> content', () => {
+    const { container } = renderPreview('before <script>window.__pwned = true</script> after')
+    expect(container.innerHTML).not.toContain('__pwned')
+  })
+
+  it('strips a raw <style> element (CSS-based UI redress)', () => {
+    // The style tag itself must not survive as a live element - its text
+    // content becoming inert prose (rather than a stylesheet) is fine.
+    const { container } = renderPreview('before <style>body{display:none}</style> after')
+    expect(container.querySelector('style')).toBeNull()
+  })
+
+  it('strips javascript: URLs from links', () => {
+    const { container } = renderPreview('[click me](javascript:alert(1))')
+    const link = container.querySelector('a')
+    expect(link?.getAttribute('href') ?? '').not.toContain('javascript:')
+  })
+
+  it('does not execute inline event-handler attributes on parsed raw elements', () => {
+    const { container } = renderPreview('<img src="x" onerror="window.__pwned = true">')
+    expect(container.innerHTML).not.toContain('onerror')
+  })
+
+  it('still renders KaTeX math with its classes and MathML intact', () => {
+    const { container } = renderPreview('Inline math $x^2 + y^2 = z^2$')
+    expect(container.querySelector('.katex')).not.toBeNull()
+    expect(container.querySelector('.katex-mathml math')).not.toBeNull()
+  })
+
+  it('still syntax-highlights fenced code blocks', () => {
+    const { container } = renderPreview('```python\ndef hello():\n    return 42\n```')
+    expect(container.querySelectorAll('span[class*="token"]').length).toBeGreaterThan(0)
+  })
+
+  it('still renders GFM tables, task lists, and safe links', () => {
+    const { container } = renderPreview(
+      '| a | b |\n|---|---|\n| 1 | 2 |\n\n- [x] done\n- [ ] todo\n\n[a link](https://example.com)'
+    )
+    expect(container.querySelector('table')).not.toBeNull()
+    expect(container.querySelectorAll('input[type="checkbox"]').length).toBe(2)
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com')
+  })
+})

--- a/frontend/src/components/ui/markdown-editor.tsx
+++ b/frontend/src/components/ui/markdown-editor.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import { forwardRef } from 'react'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
+import rehypeSanitize from 'rehype-sanitize'
 
 const MDEditor = dynamic(
   () => import('@uiw/react-md-editor').then((mod) => mod.default),
@@ -14,9 +15,18 @@ const MDEditor = dynamic(
 // concatenates these with its defaults (gfm, prism, raw), so syntax
 // highlighting and GFM are preserved. KaTeX CSS is loaded globally in
 // app/layout.tsx.
-const PREVIEW_OPTIONS = {
+//
+// The library's own `raw` default lets literal HTML in the markdown source
+// (e.g. pasted content, or an AI-generated note echoing an indirect prompt
+// injection) render as live elements - notably a real <iframe>, not just
+// inert text. rehypeSanitize (default schema) strips that down to safe
+// HTML. It must run *before* rehypeKatex: katex's own generated markup
+// (katex-html spans, MathML) isn't in the default sanitize schema and gets
+// stripped if sanitize runs after it - order here is load-bearing, verified
+// against the actual rendered output for math/code/GFM before changing it.
+export const PREVIEW_OPTIONS = {
   remarkPlugins: [remarkMath],
-  rehypePlugins: [rehypeKatex],
+  rehypePlugins: [rehypeSanitize, rehypeKatex],
 }
 
 export interface MarkdownEditorProps {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,9 +4,17 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  // jsdom doesn't paint, so tests never need real CSS/style computation - and
+  // without this, importing a component that bundles its own .css (e.g.
+  // @uiw/react-markdown-preview) fails to resolve this project's Tailwind v4
+  // postcss.config.mjs (string-form plugin list) outside of Next.js's own
+  // build pipeline. `test.css: false` alone doesn't prevent Vite from trying
+  // to resolve the postcss config; this bypasses it outright.
+  css: { postcss: { plugins: [] } },
   test: {
     environment: 'jsdom',
     globals: true,
+    css: false,
     setupFiles: ['./src/test/setup.ts'],
     alias: {
       '@': path.resolve(__dirname, './src')

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -13,6 +13,8 @@ from typing import Optional, Tuple
 import httpx
 from loguru import logger
 
+from open_notebook.utils.url_validation import validate_url
+
 # Test models for each provider - uses minimal/cheapest models for testing
 # Format: (model_name, model_type)
 TEST_MODELS = {
@@ -61,6 +63,10 @@ async def _test_azure_connection(
     test_endpoint = test_endpoint.rstrip("/")
 
     try:
+        # Re-validate at request time: the endpoint may have been saved
+        # against a hostname that only later resolved to an internal
+        # address (DNS rebinding), so a save-time check alone isn't enough.
+        validate_url(test_endpoint, "azure")
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
                 f"{test_endpoint}/openai/models?api-version={test_api_version}",
@@ -86,6 +92,8 @@ async def _test_azure_connection(
             else:
                 return False, f"Azure returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to Azure endpoint. Check the URL."
     except httpx.TimeoutException:
@@ -97,6 +105,8 @@ async def _test_azure_connection(
 async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
     """Test Ollama server connectivity."""
     try:
+        # Re-validate at request time (see _test_azure_connection for why).
+        validate_url(base_url, "ollama")
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Try /api/tags endpoint (standard Ollama)
             response = await client.get(f"{base_url}/api/tags")
@@ -121,6 +131,8 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
             else:
                 return False, f"Server returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to Ollama. Check if Ollama server is running."
     except httpx.TimeoutException:
@@ -132,6 +144,8 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
 async def _test_openai_compatible_connection(base_url: str, api_key: Optional[str] = None) -> Tuple[bool, str]:
     """Test OpenAI-compatible server connectivity."""
     try:
+        # Re-validate at request time (see _test_azure_connection for why).
+        validate_url(base_url, "openai_compatible")
         headers = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
@@ -160,6 +174,8 @@ async def _test_openai_compatible_connection(base_url: str, api_key: Optional[st
             else:
                 return False, f"Server returned status {response.status_code}"
 
+    except ValueError as e:
+        return False, str(e)
     except httpx.ConnectError:
         return False, "Cannot connect to server. Check the URL is correct."
     except httpx.TimeoutException:

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -12,8 +12,41 @@ from loguru import logger
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.base import ObjectModel, RecordModel
 from open_notebook.exceptions import ConfigurationError
+from open_notebook.utils.url_validation import validate_url
 
 ModelType = Union[LanguageModel, EmbeddingModel, SpeechToTextModel, TextToSpeechModel]
+
+# Config keys from Credential.to_esperanto_config() that may carry a
+# user-configured URL (ollama/azure/openai_compatible/vertex).
+_URL_CONFIG_KEYS = (
+    "base_url",
+    "endpoint",
+    "endpoint_llm",
+    "endpoint_embedding",
+    "endpoint_stt",
+    "endpoint_tts",
+)
+
+
+def _revalidate_config_urls(config: dict, provider: str) -> None:
+    """
+    Re-validate a credential's URL fields immediately before they're used for
+    a real request.
+
+    validate_url() is also enforced when a credential is created/updated, but
+    that alone leaves a DNS-rebinding TOCTOU window: a hostname that resolved
+    to a public IP at save time can later be repointed to an internal/
+    metadata address, and Esperanto/httpx re-resolve DNS fresh on every
+    connection. Re-checking here narrows that window to "this call", instead
+    of "any time after the credential was saved".
+    """
+    for key in _URL_CONFIG_KEYS:
+        value = config.get(key)
+        if value:
+            try:
+                validate_url(value, provider)
+            except ValueError as e:
+                raise ConfigurationError(str(e)) from e
 
 
 class Model(ObjectModel):
@@ -123,6 +156,7 @@ class ModelManager:
             credential = await model.get_credential_obj()
             if credential:
                 config = credential.to_esperanto_config()
+                _revalidate_config_urls(config, model.provider)
                 logger.debug(
                     f"Using credential '{credential.name}' for model {model.name}"
                 )

--- a/open_notebook/database/repository.py
+++ b/open_notebook/database/repository.py
@@ -1,12 +1,28 @@
 import os
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from loguru import logger
 from surrealdb import AsyncSurreal, RecordID  # type: ignore
+from surrealdb.data.types.table import Table  # type: ignore
 
 T = TypeVar("T", Dict[str, Any], List[Dict[str, Any]])
+
+# Bare SurrealDB table/relation identifier: no ':', whitespace, or query
+# syntax. Used to validate the parts of RELATE/UPSERT/UPDATE that name a
+# table or edge-relation and therefore can't be bound as a query parameter
+# (SurrealQL only allows binding record/table *values*, not identifiers in
+# that position).
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _ensure_safe_identifier(value: str, kind: str) -> str:
+    """Validate a table/relationship name before it is interpolated into a query."""
+    if not isinstance(value, str) or not _IDENTIFIER_RE.match(value):
+        raise ValueError(f"Invalid {kind} name: {value!r}")
+    return value
 
 
 def _get_env_or_default(name: str, default: str) -> str:
@@ -117,17 +133,26 @@ async def repo_create(table: str, data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def repo_relate(
-    source: str, relationship: str, target: str, data: Optional[Dict[str, Any]] = None
+    source: Union[str, RecordID],
+    relationship: str,
+    target: Union[str, RecordID],
+    data: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Create a relationship between two records with optional data"""
     if data is None:
         data = {}
-    query = f"RELATE {source}->{relationship}->{target} CONTENT $data;"
+    # relationship is an edge-table name, not a record value, so it can't be
+    # bound as a query parameter; validate it against an identifier allowlist
+    # instead of trusting the caller. source/target are always bound.
+    _ensure_safe_identifier(relationship, "relationship")
+    query = f"RELATE $source->{relationship}->$target CONTENT $data;"
     # logger.debug(f"Relate query: {query}")
 
     return await repo_query(
         query,
         {
+            "source": ensure_record_id(source),
+            "target": ensure_record_id(target),
             "data": data,
         },
     )
@@ -140,27 +165,32 @@ async def repo_upsert(
     data.pop("id", None)
     if add_timestamp:
         data["updated"] = datetime.now(timezone.utc)
-    query = f"UPSERT {id if id else table} MERGE $data;"
-    return await repo_query(query, {"data": data})
+    _ensure_safe_identifier(table, "table")
+    target: Union[RecordID, Table] = ensure_record_id(id) if id else Table(table)
+    query = "UPSERT $target MERGE $data;"
+    return await repo_query(query, {"target": target, "data": data})
 
 
 async def repo_update(
-    table: str, id: str, data: Dict[str, Any]
+    table: str, id: Union[str, RecordID], data: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
     """Update an existing record by table and id"""
     # If id already contains the table name, use it as is
     try:
-        if isinstance(id, RecordID) or (":" in id and id.startswith(f"{table}:")):
-            record_id = id
+        _ensure_safe_identifier(table, "table")
+        if isinstance(id, RecordID):
+            record_id: RecordID = id
+        elif ":" in id and id.startswith(f"{table}:"):
+            record_id = ensure_record_id(id)
         else:
-            record_id = f"{table}:{id}"
+            record_id = RecordID(table, id)
         data.pop("id", None)
         if "created" in data and isinstance(data["created"], str):
             data["created"] = datetime.fromisoformat(data["created"])
         data["updated"] = datetime.now(timezone.utc)
-        query = f"UPDATE {record_id} MERGE $data;"
+        query = "UPDATE $target MERGE $data;"
         # logger.debug(f"Update query: {query}")
-        result = await repo_query(query, {"data": data})
+        result = await repo_query(query, {"target": record_id, "data": data})
         # if isinstance(result, list):
         #     return [_return_data(item) for item in result]
         return parse_record_ids(result)

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -79,8 +79,14 @@ class Notebook(ObjectModel):
         notes = await self.get_notes(include_content=True)
         context_blocks = []
 
+        insights_by_source = await SourceInsight.get_for_sources(
+            [source.id for source in sources if source.id]
+        )
         for source in sources:
-            source_context = await source.get_context(context_size="long")
+            source_context = await source.get_context(
+                context_size="long",
+                insights=insights_by_source.get(source.id or "", []),
+            )
             if isinstance(source_context, dict):
                 title = source_context.get("title") or source.title or "Untitled source"
                 full_text = source_context.get("full_text")
@@ -327,6 +333,35 @@ class SourceInsight(ObjectModel):
     insight_type: str
     content: str
 
+    @classmethod
+    async def get_for_sources(
+        cls, source_ids: List[str]
+    ) -> Dict[str, List["SourceInsight"]]:
+        """
+        Batch-fetch insights for many sources in a single query.
+
+        Building notebook/chat context otherwise calls get_insights() once
+        per source - fine for one source, but O(n) round trips (each paying
+        its own connection setup, see database/CLAUDE.md) when a caller
+        loops over every source in a notebook.
+        """
+        grouped: Dict[str, List[SourceInsight]] = {sid: [] for sid in source_ids if sid}
+        if not grouped:
+            return grouped
+        try:
+            result = await repo_query(
+                "SELECT * FROM source_insight WHERE source IN $source_ids",
+                {"source_ids": [ensure_record_id(sid) for sid in grouped]},
+            )
+        except Exception as e:
+            logger.error(f"Error batch-fetching insights for sources: {str(e)}")
+            logger.exception(e)
+            raise DatabaseOperationError("Failed to fetch insights for sources")
+        for row in result:
+            key = str(row.get("source"))
+            grouped.setdefault(key, []).append(cls(**row))
+        return grouped
+
     async def get_source(self) -> "Source":
         try:
             src = await repo_query(
@@ -428,10 +463,15 @@ class Source(ObjectModel):
             return None
 
     async def get_context(
-        self, context_size: Literal["short", "long"] = "short"
+        self,
+        context_size: Literal["short", "long"] = "short",
+        insights: Optional[List["SourceInsight"]] = None,
     ) -> Dict[str, Any]:
-        insights_list = await self.get_insights()
-        insights = [insight.model_dump() for insight in insights_list]
+        # Callers looping over many sources can batch-fetch insights up front
+        # via SourceInsight.get_for_sources() and pass them in here, instead
+        # of paying a separate query per source.
+        insight_objects = insights if insights is not None else await self.get_insights()
+        insights = [insight.model_dump() for insight in insight_objects]
         if context_size == "long":
             return dict(
                 id=self.id,

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -475,6 +475,7 @@ class Source(ObjectModel):
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
+        await Notebook.get(notebook_id)  # raises NotFoundError if invalid/missing
         return await self.relate("reference", notebook_id)
 
     async def vectorize(self) -> str:
@@ -662,6 +663,7 @@ class Note(ObjectModel):
     async def add_to_notebook(self, notebook_id: str) -> Any:
         if not notebook_id:
             raise InvalidInputError("Notebook ID must be provided")
+        await Notebook.get(notebook_id)  # raises NotFoundError if invalid/missing
         return await self.relate("artifact", notebook_id)
 
     def get_context(

--- a/open_notebook/graphs/prompt.py
+++ b/open_notebook/graphs/prompt.py
@@ -19,8 +19,12 @@ class PatternChainState(TypedDict):
 
 async def call_model(state: dict, config: RunnableConfig) -> dict:
     content = state["input_text"]
+    # state["prompt"] is caller-supplied free text. Never compile it as Jinja
+    # template *source* (Prompter(template_text=...)) - pass it as a plain
+    # render variable into a fixed, developer-authored template instead.
+    # See docs/7-DEVELOPMENT/security.md (GHSA-f35w-wx37-26q7).
     system_prompt = Prompter(
-        template_text=state["prompt"], parser=state.get("parser")
+        prompt_template="pattern/generic", parser=state.get("parser")
     ).render(data=state)
     payload = [SystemMessage(content=system_prompt)] + [HumanMessage(content=content)]
     chain = await provision_langchain_model(

--- a/open_notebook/graphs/transformation.py
+++ b/open_notebook/graphs/transformation.py
@@ -30,15 +30,17 @@ async def run_transformation(state: dict, config: RunnableConfig) -> dict:
     try:
         if not content:
             content = source.full_text
-        transformation_template_text = transformation.prompt
+        # transformation.prompt is user-controlled free text. Never compile it as
+        # Jinja template *source* (Prompter(template_text=...)) - pass it as a
+        # plain render variable into a fixed, developer-authored template instead.
+        # See docs/7-DEVELOPMENT/security.md (GHSA-f35w-wx37-26q7).
+        instructions = transformation.prompt
         default_prompts: DefaultPrompts = DefaultPrompts(transformation_instructions=None)
         if default_prompts.transformation_instructions:
-            transformation_template_text = f"{default_prompts.transformation_instructions}\n\n{transformation_template_text}"
+            instructions = f"{default_prompts.transformation_instructions}\n\n{instructions}"
 
-        transformation_template_text = f"{transformation_template_text}\n\n# INPUT"
-
-        system_prompt = Prompter(template_text=transformation_template_text).render(
-            data=state
+        system_prompt = Prompter(prompt_template="transformation/execute").render(
+            data={**state, "instructions": instructions}
         )
         content_str = str(content) if content else ""
         payload = [SystemMessage(content=system_prompt), HumanMessage(content=content_str)]

--- a/open_notebook/utils/url_validation.py
+++ b/open_notebook/utils/url_validation.py
@@ -1,0 +1,131 @@
+"""
+URL validation shared by the credentials API and the AI provisioning layer.
+
+Lives in open_notebook.utils (not api/) so it can be imported both by the API
+layer (credential create/update, source-URL ingestion) and by open_notebook's
+own AI layer (connection_tester.py, ModelManager) to re-validate a
+provider-configured URL immediately before it is actually used - closing most
+of the DNS-rebinding TOCTOU window left by validating only once, at save time.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# AWS's IMDSv6 metadata endpoint. Unlike the IPv4 metadata address
+# (169.254.169.254), this is a Unique Local Address, not link-local, so it is
+# not caught by ip.is_link_local and must be checked explicitly.
+_AWS_IMDS_V6_ADDRESS = ipaddress.ip_address("fd00:ec2::254")
+
+
+def validate_url(url: str, provider: str) -> None:
+    """
+    Validate URL format for API endpoints.
+
+    This is a self-hosted application, so we allow:
+    - Private IPs (10.x, 172.16-31.x, 192.168.x) for self-hosted services
+    - Localhost for local services (Ollama, LM Studio, etc.)
+
+    We only block:
+    - Invalid schemes (must be http or https)
+    - Malformed URLs
+    - Link-local addresses (169.254.x.x) - used for cloud metadata endpoints
+    - AWS's IPv6 metadata address (fd00:ec2::254)
+    - Hostnames that resolve to any of the above
+
+    Args:
+        url: The URL to validate
+        provider: The provider name (for logging/context)
+
+    Raises:
+        ValueError: If the URL is invalid
+    """
+    if not url or not url.strip():
+        return  # Empty URLs handled elsewhere
+
+    try:
+        parsed = urlparse(url.strip())
+
+        # Validate scheme - only http/https allowed
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
+            )
+
+        # Extract hostname
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("Invalid URL: hostname could not be determined.")
+
+        # Try to parse as IP address to check for dangerous addresses
+        try:
+            ip = ipaddress.ip_address(hostname)
+            _reject_dangerous_ip(ip, hostname)
+
+        except ValueError as ve:
+            # Re-raise our own ValueErrors
+            if "Link-local" in str(ve) or "Invalid URL" in str(ve) or "metadata" in str(ve):
+                raise
+            # Not an IP address, it's a hostname - need to resolve and check
+            try:
+                # Resolve hostname to IP address
+                resolved_ips = socket.getaddrinfo(hostname, None)
+                for family, _, _, _, sockaddr in resolved_ips:
+                    ip_addr = sockaddr[0]
+                    try:
+                        parsed_ip = ipaddress.ip_address(ip_addr)
+                        _reject_dangerous_ip(parsed_ip, hostname, resolved=True)
+                    except ValueError as inner_ve:
+                        if "link-local" in str(inner_ve).lower() or "metadata" in str(inner_ve).lower():
+                            raise
+                        # Skip non-IP addresses (e.g., IPv6 zones)
+                        continue
+            except socket.gaierror:
+                # Could not resolve hostname - allow it since the URL may be
+                # valid in the deployment environment (e.g., Azure endpoints,
+                # internal DNS names). We only block link-local addresses.
+                pass
+
+    except ValueError:
+        raise
+    except Exception:
+        raise ValueError("Invalid URL format. Check server logs for details.")
+
+
+def _reject_dangerous_ip(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+    hostname: str,
+    resolved: bool = False,
+) -> None:
+    """Raise ValueError if `ip` is a link-local or cloud-metadata address."""
+    is_ipv4_mapped_link_local = (
+        hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped and ip.ipv4_mapped.is_link_local
+    )
+
+    # Block link-local addresses (169.254.x.x / fe80::/10) - used for cloud
+    # metadata - including IPv4-mapped IPv6 addresses pointing to link-local
+    # (e.g. ::ffff:169.254.169.254 bypasses IPv6 is_link_local check).
+    if ip.is_link_local or is_ipv4_mapped_link_local:
+        if resolved:
+            raise ValueError(
+                f"Hostname '{hostname}' resolves to a link-local address (169.254.x.x) "
+                "which is not allowed for security reasons. These addresses are used "
+                "for cloud metadata endpoints."
+            )
+        raise ValueError(
+            "Link-local addresses (169.254.x.x) are not allowed for security reasons. "
+            "These addresses are used for cloud metadata endpoints."
+        )
+
+    # Block AWS's IMDSv6 metadata address - a Unique Local Address, not
+    # link-local, so it needs its own explicit check.
+    if ip == _AWS_IMDS_V6_ADDRESS:
+        if resolved:
+            raise ValueError(
+                f"Hostname '{hostname}' resolves to the AWS IMDSv6 metadata address "
+                "(fd00:ec2::254), which is not allowed for security reasons."
+            )
+        raise ValueError(
+            "The AWS IMDSv6 metadata address (fd00:ec2::254) is not allowed for "
+            "security reasons."
+        )

--- a/prompts/pattern/generic.jinja
+++ b/prompts/pattern/generic.jinja
@@ -1,0 +1,5 @@
+{{ prompt }}
+{%- if format_instructions %}
+
+{{ format_instructions }}
+{%- endif %}

--- a/prompts/transformation/execute.jinja
+++ b/prompts/transformation/execute.jinja
@@ -1,0 +1,3 @@
+{{ instructions }}
+
+# INPUT

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -18,7 +18,13 @@ from api.podcast_service import PodcastService
 from open_notebook.ai.models import ModelManager
 from open_notebook.domain.base import RecordModel
 from open_notebook.domain.content_settings import ContentSettings
-from open_notebook.domain.notebook import Asset, Note, Notebook, Source
+from open_notebook.domain.notebook import (
+    Asset,
+    Note,
+    Notebook,
+    Source,
+    SourceInsight,
+)
 from open_notebook.domain.transformation import Transformation
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.podcasts.models import EpisodeProfile, SpeakerProfile
@@ -127,13 +133,15 @@ class TestNotebookDomain:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_insights(self):
-            return []
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
 
         with (
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
-            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
         ):
             context = await notebook.get_context()
 
@@ -203,12 +211,18 @@ class TestNotebookDomain:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_context(self, context_size="short"):
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
+
+        async def fake_get_context(self, context_size="short", insights=None):
             raise RuntimeError("source context failed")
 
         with (
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
             patch.object(Source, "get_context", new=fake_get_context),
         ):
             with pytest.raises(RuntimeError, match="source context failed"):
@@ -477,8 +491,8 @@ class TestPodcastService:
         async def fake_get_notes(self, include_content=False):
             return []
 
-        async def fake_get_insights(self):
-            return []
+        async def fake_get_for_sources(cls, source_ids):
+            return {sid: [] for sid in source_ids}
 
         def fake_submit_command(app_name, command_name, command_args):
             submitted_args.update(command_args)
@@ -501,7 +515,9 @@ class TestPodcastService:
             patch.object(Notebook, "get", new=AsyncMock(return_value=notebook)),
             patch.object(Notebook, "get_sources", new=fake_get_sources),
             patch.object(Notebook, "get_notes", new=fake_get_notes),
-            patch.object(Source, "get_insights", new=fake_get_insights),
+            patch.object(
+                SourceInsight, "get_for_sources", new=classmethod(fake_get_for_sources)
+            ),
             patch("api.podcast_service.submit_command", new=fake_submit_command),
             patch.dict(
                 sys.modules, {"commands.podcast_commands": fake_commands_module}

--- a/tests/test_embedding_rebuild_estimate_query.py
+++ b/tests/test_embedding_rebuild_estimate_query.py
@@ -1,0 +1,130 @@
+"""
+Regression test for the malformed "existing sources" count query in
+api/routers/embedding_rebuild.py's start_rebuild() (mode="existing" branch).
+
+The query used to end in `FROM {}` - a stray, unfilled-looking placeholder
+(not an f-string, so not injectable, but SurrealQL requires SELECT to have
+a FROM target, and `{}` isn't a real table). It happened to still produce
+a correct result in this repo's embedded SurrealDB engine, but that's an
+accident of how the parser tolerates an empty-object FROM target, not
+documented/guaranteed SurrealQL behavior - and it read as broken.
+
+This is specifically a "is the query text itself valid, well-defined
+SurrealQL that returns the right answer" bug, which a mocked repo_query
+can't catch (mocking would just assume the query is fine and test the
+Python branching around it, which was never the problem). So this test
+runs the actual query from the source file against a real embedded
+SurrealDB instance instead of mocking - matching how this specific fix was
+verified during development.
+"""
+
+import re
+
+import pytest
+import pytest_asyncio
+from surrealdb import AsyncSurreal
+
+from open_notebook.database.repository import repo_query
+
+
+def _extract_existing_sources_query() -> str:
+    """Pull the exact query text out of the source file, so this test
+    can't silently drift from what's actually shipped."""
+    with open("api/routers/embedding_rebuild.py") as f:
+        content = f.read()
+    match = re.search(
+        r'result = await repo_query\(\s*"""(.*?)"""', content, re.DOTALL
+    )
+    assert match, "could not locate the existing-sources count query in embedding_rebuild.py"
+    return match.group(1)
+
+
+@pytest_asyncio.fixture
+async def embedded_db(tmp_path, monkeypatch):
+    """Point repo_query at a scratch file-backed embedded SurrealDB instance
+    for the duration of this test, then restore the real config."""
+    db_path = tmp_path / "embedding_rebuild_test_db"
+    monkeypatch.setenv("SURREAL_URL", f"file://{db_path}")
+    monkeypatch.setenv("SURREAL_NAMESPACE", "test_ns")
+    monkeypatch.setenv("SURREAL_DATABASE", "test_db")
+    monkeypatch.setenv("SURREAL_USER", "root")
+    monkeypatch.setenv("SURREAL_PASSWORD", "root")
+
+    bootstrap = AsyncSurreal(f"file://{db_path}")
+    await bootstrap.use("test_ns", "test_db")
+    await bootstrap.query("DEFINE USER root ON ROOT PASSWORD 'root' ROLES OWNER")
+    await bootstrap.close()
+
+    yield
+
+
+class TestExistingSourcesCountQuery:
+    def test_query_no_longer_contains_the_stray_placeholder(self):
+        query = _extract_existing_sources_query()
+        assert "FROM {}" not in query
+        assert "RETURN" in query
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_no_source_embeddings(self, embedded_db):
+        query = _extract_existing_sources_query()
+        result = await repo_query(query)
+        assert result == [0]
+
+    @pytest.mark.asyncio
+    async def test_counts_distinct_sources_with_a_nonempty_embedding(self, embedded_db):
+        query = _extract_existing_sources_query()
+
+        for i in range(3):
+            await repo_query(f"CREATE source:s{i} SET title = 'Source {i}';")
+        await repo_query(
+            "CREATE source_embedding SET source = source:s0, content = 'x', embedding = [0.1, 0.2];"
+        )
+        await repo_query(
+            "CREATE source_embedding SET source = source:s1, content = 'x', embedding = [0.3, 0.4];"
+        )
+        # s2 has no source_embedding at all - must not be counted
+
+        result = await repo_query(query)
+        assert result == [2]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_embedding_rows_for_one_source_count_once(self, embedded_db):
+        query = _extract_existing_sources_query()
+
+        await repo_query("CREATE source:s0 SET title = 'S0';")
+        await repo_query(
+            "CREATE source_embedding SET source = source:s0, content = 'a', embedding = [0.1];"
+        )
+        await repo_query(
+            "CREATE source_embedding SET source = source:s0, content = 'b', embedding = [0.2];"
+        )
+
+        result = await repo_query(query)
+        assert result == [1]
+
+    @pytest.mark.asyncio
+    async def test_empty_embedding_array_is_excluded(self, embedded_db):
+        query = _extract_existing_sources_query()
+
+        await repo_query("CREATE source:s0 SET title = 'S0';")
+        await repo_query(
+            "CREATE source_embedding SET source = source:s0, content = 'a', embedding = [];"
+        )
+
+        result = await repo_query(query)
+        assert result == [0]
+
+    @pytest.mark.asyncio
+    async def test_result_shape_matches_what_start_rebuild_expects(self, embedded_db):
+        """Locks in the exact contract api/routers/embedding_rebuild.py's
+        start_rebuild() relies on (result[0] is a bare int), so a future
+        query rewrite can't silently change the shape without this failing."""
+        query = _extract_existing_sources_query()
+        await repo_query("CREATE source:s0 SET title = 'S0';")
+        await repo_query(
+            "CREATE source_embedding SET source = source:s0, content = 'a', embedding = [0.1];"
+        )
+
+        result = await repo_query(query)
+        assert isinstance(result, list)
+        assert isinstance(result[0], int)


### PR DESCRIPTION
The "existing" rebuild-mode count query used `SELECT VALUE count(...) as count FROM {}` - SurrealDB requires a FROM clause on SELECT, but this is a single self-contained aggregate expression with nothing to iterate over, so the empty-object FROM was wrong. Rewritten as `RETURN [count(...)]`, the correct idiom for a standalone computed value, wrapped in `[]` to match the list-of-one-value shape the branch below expects (same as every other query in this function).

Plain correctness bug, not a security fix - bundled into the same working tree as the security hardening above. **Stacked on #1002-#1009** (unmerged). `tests/test_embedding_rebuild_estimate_query.py` passes (6/6).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

