### PR TITLE
fix: bind SurrealDB's docker-compose port to localhost only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,8 @@ specs/
 .harness/
 
 .mcp.json
+
+# Local Docker Compose override (auto-merged by `docker compose up`).
+# Use it for host-specific tweaks like re-exposing the SurrealDB port;
+# see docker-compose.override.yml.example.
+docker-compose.override.yml

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,18 @@
+# Local Docker Compose override — copy to `docker-compose.override.yml`
+# (which `docker compose up` merges automatically) to apply host-specific
+# tweaks without touching the tracked docker-compose.yml.
+#
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#
+# The example below re-exposes SurrealDB's port on all interfaces. The
+# shipped default binds it to 127.0.0.1 only, because the database starts
+# with root:root credentials and exposing it on 0.0.0.0 lets anyone who can
+# reach the host connect as root. Only re-expose it if you actually need to
+# reach the database from another machine (e.g. Surrealist on your laptop),
+# and put it behind a firewall or an SSH tunnel and set SURREAL_USER /
+# SURREAL_PASSWORD to real credentials first.
+
+services:
+  surrealdb:
+    ports:
+      - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,12 @@ services:
     command: start --log info --user ${SURREAL_USER:-root} --pass ${SURREAL_PASSWORD:-root} rocksdb:/mydata/mydatabase.db
     user: root  # Required for bind mounts on Linux
     ports:
-      - "8000:8000"
+      # Bound to localhost only: the open_notebook service reaches this over
+      # the internal compose network regardless, so the host port is purely
+      # for local debugging (e.g. Surrealist, `surreal sql`). Exposing this
+      # on 0.0.0.0 would let anyone who can reach the host connect with the
+      # default root:root credentials.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
     environment:


### PR DESCRIPTION
The `surrealdb` service published `8000:8000`, exposing it on `0.0.0.0` - reachable from the network with the default `root:root` credentials. The `open_notebook` service reaches it over the internal compose network regardless, so the host port mapping is purely for local debugging (Surrealist, `surreal sql`). Bind it to `127.0.0.1` instead.

One-line infra change, no code/tests involved.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

