### PR TITLE
fix: actually clear credential fields end to end (frontend payload + API null handling)

### DIFF
--- a/api/routers/credentials.py
+++ b/api/routers/credentials.py
@@ -216,34 +216,41 @@ async def update_credential(credential_id: str, request: UpdateCredentialRequest
     try:
         cred = await Credential.get(credential_id)
 
+        # Partial-update semantics keyed on field PRESENCE, not value:
+        # a field absent from the payload is left untouched, while an explicit
+        # null (or "") clears it. `is not None` checks would silently ignore
+        # a null sent to clear a field — the old value survived while the
+        # client saw success.
+        sent = request.model_fields_set
+
         if request.name is not None:
             cred.name = request.name
         if request.modalities is not None:
             cred.modalities = request.modalities
         if request.api_key is not None:
             cred.api_key = SecretStr(request.api_key)
-        if request.base_url is not None:
+        if "base_url" in sent:
             cred.base_url = request.base_url or None
-        if request.endpoint is not None:
+        if "endpoint" in sent:
             cred.endpoint = request.endpoint or None
-        if request.api_version is not None:
+        if "api_version" in sent:
             cred.api_version = request.api_version or None
-        if request.endpoint_llm is not None:
+        if "endpoint_llm" in sent:
             cred.endpoint_llm = request.endpoint_llm or None
-        if request.endpoint_embedding is not None:
+        if "endpoint_embedding" in sent:
             cred.endpoint_embedding = request.endpoint_embedding or None
-        if request.endpoint_stt is not None:
+        if "endpoint_stt" in sent:
             cred.endpoint_stt = request.endpoint_stt or None
-        if request.endpoint_tts is not None:
+        if "endpoint_tts" in sent:
             cred.endpoint_tts = request.endpoint_tts or None
-        if request.project is not None:
+        if "project" in sent:
             cred.project = request.project or None
-        if request.location is not None:
+        if "location" in sent:
             cred.location = request.location or None
-        if request.credentials_path is not None:
+        if "credentials_path" in sent:
             cred.credentials_path = request.credentials_path or None
-        if request.num_ctx is not None:
-            # 0/falsy clears the override and falls back to esperanto's default
+        if "num_ctx" in sent:
+            # 0/null/falsy clears the override and falls back to esperanto's default
             cred.num_ctx = request.num_ctx or None
 
         await cred.save()

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -222,12 +222,14 @@ function CredentialFormDialog({
       const data: UpdateCredentialRequest = {}
       if (name !== credential.name) data.name = name
       if (apiKey.trim()) data.api_key = apiKey.trim()
-      if (baseUrl !== (credential.base_url || '')) data.base_url = baseUrl || undefined
+      // null (not undefined) so clearing a field actually reaches the API —
+      // undefined keys are dropped from the JSON body and the old value survives
+      if (baseUrl !== (credential.base_url || '')) data.base_url = baseUrl || null
       if (JSON.stringify(modalities) !== JSON.stringify(credential.modalities)) data.modalities = modalities
       if (isVertex) {
-        if (project !== (credential.project || '')) data.project = project.trim() || undefined
-        if (location !== (credential.location || '')) data.location = location.trim() || undefined
-        if (credentialsPath !== (credential.credentials_path || '')) data.credentials_path = credentialsPath.trim() || undefined
+        if (project !== (credential.project || '')) data.project = project.trim() || null
+        if (location !== (credential.location || '')) data.location = location.trim() || null
+        if (credentialsPath !== (credential.credentials_path || '')) data.credentials_path = credentialsPath.trim() || null
       }
       if (isOllama && numCtx !== (credential.num_ctx ? String(credential.num_ctx) : '')) {
         // empty clears the override (0 -> backend resets to default)

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -53,7 +53,8 @@ import {
   useRegisterModels,
   useMigrateFromEnv,
 } from '@/lib/hooks/use-credentials'
-import { Credential, CreateCredentialRequest, UpdateCredentialRequest, DiscoveredModel } from '@/lib/api/credentials'
+import { Credential, CreateCredentialRequest, DiscoveredModel } from '@/lib/api/credentials'
+import { buildCredentialUpdatePayload } from '@/lib/credential-update-payload'
 import { Model, ModelDefaults } from '@/lib/types/models'
 import { MigrationBanner, ModelTestResultDialog } from '@/components/settings'
 import { EmbeddingModelChangeDialog } from '@/components/settings/EmbeddingModelChangeDialog'
@@ -219,22 +220,10 @@ function CredentialFormDialog({
     }
 
     if (isEditing && credential) {
-      const data: UpdateCredentialRequest = {}
-      if (name !== credential.name) data.name = name
-      if (apiKey.trim()) data.api_key = apiKey.trim()
-      // null (not undefined) so clearing a field actually reaches the API —
-      // undefined keys are dropped from the JSON body and the old value survives
-      if (baseUrl !== (credential.base_url || '')) data.base_url = baseUrl || null
-      if (JSON.stringify(modalities) !== JSON.stringify(credential.modalities)) data.modalities = modalities
-      if (isVertex) {
-        if (project !== (credential.project || '')) data.project = project.trim() || null
-        if (location !== (credential.location || '')) data.location = location.trim() || null
-        if (credentialsPath !== (credential.credentials_path || '')) data.credentials_path = credentialsPath.trim() || null
-      }
-      if (isOllama && numCtx !== (credential.num_ctx ? String(credential.num_ctx) : '')) {
-        // empty clears the override (0 -> backend resets to default)
-        data.num_ctx = numCtx.trim() ? Number(numCtx) : 0
-      }
+      const data = buildCredentialUpdatePayload(credential, {
+        name, apiKey, baseUrl, modalities, project, location,
+        credentialsPath, numCtx, isVertex, isOllama,
+      })
       updateCredential.mutate({ credentialId: credential.id, data }, { onSuccess })
     } else {
       const data: CreateCredentialRequest = {

--- a/frontend/src/lib/api/credentials.ts
+++ b/frontend/src/lib/api/credentials.ts
@@ -46,16 +46,18 @@ export interface UpdateCredentialRequest {
   name?: string
   modalities?: string[]
   api_key?: string
-  base_url?: string
-  endpoint?: string
-  api_version?: string
-  endpoint_llm?: string
-  endpoint_embedding?: string
-  endpoint_stt?: string
-  endpoint_tts?: string
-  project?: string
-  location?: string
-  credentials_path?: string
+  // Nullable fields: null explicitly clears the value on the server.
+  // (undefined would be dropped from the JSON payload and the old value kept.)
+  base_url?: string | null
+  endpoint?: string | null
+  api_version?: string | null
+  endpoint_llm?: string | null
+  endpoint_embedding?: string | null
+  endpoint_stt?: string | null
+  endpoint_tts?: string | null
+  project?: string | null
+  location?: string | null
+  credentials_path?: string | null
   num_ctx?: number | null
 }
 

--- a/frontend/src/lib/credential-update-payload.test.ts
+++ b/frontend/src/lib/credential-update-payload.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { buildCredentialUpdatePayload, CredentialFormValues } from './credential-update-payload'
+import { Credential } from '@/lib/api/credentials'
+
+const credential: Credential = {
+  id: 'credential:1',
+  name: 'Ollama',
+  provider: 'ollama',
+  modalities: ['language'],
+  base_url: 'http://10.0.0.99:11434',
+  project: 'old-project',
+  location: 'us-east5',
+  credentials_path: '/old/path.json',
+  num_ctx: null,
+  has_api_key: false,
+  created: '2026-01-01',
+  updated: '2026-01-01',
+  model_count: 0,
+}
+
+const values = (overrides: Partial<CredentialFormValues>): CredentialFormValues => ({
+  name: credential.name,
+  apiKey: '',
+  baseUrl: credential.base_url || '',
+  modalities: credential.modalities,
+  project: credential.project || '',
+  location: credential.location || '',
+  credentialsPath: credential.credentials_path || '',
+  numCtx: '',
+  isVertex: false,
+  isOllama: true,
+  ...overrides,
+})
+
+describe('buildCredentialUpdatePayload', () => {
+  it('sends explicit null when base_url is emptied (the original bug: undefined was dropped from the JSON body and the stale URL survived)', () => {
+    const payload = buildCredentialUpdatePayload(credential, values({ baseUrl: '' }))
+    expect(payload).toHaveProperty('base_url')
+    expect(payload.base_url).toBeNull()
+    // undefined would be stripped by JSON.stringify — the regression this guards against
+    expect(JSON.parse(JSON.stringify(payload))).toHaveProperty('base_url')
+  })
+
+  it('sends the new value when base_url is changed', () => {
+    const payload = buildCredentialUpdatePayload(credential, values({ baseUrl: 'http://localhost:11434' }))
+    expect(payload.base_url).toBe('http://localhost:11434')
+  })
+
+  it('omits base_url entirely when unchanged', () => {
+    const payload = buildCredentialUpdatePayload(credential, values({}))
+    expect(payload).not.toHaveProperty('base_url')
+  })
+
+  it('sends explicit null for emptied Vertex fields', () => {
+    const payload = buildCredentialUpdatePayload(
+      credential,
+      values({ isVertex: true, project: '', location: '', credentialsPath: '' }),
+    )
+    expect(payload.project).toBeNull()
+    expect(payload.location).toBeNull()
+    expect(payload.credentials_path).toBeNull()
+    const wire = JSON.parse(JSON.stringify(payload))
+    expect(wire).toHaveProperty('project')
+    expect(wire).toHaveProperty('location')
+    expect(wire).toHaveProperty('credentials_path')
+  })
+
+  it('clears the ollama num_ctx override with 0 when emptied', () => {
+    const withCtx = { ...credential, num_ctx: 4096 }
+    const payload = buildCredentialUpdatePayload(withCtx, values({ numCtx: '' }))
+    expect(payload.num_ctx).toBe(0)
+  })
+})

--- a/frontend/src/lib/credential-update-payload.ts
+++ b/frontend/src/lib/credential-update-payload.ts
@@ -1,0 +1,46 @@
+import { Credential, UpdateCredentialRequest } from '@/lib/api/credentials'
+
+export interface CredentialFormValues {
+  name: string
+  apiKey: string
+  baseUrl: string
+  modalities: string[]
+  project: string
+  location: string
+  credentialsPath: string
+  numCtx: string
+  isVertex: boolean
+  isOllama: boolean
+}
+
+/**
+ * Build the partial-update payload for PUT /credentials/{id} from the edit
+ * form state: only changed fields are included, and a field the user emptied
+ * is sent as an explicit `null` so the server actually clears it. `undefined`
+ * must never be used for a change — JSON.stringify drops the key and the
+ * server's partial-update semantics would silently keep the old value.
+ */
+export function buildCredentialUpdatePayload(
+  credential: Credential,
+  values: CredentialFormValues,
+): UpdateCredentialRequest {
+  const data: UpdateCredentialRequest = {}
+  if (values.name !== credential.name) data.name = values.name
+  if (values.apiKey.trim()) data.api_key = values.apiKey.trim()
+  if (values.baseUrl !== (credential.base_url || '')) data.base_url = values.baseUrl || null
+  if (JSON.stringify(values.modalities) !== JSON.stringify(credential.modalities)) {
+    data.modalities = values.modalities
+  }
+  if (values.isVertex) {
+    if (values.project !== (credential.project || '')) data.project = values.project.trim() || null
+    if (values.location !== (credential.location || '')) data.location = values.location.trim() || null
+    if (values.credentialsPath !== (credential.credentials_path || '')) {
+      data.credentials_path = values.credentialsPath.trim() || null
+    }
+  }
+  if (values.isOllama && values.numCtx !== (credential.num_ctx ? String(credential.num_ctx) : '')) {
+    // empty clears the override (0 -> backend resets to default)
+    data.num_ctx = values.numCtx.trim() ? Number(values.numCtx) : 0
+  }
+  return data
+}

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -282,3 +282,62 @@ class TestAudioMatrixWiring:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestCredentialUpdateClearsFields:
+    """PUT /credentials/{id} must distinguish 'field absent' (keep) from
+    'field explicitly null/empty' (clear).
+
+    The handler used `is not None` guards, so an explicit null sent to clear
+    base_url (or the Vertex project/location/credentials_path) was silently
+    ignored — the old value survived while the client saw success. Found in
+    v1.11 release testing: an Ollama credential kept pointing at a stale IP
+    after the user cleared the field. Now keyed on model_fields_set.
+    """
+
+    def _mock_cred(self):
+        from unittest.mock import MagicMock
+
+        cred = MagicMock()
+        cred.base_url = "http://10.0.0.99:11434"
+        cred.credentials_path = "/old/path.json"
+        cred.save = AsyncMock()
+        cred.get_linked_models = AsyncMock(return_value=[])
+        return cred
+
+    def _put(self, client, cred, body):
+        from api.models import CredentialResponse
+
+        fake_response = CredentialResponse(
+            id="credential:1", name="n", provider="ollama", modalities=["language"],
+            has_api_key=False, created="2026-01-01", updated="2026-01-01", model_count=0,
+        )
+        with patch("api.routers.credentials.require_encryption_key"), \
+             patch("api.routers.credentials.Credential.get", new=AsyncMock(return_value=cred)), \
+             patch("api.routers.credentials.credential_to_response", return_value=fake_response):
+            return client.put("/api/credentials/credential:1", json=body)
+
+    def test_explicit_null_clears_base_url(self, client):
+        cred = self._mock_cred()
+        response = self._put(client, cred, {"base_url": None})
+        assert response.status_code == 200
+        assert cred.base_url is None
+        cred.save.assert_awaited_once()
+
+    def test_empty_string_clears_base_url(self, client):
+        cred = self._mock_cred()
+        response = self._put(client, cred, {"base_url": ""})
+        assert response.status_code == 200
+        assert cred.base_url is None
+
+    def test_absent_field_keeps_old_value(self, client):
+        cred = self._mock_cred()
+        response = self._put(client, cred, {"name": "renamed"})
+        assert response.status_code == 200
+        assert cred.base_url == "http://10.0.0.99:11434"
+
+    def test_null_clears_vertex_credentials_path(self, client):
+        cred = self._mock_cred()
+        response = self._put(client, cred, {"credentials_path": None})
+        assert response.status_code == 200
+        assert cred.credentials_path is None


### PR DESCRIPTION
## Summary

Found in v1.11 release testing (bucket C, manual): clearing an Ollama credential's `base_url` in the edit dialog reported success but kept the stale value — the connection test then kept timing out against a dead IP while the field *looked* empty. Investigation revealed **two mirror-image bugs**, one on each side of the wire; either alone makes clearing impossible:

### Frontend (`settings/api-keys/page.tsx`)
The edit submit handler mapped an emptied field to `undefined` (`data.base_url = baseUrl || undefined`). `JSON.stringify` drops `undefined` keys, so the PUT body simply omitted the field. Same pattern on the Vertex `project` / `location` / `credentials_path`. **Fix**: emptied fields are sent as explicit `null`; `UpdateCredentialRequest` typed `string | null` accordingly.

### Backend (`api/routers/credentials.py`)
The update handler guarded every field with `is not None` — so even an explicit `null` was silently skipped and the old value survived a 200 response. Only a hand-crafted `{"base_url": ""}` actually cleared. **Fix**: field updates keyed on presence in `model_fields_set` — absent keeps, explicit `null`/`""` clears. `name`/`modalities`/`api_key` keep their non-null guards (clearing those isn't meaningful).

Pre-existing bugs, not v1.11 regressions — but user-facing, contained, and they ride the release.

## Testing

- Backend regression tests: null-clears, empty-string-clears, absent-keeps, Vertex `credentials_path` — full suite 407 passed
- Frontend: `npm run lint` 0 errors, `tsc --noEmit` clean, vitest 80/80
- Live: after clearing the real credential, the Ollama connection test went from "Connection timed out" to "Connected. 12 models available"