### PR TITLE
fix(frontend): keep the note editor dialog inside the viewport with long content

### DIFF
--- a/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
@@ -120,13 +120,13 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className={cn(
-          "sm:max-w-3xl w-full max-h-[90vh] overflow-hidden p-0",
+          "sm:max-w-3xl w-full max-h-[90vh] overflow-hidden p-0 flex flex-col",
           isEditorFullscreen && "!max-w-screen !max-h-screen border-none w-screen h-screen"
       )}>
         <DialogTitle className="sr-only">
           {isEditing ? t('sources.editNote') : t('sources.createNote')}
         </DialogTitle>
-        <form onSubmit={handleSubmit(onSubmit)} className="flex h-full flex-col min-w-0">
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-1 min-h-0 flex-col min-w-0">
           {isEditing && noteLoading ? (
             <div className="flex-1 flex items-center justify-center py-10">
               <span className="text-sm text-muted-foreground">{t('common.loading')}</span>
@@ -147,7 +147,7 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
               </div>
 
               <div className={cn(
-                  "flex-1 overflow-y-auto",
+                  "flex-1 min-h-0 overflow-y-auto",
                   !isEditorFullscreen && "px-6 py-4")
               }>
                 <Controller

--- a/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
@@ -120,7 +120,7 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className={cn(
-          "sm:max-w-3xl w-full max-h-[90vh] overflow-hidden p-0 flex flex-col",
+          "sm:max-w-3xl w-full h-[90vh] max-h-[90vh] overflow-hidden p-0 flex flex-col",
           isEditorFullscreen && "!max-w-screen !max-h-screen border-none w-screen h-screen"
       )}>
         <DialogTitle className="sr-only">


### PR DESCRIPTION
## Summary

Found in v1.11 release testing (bucket C, manual): typing a long note made the dialog grow past the viewport with no internal scroll and no reachable Save button.

**This is a regression from #932 in this release** (removing the editor's `max-h-[500px]`): the removal relied on the `flex-1`/`h-full` parent chain, but `DialogContent` isn't a flex container and has no definite height (only `max-h-[90vh]`) — so `h-full` resolved to auto, the `flex-1` wrapper (default `min-height: auto`) never shrank below its content, and the inner `overflow-y-auto` never engaged.

**Fix** — the standard scroll-inside-dialog flex pattern:
- `DialogContent`: `flex flex-col`
- form: `flex-1 min-h-0` (instead of `h-full`)
- editor wrapper: `min-h-0`

The #932 goal is preserved: the editor still fills the dialog on tall windows; it just can't push past it anymore.

## Testing

- Verified in the real browser via Playwright with a 200-line note: dialog height 1089px within a 1210px viewport (≤90vh), footer buttons visible, internal editor scroll active
- `npm run lint` (0 errors), `npx tsc --noEmit` clean, `npm run test` 80/80

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

