### PR TITLE
fix: fail fast on unsupported file types instead of retrying for an hour

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -125,6 +125,48 @@ def _write_uploaded_file(filename: str, content: bytes) -> str:
         raise
 
 
+async def ensure_file_type_supported(file_path: str) -> None:
+    """Reject files that content-core cannot process, so the user gets an
+    immediate, specific error instead of a background job that only fails
+    after exhausting its retry budget (~1 hour, see #975).
+
+    Runs content-core's own identification + routing (reads ~1KB of the
+    file, no extraction) rather than a hand-maintained extension allowlist,
+    which would drift out of sync with content-core's supported types and
+    reject files it actually handles, e.g. extensionless plain text (see
+    tests/test_upload_type_mitigations.py for the earlier analysis).
+    Fails open on unexpected errors - worst case the failure surfaces at
+    processing time, as before."""
+    try:
+        from content_core.common import (
+            ProcessSourceState,
+            UnsupportedTypeException,
+        )
+        from content_core.content.extraction.graph import file_type_router_docling
+        from content_core.content.identification import get_file_type
+    except ImportError as e:
+        logger.warning(f"content-core layout changed, skipping upload validation: {e}")
+        return
+
+    try:
+        identified_type = await get_file_type(file_path)
+        state = ProcessSourceState(
+            file_path=file_path,
+            identified_type=identified_type,
+            document_engine="auto",  # same engine content_process() runs with
+        )
+        await file_type_router_docling(state)
+    except UnsupportedTypeException as e:
+        suffix = Path(file_path).suffix.lower() or "unknown"
+        logger.info(f"Rejected upload with unsupported file type ({suffix}): {e}")
+        raise InvalidInputError(
+            f"Unsupported file type: {suffix}. Supported formats include PDF, "
+            "EPUB, DOCX, PPTX, XLSX, TXT, Markdown, and common audio/video files."
+        )
+    except Exception as e:
+        logger.warning(f"Could not pre-validate file type for {file_path}: {e}")
+
+
 async def save_uploaded_file(upload_file: UploadFile) -> str:
     """Save uploaded file to uploads folder and return file path."""
     if not upload_file.filename:
@@ -395,6 +437,7 @@ async def create_source(
                     status_code=400,
                     detail="Invalid file path: must be within the uploads directory",
                 )
+            await ensure_file_type_supported(final_file_path)
             content_state["file_path"] = final_file_path
             content_state["delete_source"] = source_data.delete_source
         elif source_data.type == "text":
@@ -798,7 +841,14 @@ async def get_source_status(source_id: str):
             if status == "completed":
                 message = "Source processing completed successfully"
             elif status == "failed":
-                message = "Source processing failed"
+                # Surface the stored failure reason (e.g. an unsupported file
+                # type) instead of a generic message the user can't act on
+                error_detail = (processing_info or {}).get("error")
+                message = (
+                    f"Source processing failed: {error_detail}"
+                    if error_detail
+                    else "Source processing failed"
+                )
             elif status == "running":
                 message = "Source processing in progress"
             elif status == "queued":

--- a/open_notebook/graphs/source.py
+++ b/open_notebook/graphs/source.py
@@ -2,7 +2,7 @@ import operator
 from typing import Any, Dict, List, Optional
 
 from content_core import extract_content
-from content_core.common import ProcessSourceState
+from content_core.common import ProcessSourceState, UnsupportedTypeException
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Send
@@ -75,7 +75,14 @@ async def content_process(state: SourceState) -> dict:
         logger.warning(f"Failed to retrieve speech-to-text model configuration: {e}")
         # Continue without custom audio model (content-core will use its default)
 
-    processed_state = await extract_content(content_state)
+    try:
+        processed_state = await extract_content(content_state)
+    except UnsupportedTypeException as e:
+        # Permanent failure: retrying can't make an unsupported format
+        # processable. Re-raise as ValueError so the command's stop_on list
+        # fails the job immediately (and logs the reason) instead of burning
+        # 15 exponential-backoff retries (~1 hour) on a deterministic error.
+        raise ValueError(str(e)) from e
 
     # content-core signals a soft extraction failure (e.g. an unreachable or
     # invalid URL) by returning title="Error" and content prefixed with

