### PR TITLE
fix: creating a new transformation does nothing when the list is empty

### DIFF
--- a/frontend/src/app/(dashboard)/transformations/components/TransformationsList.test.tsx
+++ b/frontend/src/app/(dashboard)/transformations/components/TransformationsList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { TransformationsList } from './TransformationsList'
+import { Transformation } from '@/lib/types/transformations'
+
+// useTranslation is mocked globally in setup.ts (t returns the key string)
+
+vi.mock('./TransformationEditorDialog', () => ({
+  TransformationEditorDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="transformation-editor-dialog" /> : null,
+}))
+
+vi.mock('./TransformationCard', () => ({
+  TransformationCard: () => <div data-testid="transformation-card" />,
+}))
+
+const mockTransformation: Transformation = {
+  id: 'transformation:1',
+  name: 'summarize',
+  title: 'Summarize',
+  description: 'Summarize the content',
+  prompt: 'Summarize this',
+  apply_default: false,
+  model_id: null,
+  created: '2026-01-01T00:00:00Z',
+  updated: '2026-01-01T00:00:00Z',
+}
+
+describe('TransformationsList', () => {
+  it('opens the editor dialog from the empty state create button', () => {
+    render(<TransformationsList transformations={[]} isLoading={false} />)
+
+    fireEvent.click(screen.getByText('transformations.createNew'))
+
+    expect(screen.getByTestId('transformation-editor-dialog')).toBeInTheDocument()
+  })
+
+  it('opens the editor dialog from the list header create button', () => {
+    render(<TransformationsList transformations={[mockTransformation]} isLoading={false} />)
+
+    fireEvent.click(screen.getByText('transformations.createNew'))
+
+    expect(screen.getByTestId('transformation-editor-dialog')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/transformations/components/TransformationsList.tsx
+++ b/frontend/src/app/(dashboard)/transformations/components/TransformationsList.tsx
@@ -35,19 +35,35 @@ export function TransformationsList({ transformations, isLoading, onPlayground }
     )
   }
 
+  const editorDialog = (
+    <TransformationEditorDialog
+      open={editorOpen}
+      onOpenChange={(open) => {
+        setEditorOpen(open)
+        if (!open) {
+          setEditingTransformation(undefined)
+        }
+      }}
+      transformation={editingTransformation}
+    />
+  )
+
   if (!transformations || transformations.length === 0) {
     return (
-      <EmptyState
-        icon={Wand2}
-        title={t('transformations.noTransformations')}
-        description={t('transformations.createOne')}
-        action={
-          <Button onClick={() => handleOpenEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            {t('transformations.createNew')}
-          </Button>
-        }
-      />
+      <>
+        <EmptyState
+          icon={Wand2}
+          title={t('transformations.noTransformations')}
+          description={t('transformations.createOne')}
+          action={
+            <Button onClick={() => handleOpenEditor()}>
+              <Plus className="h-4 w-4 mr-2" />
+              {t('transformations.createNew')}
+            </Button>
+          }
+        />
+        {editorDialog}
+      </>
     )
   }
 
@@ -74,16 +90,7 @@ export function TransformationsList({ transformations, isLoading, onPlayground }
         </div>
       </div>
 
-      <TransformationEditorDialog
-        open={editorOpen}
-        onOpenChange={(open) => {
-          setEditorOpen(open)
-          if (!open) {
-            setEditingTransformation(undefined)
-          }
-        }}
-        transformation={editingTransformation}
-      />
+      {editorDialog}
     </>
   )
 }


### PR DESCRIPTION
Fixes #999

After deleting every transformation, the "New Transformation" button in the empty state stops working — clicking it does nothing (there's a repro video in the issue).

Root cause: `TransformationsList` returns early for the empty state, and `TransformationEditorDialog` was only rendered in the non-empty branch. So with zero transformations the button click sets `editorOpen = true`, but there's no dialog mounted to open.

The fix renders the dialog in both branches (pulled it out into a single `editorDialog` element so it isn't duplicated). No behavior change for the non-empty list.

## Testing

- Added a component test that clicks the empty-state create button and asserts the dialog opens — it fails on `main` and passes with the fix. Also added one for the list-header create button so that path stays covered.
- `npm run test` — 82/82 passing
- `npm run lint` — no new warnings
- `npm run build` — passes

To verify manually: delete all transformations, then click "New Transformation" in the empty state — the editor dialog should open.

Frontend-only change, no new i18n keys (reuses existing strings). Risk is minimal: worst case would be the dialog rendering wrong in the empty state, which the new test would catch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

