### PR TITLE
fix: title sort 500 and form-validation 500s in the sources API

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -14,6 +14,7 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, Response
 from loguru import logger
+from pydantic import ValidationError
 from surreal_commands import execute_command_sync, submit_command
 
 from api.command_service import CommandService
@@ -41,7 +42,10 @@ router = APIRouter()
 SOURCE_SORT_FIELDS = {
     "created": "created",
     "updated": "updated",
-    "title": "title",
+    # `title` carries a SEARCH (BM25) index; SurrealDB's planner tries to use
+    # it for ORDER BY and fails ("No iterator has been found"), so we sort by
+    # a computed alias instead — which also makes the sort case-insensitive.
+    "title": "title_sort",
     "insights_count": "insights_count",
     "embedded": "embedded",
     "type": "type",
@@ -165,7 +169,9 @@ def parse_source_form_data(
             notebooks_list = json.loads(notebooks)
         except json.JSONDecodeError:
             logger.error(f"Invalid JSON in notebooks field: {notebooks}")
-            raise ValueError("Invalid JSON in notebooks field")
+            raise HTTPException(
+                status_code=422, detail="Invalid JSON in notebooks field"
+            )
 
     transformations_list = []
     if transformations:
@@ -173,7 +179,9 @@ def parse_source_form_data(
             transformations_list = json.loads(transformations)
         except json.JSONDecodeError:
             logger.error(f"Invalid JSON in transformations field: {transformations}")
-            raise ValueError("Invalid JSON in transformations field")
+            raise HTTPException(
+                status_code=422, detail="Invalid JSON in transformations field"
+            )
 
     # Create SourceCreate instance
     try:
@@ -190,7 +198,10 @@ def parse_source_form_data(
             delete_source=delete_source_bool,
             async_processing=async_processing_bool,
         )
-        pass  # SourceCreate instance created successfully
+    except ValidationError as e:
+        errors = "; ".join(err.get("msg", "invalid value") for err in e.errors())
+        logger.error(f"Invalid source form data: {errors}")
+        raise HTTPException(status_code=422, detail=f"Invalid source data: {errors}")
     except Exception as e:
         logger.error(f"Failed to create SourceCreate instance: {e}")
         raise
@@ -242,6 +253,7 @@ async def get_sources(
             # Query sources for specific notebook - include command field with FETCH
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command,
+                string::lowercase(title OR '') AS title_sort,
                 ({SOURCE_TYPE_EXPRESSION}) AS type,
                 (SELECT VALUE count() FROM source_insight WHERE source = $parent.id GROUP ALL)[0].count OR 0 AS insights_count,
                 (SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded
@@ -262,6 +274,7 @@ async def get_sources(
             # Query all sources - include command field with FETCH
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command,
+                string::lowercase(title OR '') AS title_sort,
                 ({SOURCE_TYPE_EXPRESSION}) AS type,
                 (SELECT VALUE count() FROM source_insight WHERE source = $parent.id GROUP ALL)[0].count OR 0 AS insights_count,
                 (SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded

--- a/tests/test_source_create_array_limits.py
+++ b/tests/test_source_create_array_limits.py
@@ -54,3 +54,50 @@ class TestTransformationsMaxLength:
     def test_default_is_empty_list(self):
         request = SourceCreate(type="text", content="hi")
         assert request.transformations == []
+
+
+class TestFormParsingReturns422:
+    """The multipart form path builds SourceCreate manually in
+    parse_source_form_data(), so pydantic's ValidationError doesn't go
+    through FastAPI's request-validation handler — without an explicit
+    catch it surfaced as a 500. These hit the real endpoint and assert
+    the client gets a clean 422 instead (found in v1.11 release testing).
+    """
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from api.main import app
+
+        return TestClient(app)
+
+    def test_51_notebooks_via_form_returns_422(self, client):
+        import json as _json
+
+        response = client.post(
+            "/api/sources",
+            data={
+                "type": "text",
+                "content": "probe",
+                "notebooks": _json.dumps(make_ids(51, "notebook")),
+            },
+        )
+        assert response.status_code == 422
+        assert "Invalid source data" in response.json()["detail"]
+
+    def test_invalid_notebooks_json_returns_422(self, client):
+        response = client.post(
+            "/api/sources",
+            data={"type": "text", "content": "probe", "notebooks": "not-json["},
+        )
+        assert response.status_code == 422
+        assert "notebooks" in response.json()["detail"]
+
+    def test_invalid_transformations_json_returns_422(self, client):
+        response = client.post(
+            "/api/sources",
+            data={"type": "text", "content": "probe", "transformations": "]bad"},
+        )
+        assert response.status_code == 422
+        assert "transformations" in response.json()["detail"]

--- a/tests/test_sources_api.py
+++ b/tests/test_sources_api.py
@@ -216,3 +216,37 @@ class TestGetSourceNotFound:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestTitleSortUsesAlias:
+    """Regression for sort_by=title returning a 500 (v1.11 release testing).
+
+    source.title carries a SEARCH (BM25) index and SurrealDB's planner
+    fails ORDER BY on such a column with "No iterator has been found".
+    The router must therefore sort by the computed `title_sort` alias,
+    never by the raw indexed column.
+    """
+
+    @pytest.mark.asyncio
+    @patch("api.routers.sources.repo_query", new_callable=AsyncMock)
+    async def test_sort_by_title_orders_by_alias(self, mock_query, client):
+        mock_query.return_value = []
+
+        response = client.get("/api/sources?sort_by=title")
+
+        assert response.status_code == 200
+        query = mock_query.call_args[0][0]
+        assert "ORDER BY title_sort" in query
+        assert "AS title_sort" in query
+
+    @pytest.mark.asyncio
+    @patch("api.routers.sources.repo_query", new_callable=AsyncMock)
+    async def test_all_sort_fields_return_200(self, mock_query, client):
+        mock_query.return_value = []
+        for field in ["type", "title", "created", "updated", "insights_count", "embedded"]:
+            response = client.get(f"/api/sources?sort_by={field}")
+            assert response.status_code == 200, f"sort_by={field}"
+
+    def test_invalid_sort_field_returns_400(self, client):
+        response = client.get("/api/sources?sort_by=bogus")
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary

Two bugs found while running the v1.11 release test plan (targeted API probes against a live stack):

### `GET /api/sources?sort_by=title` → 500 (#895 feature)
`source.title` has a SEARCH/BM25 index (`idx_source_title`, migration 1), and SurrealDB v2's planner fails `ORDER BY` on a search-indexed column with `"No iterator has been found"`. Every other sort field worked (`created`/`updated` are unindexed, the rest are computed aliases) — which is also why the UI's Title column header was broken while everything else sorted fine. The query now selects `string::lowercase(title OR '') AS title_sort` and orders by the alias, which sidesteps the index and makes title sorting case-insensitive.

### `POST /api/sources` with bad form data → 500 (#1015 hardening)
The 50-item cap on `notebooks`/`transformations` exists on `SourceCreate`, but the multipart path constructs the model manually inside `parse_source_form_data()` — so the `ValidationError` (and the invalid-JSON `ValueError`s next to it) bypassed FastAPI's request-validation handler and surfaced as raw 500s. All three cases now return a clean 422 with a descriptive message.

## Testing

- Reproduced both 500s against a live SurrealDB v2 + API stack; verified the aliased query returns correctly ordered results against real data
- New regression tests: ORDER BY uses the alias, all six sort fields return 200, invalid sort field returns 400, and the three 422 form paths
- Full suite: **403 passed**

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