--- a/tests/test_unsupported_file_type.py
+++ b/tests/test_unsupported_file_type.py
@@ -1,0 +1,198 @@
+"""
+Tests for the unsupported-file-type handling (#975).
+
+Uploading a file content-core can't process (e.g. .odt) used to be
+accepted silently, then burn process_source's 15 exponential-backoff
+retries (~1 hour) before failing with a generic "Source processing
+failed" and no log line. Three fixes, each locked in here:
+
+1. create_source() rejects unsupported files at upload time with a 400
+   by running content-core's own identification + routing
+   (ensure_file_type_supported) - deliberately NOT an extension
+   allowlist, so files content-core does handle (e.g. extensionless
+   plain text) keep working.
+2. content_process() re-raises UnsupportedTypeException as ValueError,
+   which is in the command's stop_on list - the job fails on attempt 1
+   instead of retrying a deterministic error.
+3. get_source_status() surfaces the stored error_message for failed
+   jobs instead of a generic message.
+"""
+
+import zipfile
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.routers.sources import ensure_file_type_supported
+from open_notebook.exceptions import InvalidInputError
+
+
+def make_fake_odt(path):
+    """Minimal OpenDocument text file: a ZIP that isn't DOCX/XLSX/PPTX/EPUB."""
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("mimetype", "application/vnd.oasis.opendocument.text")
+        z.writestr("META-INF/manifest.xml", "<manifest/>")
+        z.writestr("content.xml", "<office:document-content/>")
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+class TestEnsureFileTypeSupported:
+    @pytest.mark.asyncio
+    async def test_odt_file_is_rejected(self, tmp_path):
+        odt = tmp_path / "document.odt"
+        make_fake_odt(odt)
+
+        with pytest.raises(InvalidInputError, match=r"Unsupported file type: \.odt"):
+            await ensure_file_type_supported(str(odt))
+
+    @pytest.mark.asyncio
+    async def test_plain_text_file_is_accepted(self, tmp_path):
+        txt = tmp_path / "notes.txt"
+        txt.write_text("Just some plain text content for testing purposes.")
+
+        await ensure_file_type_supported(str(txt))
+
+    @pytest.mark.asyncio
+    async def test_extensionless_text_file_is_accepted(self, tmp_path):
+        # The reason this isn't an extension allowlist: content-core
+        # detects plain text by content and processes it fine.
+        no_ext = tmp_path / "README"
+        no_ext.write_text("Readable prose without any file extension at all.")
+
+        await ensure_file_type_supported(str(no_ext))
+
+    @pytest.mark.asyncio
+    async def test_pdf_file_is_accepted(self, tmp_path):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 minimal header is enough for identification")
+
+        await ensure_file_type_supported(str(pdf))
+
+    @pytest.mark.asyncio
+    async def test_fails_open_when_file_unreadable(self, tmp_path):
+        # A pre-validation hiccup must not block the upload - the worker
+        # remains the authority and would surface the failure instead.
+        await ensure_file_type_supported(str(tmp_path / "does-not-exist.txt"))
+
+
+class TestCreateSourceRejectsUnsupportedUpload:
+    def test_odt_upload_returns_400_and_cleans_up_file(
+        self, client, tmp_path, monkeypatch
+    ):
+        uploads = tmp_path / "uploads"
+        uploads.mkdir()
+        monkeypatch.setattr("api.routers.sources.UPLOADS_FOLDER", str(uploads))
+
+        odt = tmp_path / "document.odt"
+        make_fake_odt(odt)
+
+        with patch(
+            "api.routers.sources.Notebook.get",
+            new=AsyncMock(return_value=MagicMock()),
+        ):
+            response = client.post(
+                "/api/sources",
+                data={
+                    "type": "upload",
+                    "notebooks": '["notebook:test123"]',
+                    "async_processing": "true",
+                },
+                files={"file": ("document.odt", odt.read_bytes())},
+            )
+
+        assert response.status_code == 400
+        assert "Unsupported file type: .odt" in response.json()["detail"]
+        # The saved upload must not be left behind after rejection
+        assert list(uploads.iterdir()) == []
+
+
+class TestContentProcessDoesNotRetryUnsupportedTypes:
+    @pytest.mark.asyncio
+    async def test_unsupported_type_exception_becomes_value_error(self):
+        from content_core.common import UnsupportedTypeException
+
+        from open_notebook.graphs.source import content_process
+
+        mock_manager = MagicMock()
+        mock_manager.get_defaults = AsyncMock(side_effect=Exception("no db in test"))
+
+        with (
+            patch(
+                "open_notebook.graphs.source.extract_content",
+                new=AsyncMock(
+                    side_effect=UnsupportedTypeException(
+                        "Unsupported file type: application/zip"
+                    )
+                ),
+            ),
+            patch(
+                "open_notebook.graphs.source.ModelManager",
+                return_value=mock_manager,
+            ),
+        ):
+            # ValueError is in process_source's stop_on list; anything else
+            # would be retried 15 times with exponential backoff
+            state: Any = {
+                "content_state": {"file_path": "/tmp/document.odt"},
+                "apply_transformations": [],
+                "source_id": "source:test123",
+                "notebook_ids": [],
+                "transformation": [],
+                "embed": False,
+            }
+            with pytest.raises(
+                ValueError, match="Unsupported file type: application/zip"
+            ):
+                await content_process(state)
+
+
+class TestSourceStatusSurfacesFailureReason:
+    def _get_status(self, client, progress):
+        from open_notebook.domain.notebook import Source
+
+        source = Source(
+            id="source:test123",
+            title="Test Source",
+            topics=[],
+            command="command:test123",
+        )
+
+        with (
+            patch(
+                "api.routers.sources.Source.get",
+                new=AsyncMock(return_value=source),
+            ),
+            patch.object(Source, "get_status", new=AsyncMock(return_value="failed")),
+            patch.object(
+                Source,
+                "get_processing_progress",
+                new=AsyncMock(return_value=progress),
+            ),
+        ):
+            return client.get("/api/sources/source:test123/status")
+
+    def test_failed_status_includes_error_message(self, client):
+        response = self._get_status(
+            client,
+            {"status": "failed", "error": "Unsupported file type: application/zip"},
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.json()["message"]
+            == "Source processing failed: Unsupported file type: application/zip"
+        )
+
+    def test_failed_status_without_error_keeps_generic_message(self, client):
+        response = self._get_status(client, {"status": "failed", "error": None})
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Source processing failed"


