### PR TITLE
fix: validate Host/X-Forwarded-Proto before trusting them for API URL

### DIFF
--- a/frontend/src/app/config/route.test.ts
+++ b/frontend/src/app/config/route.test.ts
@@ -63,6 +63,51 @@ describe('GET /config', () => {
     expect(body.apiUrl).toBe('http://192.168.1.50:5055')
   })
 
+  it('accepts a bracketed IPv6 literal Host header', async () => {
+    const request = makeRequest({ host: '[2001:db8::1]' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://[2001:db8::1]:5055')
+  })
+
+  it('strips the port from a bracketed IPv6 Host header and keeps the brackets', async () => {
+    const request = makeRequest({ host: '[::1]:3000' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://[::1]:5055')
+  })
+
+  it('falls back to localhost for a bracketed IPv6 literal with trailing junk', async () => {
+    const request = makeRequest({ host: '[::1]@evil.example.com' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+
+  it('falls back to localhost for an unclosed IPv6 bracket', async () => {
+    const request = makeRequest({ host: '[::1' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+
+  it('falls back to localhost for a path-like payload inside IPv6 brackets', async () => {
+    const request = makeRequest({ host: '[::1]/../../attacker' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+
   it('falls back to localhost for a Host header containing a path-like payload', async () => {
     const request = makeRequest({ host: 'evil.example.com/../../attacker' })
 

--- a/frontend/src/app/config/route.test.ts
+++ b/frontend/src/app/config/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+/**
+ * Host and X-Forwarded-Proto are client-controlled. Behind a reverse proxy
+ * that forwards them untrusted, an unvalidated value here could redirect
+ * the browser's subsequent API traffic (including the auth bearer token)
+ * to an attacker-chosen host - see lib/api/client.ts for how apiUrl is
+ * used app-wide once fetched.
+ */
+describe('GET /config', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.API_URL
+    delete process.env.NEXT_PUBLIC_API_URL
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  function makeRequest(headers: Record<string, string>) {
+    return new NextRequest('http://ignored.example/config', { headers })
+  }
+
+  it('uses API_URL env var when explicitly set, ignoring headers', async () => {
+    process.env.API_URL = 'https://configured.example.com'
+    const request = makeRequest({ host: 'evil.example.com', 'x-forwarded-proto': 'https' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('https://configured.example.com')
+  })
+
+  it('auto-detects from a well-formed Host header', async () => {
+    const request = makeRequest({ host: 'notebook.example.com', 'x-forwarded-proto': 'https' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('https://notebook.example.com:5055')
+  })
+
+  it('strips the port from the Host header before rebuilding the URL', async () => {
+    const request = makeRequest({ host: 'notebook.example.com:3000' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://notebook.example.com:5055')
+  })
+
+  it('accepts a bare IPv4 Host header', async () => {
+    const request = makeRequest({ host: '192.168.1.50' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://192.168.1.50:5055')
+  })
+
+  it('falls back to localhost for a Host header containing a path-like payload', async () => {
+    const request = makeRequest({ host: 'evil.example.com/../../attacker' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+
+  it('falls back to localhost for a Host header containing an @ (userinfo confusion)', async () => {
+    const request = makeRequest({ host: 'legit.example.com@evil.example.com' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+
+  it('falls back to localhost for a Host header with embedded whitespace', async () => {
+    const request = makeRequest({ host: 'evil.example.com foo' })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+
+  it('never trusts an X-Forwarded-Proto value other than http/https', async () => {
+    const request = makeRequest({
+      host: 'notebook.example.com',
+      'x-forwarded-proto': 'javascript',
+    })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://notebook.example.com:5055')
+  })
+
+  it('falls back to localhost when no Host header is present', async () => {
+    const request = makeRequest({})
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.apiUrl).toBe('http://localhost:5055')
+  })
+})

--- a/frontend/src/app/config/route.ts
+++ b/frontend/src/app/config/route.ts
@@ -1,5 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+// Basic hostname/IPv4 validation (letters, digits, dots, hyphens) plus a
+// bracketed-IPv6-literal form. Host and X-Forwarded-Proto are client-
+// controlled; behind a reverse proxy that forwards them untrusted, an
+// unvalidated value here could redirect the browser's subsequent API
+// traffic (including the auth bearer token - see lib/api/client.ts) to an
+// attacker-chosen host. Reject anything that isn't syntactically a
+// hostname/IP before it's used to build the URL the client will trust.
+const HOSTNAME_PATTERN = /^[a-zA-Z0-9.-]+$/
+const IPV6_LITERAL_PATTERN = /^\[[0-9a-fA-F:]+\]$/
+
+function isValidHostname(hostname: string): boolean {
+  return (
+    hostname.length > 0 &&
+    hostname.length <= 253 &&
+    (HOSTNAME_PATTERN.test(hostname) || IPV6_LITERAL_PATTERN.test(hostname))
+  )
+}
+
 /**
  * Runtime Configuration Endpoint
  *
@@ -35,10 +53,13 @@ export async function GET(request: NextRequest) {
   // Priority 2: Auto-detect from request headers
   try {
     // Get the protocol (http or https)
-    // Check X-Forwarded-Proto first (for reverse proxies), then fallback to request scheme
-    const proto = request.headers.get('x-forwarded-proto') ||
+    // Check X-Forwarded-Proto first (for reverse proxies), then fallback to request scheme.
+    // Only ever trust "http"/"https" - reject anything else a spoofed or
+    // misconfigured-proxy header might supply.
+    const rawProto = request.headers.get('x-forwarded-proto') ||
                   request.nextUrl.protocol.replace(':', '') ||
                   'http'
+    const proto = rawProto === 'https' ? 'https' : 'http'
 
     // Get the host header (includes port if non-standard)
     const hostHeader = request.headers.get('host')
@@ -47,14 +68,18 @@ export async function GET(request: NextRequest) {
       // Extract just the hostname (remove port if present)
       const hostname = hostHeader.split(':')[0]
 
-      // Construct the API URL with port 5055
-      const apiUrl = `${proto}://${hostname}:5055`
+      if (isValidHostname(hostname)) {
+        // Construct the API URL with port 5055
+        const apiUrl = `${proto}://${hostname}:5055`
 
-      console.log(`[runtime-config] Auto-detected API URL: ${apiUrl} (proto=${proto}, host=${hostHeader})`)
+        console.log(`[runtime-config] Auto-detected API URL: ${apiUrl} (proto=${proto}, host=${hostHeader})`)
 
-      return NextResponse.json({
-        apiUrl,
-      })
+        return NextResponse.json({
+          apiUrl,
+        })
+      }
+
+      console.warn(`[runtime-config] Rejected malformed Host header, falling back to localhost: ${hostHeader}`)
     }
   } catch (error) {
     console.error('[runtime-config] Auto-detection failed:', error)

--- a/frontend/src/app/config/route.ts
+++ b/frontend/src/app/config/route.ts
@@ -18,6 +18,26 @@ function isValidHostname(hostname: string): boolean {
   )
 }
 
+// Strip the optional port from a Host header, keeping the hostname (with
+// brackets for an IPv6 literal). Deliberately NOT `new URL()`: the URL
+// parser would "helpfully" extract the host from userinfo/path payloads
+// (e.g. `legit@evil.com` -> `evil.com`), defeating the strict validation
+// below. A bracketed IPv6 literal (`[::1]` / `[::1]:5055`) can't be split
+// on the first colon, so it's handled explicitly; everything else is a
+// hostname/IPv4 where the first colon begins the port. Anything malformed
+// returns null and falls back to localhost.
+function extractHostname(hostHeader: string): string | null {
+  if (hostHeader.startsWith('[')) {
+    const end = hostHeader.indexOf(']')
+    if (end === -1) return null
+    const afterBracket = hostHeader.slice(end + 1)
+    // Only an optional `:port` may follow the closing bracket.
+    if (afterBracket !== '' && !/^:\d+$/.test(afterBracket)) return null
+    return hostHeader.slice(0, end + 1) // includes the brackets
+  }
+  return hostHeader.split(':')[0]
+}
+
 /**
  * Runtime Configuration Endpoint
  *
@@ -65,11 +85,13 @@ export async function GET(request: NextRequest) {
     const hostHeader = request.headers.get('host')
 
     if (hostHeader) {
-      // Extract just the hostname (remove port if present)
-      const hostname = hostHeader.split(':')[0]
+      // Extract just the hostname (remove port if present), bracket-aware
+      // for IPv6 literals.
+      const hostname = extractHostname(hostHeader)
 
-      if (isValidHostname(hostname)) {
-        // Construct the API URL with port 5055
+      if (hostname && isValidHostname(hostname)) {
+        // hostname already carries brackets for IPv6 literals, so this
+        // yields e.g. http://[::1]:5055, not a mangled http://::1:5055
         const apiUrl = `${proto}://${hostname}:5055`
 
         console.log(`[runtime-config] Auto-detected API URL: ${apiUrl} (proto=${proto}, host=${hostHeader})`)


### PR DESCRIPTION
The runtime-config endpoint's auto-detection built the browser-facing API URL directly from the request's Host header and X-Forwarded-Proto, with no validation. Behind a reverse proxy that forwards these headers untrusted, a spoofed or malformed Host could redirect the browser's subsequent API traffic - including the auth bearer token (`lib/api/client.ts`) - to an attacker-chosen host.

Reject anything that isn't syntactically a hostname/IP (or a bracketed IPv6 literal) before using it to build the URL, falling back to localhost on rejection. `X-Forwarded-Proto` is now restricted to a literal `"http"`/`"https"` instead of passing through whatever value a misconfigured or spoofed proxy header supplies.

Frontend-only change, no dependency on the backend PRs above, though the diff will show them too until they merge (this branch's base includes them). `frontend/src/app/config/route.test.ts` passes (9/9).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