### PR DESCRIPTION
## Description

Uploading a file content-core can't process (like an `.odt`) currently gets accepted, quietly burns all 15 retry attempts of `process_source` (~1 hour of exponential backoff), and then shows a generic "Source processing failed" with a Retry button that would waste another hour. Nothing hits the logs either, because retries log at debug level.

Root cause: content-core raises `UnsupportedTypeException` for these files, which isn't in the command's `stop_on` list (`ValueError`, `ConfigurationError`), so a deterministic failure gets treated as transient.

Three changes:

1. **Reject unsupported files at upload time.** `create_source` now runs content-core's own identification + routing on the uploaded file (new `ensure_file_type_supported`) and returns a 400 with a clear message before anything is queued. I deliberately did *not* use an extension allowlist — `tests/test_upload_type_mitigations.py` already documents why one would drift out of sync with content-core and reject files it actually handles (extensionless plain text, for example). The check reads ~1KB of the file, is literally the same code path the worker runs so it can't disagree with it, and fails open: if the pre-check itself errors unexpectedly, the upload goes through and the worker stays the authority.

2. **Stop retrying unsupported types in the worker.** `content_process` re-raises `UnsupportedTypeException` as `ValueError`, which is already in `stop_on`, so the job fails on attempt 1 and the reason is logged at error level. This also covers files that never went through upload validation (e.g. a URL source that downloads to an unsupported format).

3. **Surface the actual failure reason.** `get_source_status` now appends the stored `error_message` for failed jobs, so the source card shows "Source processing failed: Unsupported file type: ..." instead of the generic message. No frontend change needed — unmapped backend messages are displayed as-is.

Deliberately out of scope: hiding the Retry button on permanent failures (needs error classification in the frontend, and with this fix the failure is immediate and self-explanatory), and actual ODT support, which is #976.

From a local run: an `.odt` upload goes from ~1 hour to a 400 in ~50ms, and a job that reaches the worker anyway fails in ~1s instead of ~1h.

## Related Issue

Fixes #975

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [ ] Tested locally with Docker
- [x] Tested locally with development setup
- [x] Added new unit tests
- [x] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)

**Test Details:**

9 new tests in `tests/test_unsupported_file_type.py`: upload rejection with cleanup of the saved file, the cases that must *keep* working (`.txt`, `.pdf`, extensionless plain text), fail-open behavior, the `UnsupportedTypeException` → `ValueError` conversion, and the status message. Full suite: 406 passed.

Manual test against the full local stack (SurrealDB + API + worker):
- `POST /api/sources` with an `.odt` → immediate 400 `"Unsupported file type: .odt. Supported formats include PDF, EPUB, DOCX, PPTX, XLSX, TXT, Markdown, and common audio/video files."`, nothing left in the uploads folder
- same request with a `.txt` → queues and completes normally
- submitted a `process_source` job pointing straight at an `.odt` (bypassing upload validation) → job status `failed` after 1.1s with `error_message='Unsupported file type: application/zip'`, `GET /sources/{id}/status` returns `"Source processing failed: Unsupported file type: application/zip"`, and the worker log has the error line

Risk-wise, the worst case for the upload check would be a false rejection, which is why it only rejects when content-core's own router raises, and fails open on anything unexpected. A regression there would trip the "supported formats still accepted" tests.

## Design Alignment

**Which design principles does this PR support?** (See [VISION.md](https://github.com/lfnovo/open-notebook/blob/main/VISION.md))

- [ ] Privacy First
- [x] Simplicity Over Features
- [x] API-First Architecture
- [ ] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**

Validation lives in the API layer, so every client gets it for free (the Next.js UI shows the 400 message with no changes). Reusing content-core's own detection instead of maintaining a parallel format list keeps the surface small.

## Checklist

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [ ] My code follows TypeScript best practices (Frontend) — no frontend changes
- [x] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript) — n/a
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors (`ruff check .` clean; mypy reports no new errors in the touched files — the pre-existing ones on main are untouched)

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran linting: `make ruff` or `ruff check . --fix`
- [x] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable) — n/a
- [x] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made) — endpoints unchanged, only a new 400 case on POST /sources
- [x] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`) — n/a
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Additional Context

The issue is labeled `needs-design`, so to be explicit about the one real design decision here: upload validation is content-detection (content-core's own detector + router) rather than an extension allowlist. That's what keeps it from drifting from what the worker actually accepts, in both directions — no rejecting files that would process fine, no accepting files that are guaranteed to fail. If you'd rather see a different shape for this, happy to rework it.

## Pre-Submission Verification

- [x] I have read [CONTRIBUTING.md](https://github.com/lfnovo/open-notebook/blob/main/docs/7-DEVELOPMENT/contributing.md)
- [x] I have read [VISION.md](https://github.com/lfnovo/open-notebook/blob/main/VISION.md)
- [x] This PR addresses an approved issue assigned to me, **or** it's a small obvious fix (typo, docs, tiny bug) that doesn't need one — for anything bigger without an issue, mark this PR as draft and open the issue (triage takes 1–2 days)
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

