### PR TITLE
feat: add first-class oMLX provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,11 @@ SURREAL_DATABASE=open_notebook
 # API_URL=http://localhost:5055
 
 # Ollama endpoint (if running locally)
-# OLLAMA_BASE_URL=http://ollama:11434
+# OLLAMA_API_BASE=http://localhost:11434
+
+# oMLX endpoint (Apple Silicon MLX server; avoid port 8000 — SurrealDB)
+# OMLX_API_BASE=http://localhost:11435/v1
+# OMLX_API_KEY=  # optional, only if oMLX started with --api-key
 
 # Content processing
 # CHUNK_SIZE=1500

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Thanks to the [Esperanto](https://github.com/lfnovo/esperanto) library, we suppo
 | Google (GenAI) | ✅          | ✅               | ✅             | ✅             |
 | Vertex AI    | ✅          | ✅               | ❌             | ✅             |
 | Ollama       | ✅          | ✅               | ❌             | ❌             |
+| oMLX         | ✅          | ✅               | ❌             | ❌             |
 | Perplexity   | ✅          | ❌               | ❌             | ❌             |
 | ElevenLabs   | ❌          | ❌               | ✅             | ✅             |
 | Deepgram     | ❌          | ❌               | ❌             | ✅             |
@@ -219,7 +220,7 @@ Thanks to the [Esperanto](https://github.com/lfnovo/esperanto) library, we suppo
 | MiniMax      | ✅          | ❌               | ❌             | ❌             |
 | OpenAI Compatible* | ✅          | ✅               | ✅             | ✅             |
 
-*Supports LM Studio and any OpenAI-compatible endpoint
+*Supports LM Studio, oMLX (prefer the native oMLX provider), and any OpenAI-compatible endpoint
 
 ## ✨ Key Features
 

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -164,7 +164,7 @@ def create_credential_from_env(provider: str) -> Credential:
             provider=provider,
             modalities=modalities,
             api_key=SecretStr(api_key) if api_key else None,
-            base_url=os.environ.get("OMLX_API_BASE"),
+            base_url=os.environ.get("OMLX_API_BASE") or "http://localhost:11435/v1",
         )
     elif provider == "vertex":
         return Credential(

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -41,6 +41,10 @@ PROVIDER_ENV_CONFIG: Dict[str, dict] = {
     "elevenlabs": {"required": ["ELEVENLABS_API_KEY"]},
     "deepgram": {"required": ["DEEPGRAM_API_KEY"]},
     "ollama": {"required": ["OLLAMA_API_BASE"]},
+    "omlx": {
+        "required": ["OMLX_API_BASE"],
+        "optional": ["OMLX_API_KEY"],
+    },
     "vertex": {
         "required": ["VERTEX_PROJECT", "VERTEX_LOCATION"],
         "optional": ["GOOGLE_APPLICATION_CREDENTIALS"],
@@ -74,6 +78,7 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "elevenlabs": ["text_to_speech", "speech_to_text"],
     "deepgram": ["text_to_speech"],
     "ollama": ["language", "embedding"],
+    "omlx": ["language", "embedding"],
     "vertex": ["language", "embedding", "text_to_speech"],
     "azure": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "openai_compatible": ["language", "embedding", "speech_to_text", "text_to_speech"],
@@ -151,6 +156,15 @@ def create_credential_from_env(provider: str) -> Credential:
             provider=provider,
             modalities=modalities,
             base_url=os.environ.get("OLLAMA_API_BASE"),
+        )
+    elif provider == "omlx":
+        api_key = os.environ.get("OMLX_API_KEY")
+        return Credential(
+            name=name,
+            provider=provider,
+            modalities=modalities,
+            api_key=SecretStr(api_key) if api_key else None,
+            base_url=os.environ.get("OMLX_API_BASE"),
         )
     elif provider == "vertex":
         return Credential(
@@ -280,8 +294,11 @@ async def test_credential(credential_id: str) -> dict:
             success, message = await _test_ollama_connection(base_url)
             return {"provider": provider, "success": success, "message": message}
 
-        if provider == "openai_compatible":
-            base_url = config.get("base_url")
+        if provider in ("openai_compatible", "omlx"):
+            default_base = (
+                "http://localhost:11435/v1" if provider == "omlx" else None
+            )
+            base_url = config.get("base_url") or default_base
             api_key = config.get("api_key")
             if not base_url:
                 return {
@@ -412,7 +429,7 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
     }
 
     if provider in STATIC_MODELS:
-        if not api_key and provider != "ollama":
+        if not api_key and provider not in ("ollama", "omlx"):
             return []
         return [
             {"name": m, "provider": provider}
@@ -455,12 +472,14 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
             logger.warning(f"Failed to discover Ollama models: {e}")
             return []
 
-    if provider == "openai_compatible":
+    if provider in ("openai_compatible", "omlx"):
+        if provider == "omlx":
+            base_url = base_url or "http://localhost:11435/v1"
         if not base_url:
             return []
         try:
             # Re-validate at request time (see ollama branch above).
-            await validate_url(base_url, "openai_compatible")
+            await validate_url(base_url, provider)
             headers = {}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
@@ -473,12 +492,18 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
                 response.raise_for_status()
                 data = response.json()
                 return [
-                    {"name": m.get("id", ""), "provider": "openai_compatible"}
+                    {
+                        "name": m.get("id", ""),
+                        "provider": provider,
+                        "model_type": classify_model_type(
+                            m.get("id", ""), provider
+                        ),
+                    }
                     for m in data.get("data", [])
                     if m.get("id")
                 ]
         except Exception as e:
-            logger.warning(f"Failed to discover openai_compatible models: {e}")
+            logger.warning(f"Failed to discover {provider} models: {e}")
             return []
 
     if provider == "azure":

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -18,7 +18,10 @@ from api.models import CredentialResponse
 from open_notebook.ai.model_discovery import classify_model_type
 from open_notebook.domain.credential import Credential
 from open_notebook.utils.encryption import get_secret_from_env
-from open_notebook.utils.url_validation import validate_url
+from open_notebook.utils.url_validation import (
+    prepare_pinned_http_target,
+    validate_url,
+)
 
 # =============================================================================
 # Constants
@@ -478,16 +481,20 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
         if not base_url:
             return []
         try:
-            # Re-validate at request time (see ollama branch above).
-            await validate_url(base_url, provider)
-            headers = {}
+            # Pin DNS at request time so httpx cannot re-resolve to a
+            # metadata address after validation (DNS rebinding TOCTOU).
+            target = await prepare_pinned_http_target(
+                models_endpoint(base_url), provider
+            )
+            headers = dict(target.headers)
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
             async with httpx.AsyncClient() as client:
                 response = await client.get(
-                    models_endpoint(base_url),
+                    target.url,
                     headers=headers,
                     timeout=30.0,
+                    extensions=target.extensions,
                 )
                 response.raise_for_status()
                 data = response.json()

--- a/api/models.py
+++ b/api/models.py
@@ -590,6 +590,7 @@ SupportedProvider = Literal[
     "elevenlabs",
     "deepgram",
     "ollama",
+    "omlx",
     "azure",
     "vertex",
     "openai_compatible",

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -94,6 +94,7 @@ PROVIDER_PRIORITY = [
     "xai",
     "openrouter",
     "ollama",
+    "omlx",
     "azure",
     "openai_compatible",
     "dashscope",
@@ -383,6 +384,7 @@ async def get_provider_availability():
             "elevenlabs": "ELEVENLABS_API_KEY",
             "deepgram": "DEEPGRAM_API_KEY",
             "ollama": "OLLAMA_API_BASE",
+            "omlx": "OMLX_API_BASE",
             "dashscope": "DASHSCOPE_API_KEY",
             "minimax": "MINIMAX_API_KEY",
         }
@@ -455,6 +457,16 @@ async def get_provider_availability():
                     ):
                         if has_db_cred or _check_openai_compatible_support(mode):
                             supported_types[provider].append(model_type)
+            # oMLX is first-class in Open Notebook but uses Esperanto's
+            # openai-compatible client under the hood (language + embedding).
+            elif provider == "omlx":
+                esperanto_name = "openai-compatible"
+                for model_type in ("language", "embedding"):
+                    if (
+                        model_type in esperanto_available
+                        and esperanto_name in esperanto_available[model_type]
+                    ):
+                        supported_types[provider].append(model_type)
             # Special handling for azure to check mode-specific availability
             elif provider == "azure":
                 has_db_cred = await _check_provider_has_credential("azure")

--- a/docs/3-USER-GUIDE/api-configuration.md
+++ b/docs/3-USER-GUIDE/api-configuration.md
@@ -102,6 +102,7 @@ Navigation: Settings → API Keys
 | Provider | Required Fields | Notes |
 |----------|-----------------|-------|
 | Ollama | Base URL | Typically `http://localhost:11434` or `http://ollama:11434` |
+| oMLX | Base URL | Typically `http://localhost:11435/v1` (avoid port 8000 — SurrealDB) |
 
 ### Enterprise
 
@@ -205,6 +206,16 @@ For OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, OpenRouter:
 4. Discover and register models
 
 Ollama allows localhost and private IPs since it runs locally.
+
+### oMLX (URL-Based, Apple Silicon)
+
+1. Add credential with provider **oMLX**
+2. Enter the base URL ending in `/v1` (e.g., `http://localhost:11435/v1`)
+3. Optionally enter an API key if oMLX was started with `--api-key`
+4. Test connection
+5. Discover and register models
+
+> **Port conflict:** oMLX defaults to port 8000, same as SurrealDB. Prefer `OMLX_PORT=11435`. See [oMLX Setup](../5-CONFIGURATION/omlx.md).
 
 ### Azure OpenAI
 
@@ -371,6 +382,11 @@ API keys stored in the database are encrypted using Fernet (AES-128-CBC + HMAC-S
 - No API key required
 - Default URL: `http://localhost:11434` (local) or `http://ollama:11434` (Docker)
 - Ensure Ollama server is running
+
+### oMLX
+- API key optional (only if started with `--api-key`)
+- Recommended URL: `http://localhost:11435/v1` (avoid port 8000 — SurrealDB conflict)
+- See [oMLX Setup](../5-CONFIGURATION/omlx.md)
 
 ### Azure OpenAI
 - Enter your Azure endpoint in the **URL Base** field (format: `https://{resource-name}.openai.azure.com`)

--- a/docs/4-AI-PROVIDERS/index.md
+++ b/docs/4-AI-PROVIDERS/index.md
@@ -84,6 +84,17 @@ Open Notebook supports 17+ AI providers. This guide helps you **choose the right
 
 → [Setup Guide](../5-CONFIGURATION/ai-providers.md#ollama-recommended-for-local)
 
+**oMLX (Apple Silicon)**
+- Cost: Free (electricity only)
+- Speed: Fast on Apple Silicon (MLX)
+- Quality: Good (MLX model zoo)
+- Setup: 10 minutes
+- Best for: Mac users wanting local OpenAI-compatible inference
+- Privacy: 100% local
+- Note: Default port 8000 conflicts with SurrealDB — use `11435`
+
+→ [Setup Guide](../5-CONFIGURATION/omlx.md)
+
 **LM Studio (Alternative)**
 - Cost: Free (electricity only)
 - Speed: Depends on hardware
@@ -119,6 +130,7 @@ Open Notebook supports 17+ AI providers. This guide helps you **choose the right
 | **DashScope** | Fast | $ | Good | Low | 5 min | Varies |
 | **MiniMax** | Fast | $$ | Good | Low | 5 min | 204K |
 | **Ollama** | Slow-Medium | Free | Good | Max | 10 min | Varies |
+| **oMLX** | Fast (Apple Silicon) | Free | Good | Max | 10 min | Varies |
 | **LM Studio** | Slow-Medium | Free | Good | Max | 15 min | Varies |
 | **Azure** | Very Fast | $$ | Excellent | High | 10 min | 128K |
 

--- a/docs/5-CONFIGURATION/ai-providers.md
+++ b/docs/5-CONFIGURATION/ai-providers.md
@@ -403,6 +403,27 @@ CPU-only:
 
 ---
 
+### oMLX (Apple Silicon)
+
+**Cost:** Free (electricity only)
+
+**Requirements:** Apple Silicon Mac; macOS 15+ recommended.
+
+**Setup oMLX:**
+1. Install from [omlx.ai](https://omlx.ai/) / [Releases](https://github.com/jundot/omlx/releases) or Homebrew
+2. Run on a non-conflicting port (SurrealDB uses **8000**): `OMLX_PORT=11435 omlx serve`
+
+**Configure in Open Notebook:**
+1. Go to **Settings** → **API Keys**
+2. Click **Add Credential** → select **oMLX**
+3. Base URL: `http://localhost:11435/v1` (include `/v1`)
+4. Optional API key if oMLX was started with `--api-key`
+5. **Save** → **Test Connection** → **Discover Models**
+
+See [oMLX Setup Guide](omlx.md) for port conflict details and Docker networking.
+
+---
+
 ### LM Studio (Local Alternative)
 
 **Cost:** Free
@@ -544,6 +565,7 @@ If you are migrating from an older version that used environment variables, go t
 - **[Environment Reference](environment-reference.md)** - Complete list of all environment variables
 - **[Advanced Configuration](advanced.md)** - Timeouts, SSL, performance tuning
 - **[Ollama Setup](ollama.md)** - Detailed Ollama configuration guide
+- **[oMLX Setup](omlx.md)** - Apple Silicon MLX server setup
 - **[OpenAI-Compatible](openai-compatible.md)** - LM Studio and other compatible providers
 - **[Local TTS Setup](local-tts.md)** - Text-to-speech with Speaches
 - **[Local STT Setup](local-stt.md)** - Speech-to-text with Speaches

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -280,6 +280,8 @@ If you have these variables configured from a previous installation, click the *
 | `DEEPSEEK_API_KEY` | DeepSeek | Settings → API Keys → Add DeepSeek Credential |
 | `XAI_API_KEY` | xAI | Settings → API Keys → Add xAI Credential |
 | `OLLAMA_API_BASE` | Ollama | Settings → API Keys → Add Ollama Credential |
+| `OMLX_API_BASE` | oMLX | Settings → API Keys → Add oMLX Credential |
+| `OMLX_API_KEY` | oMLX | Optional; only if oMLX started with `--api-key` |
 | `OPENROUTER_API_KEY` | OpenRouter | Settings → API Keys → Add OpenRouter Credential |
 | `OPENROUTER_BASE_URL` | OpenRouter | Configure in OpenRouter credential |
 | `VOYAGE_API_KEY` | Voyage AI | Settings → API Keys → Add Voyage AI Credential |

--- a/docs/5-CONFIGURATION/index.md
+++ b/docs/5-CONFIGURATION/index.md
@@ -29,8 +29,9 @@ Setup: Get API key → Add credential in Settings UI → Done
 
 ### Option 2: Local (Free & Private)
 - **Ollama** (open-source models, on your machine)
+- **oMLX** (Apple Silicon / MLX, OpenAI-compatible API)
 
-→ Go to **[Ollama Setup](ollama.md)**
+→ Go to **[Ollama Setup](ollama.md)** · **[oMLX Setup](omlx.md)**
 
 ### Option 3: OpenAI-Compatible
 - **LM Studio** (local)
@@ -102,6 +103,8 @@ OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
 ```
 
 > **Ollama users**: Add an Ollama credential in Settings → API Keys with the correct base URL. See [Ollama Setup](ollama.md) for network configuration help.
+
+> **oMLX users (Apple Silicon)**: Add an oMLX credential with base URL `http://localhost:11435/v1` (avoid port 8000 — SurrealDB). See [oMLX Setup](omlx.md).
 
 > **LM Studio / OpenAI-Compatible**: Add an OpenAI-Compatible credential in Settings → API Keys. See [OpenAI-Compatible Guide](openai-compatible.md).
 
@@ -214,6 +217,10 @@ OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
 - Setting up and pointing to an Ollama server
 - Downloading models
 - Using embedding
+
+### [oMLX](omlx.md)
+- Apple Silicon MLX server (OpenAI-compatible `/v1`)
+- Port conflict with SurrealDB (use `11435`)
 
 ### [OpenAI-Compatible Providers](openai-compatible.md)
 - LM Studio, vLLM, Text Generation WebUI

--- a/docs/5-CONFIGURATION/omlx.md
+++ b/docs/5-CONFIGURATION/omlx.md
@@ -1,0 +1,123 @@
+# oMLX Setup Guide
+
+[oMLX](https://omlx.ai/) is a macOS-native inference server for Apple Silicon. It runs MLX models locally and exposes an **OpenAI-compatible API** at `/v1`, so Open Notebook can use it for language and embedding models without sending data to the cloud.
+
+Open Notebook treats **oMLX** as a first-class provider in Settings → API Keys. Under the hood it uses Esperanto’s `openai-compatible` client (Esperanto has no native `omlx` provider).
+
+## Why Choose oMLX?
+
+- **Apple Silicon optimized** — MLX inference on M-series Macs
+- **OpenAI-compatible** — drop-in `/v1/chat/completions` and `/v1/embeddings`
+- **Private** — models and prompts stay on your machine
+- **Optional API key** — protect the local server with `--api-key` if needed
+
+## Requirements
+
+- Apple Silicon Mac (M1 or later)
+- macOS 15+ (Sequoia) recommended
+- oMLX installed and running
+
+## Install oMLX
+
+**DMG (recommended):** download from [oMLX Releases](https://github.com/jundot/omlx/releases), drag to Applications, and launch.
+
+**Homebrew:**
+
+```bash
+brew tap jundot/omlx
+brew install omlx
+brew services start omlx
+```
+
+**CLI:**
+
+```bash
+omlx serve
+# or with a custom port (recommended — see Port Conflict below):
+OMLX_PORT=11435 omlx serve
+```
+
+Admin UI (when using the default port): `http://localhost:8000/admin`
+
+## Port Conflict with SurrealDB
+
+oMLX and SurrealDB both default to **port 8000**. Open Notebook’s database uses `8000`, so running oMLX on the default port will collide.
+
+**Recommended:** run oMLX on **11435** (same idea as Ollama’s 11434):
+
+```bash
+OMLX_PORT=11435 omlx serve
+```
+
+Or set the port in oMLX’s admin settings / `~/.omlx/settings.json`.
+
+Then use this base URL in Open Notebook:
+
+```text
+http://localhost:11435/v1
+```
+
+> Always include the `/v1` suffix — oMLX’s OpenAI API lives under `/v1` (e.g. `GET /v1/models`).
+
+## Configure Open Notebook
+
+1. Go to **Settings** → **API Keys**
+2. Click **Add Credential** → select **oMLX**
+3. Set **Base URL** to `http://localhost:11435/v1` (or your host/port)
+4. Optionally set an **API key** if you started oMLX with `--api-key`
+5. **Save** → **Test Connection** → **Discover Models** → register language and embedding models
+
+### Legacy env vars (optional fallback)
+
+```bash
+# Prefer Settings UI; env is for migration / headless setups
+export OMLX_API_BASE=http://localhost:11435/v1
+# Optional, only if oMLX was started with --api-key
+# export OMLX_API_KEY=your-key
+```
+
+## Network Notes (Docker)
+
+If Open Notebook runs in Docker and oMLX runs on the Mac host:
+
+| Setup | Base URL |
+|-------|----------|
+| Both on host | `http://localhost:11435/v1` |
+| Open Notebook in Docker, oMLX on host | `http://host.docker.internal:11435/v1` |
+
+Ensure oMLX listens on an interface Docker can reach (not only a firewalled bind if you need container access).
+
+## Modalities
+
+| Modality | Supported |
+|----------|-----------|
+| Language | ✅ |
+| Embedding | ✅ |
+| Speech-to-text | ❌ |
+| Text-to-speech | ❌ |
+
+For local STT/TTS, see [Local STT](local-stt.md) and [Local TTS](local-tts.md) (e.g. Speaches via OpenAI-Compatible).
+
+## Troubleshooting
+
+| Symptom | What to check |
+|---------|----------------|
+| Connection refused | Is oMLX running? Correct port? |
+| Wrong port / SurrealDB errors | Don’t use `8000` for oMLX — use `11435` (or another free port) |
+| 404 on `/models` | Base URL must end with `/v1` |
+| 401 Unauthorized | API key mismatch with oMLX `--api-key` |
+| No models listed | Load/download models in the oMLX admin UI first |
+| Docker can’t reach host | Use `host.docker.internal` and confirm oMLX bind address |
+
+Quick connectivity check:
+
+```bash
+curl http://localhost:11435/v1/models
+```
+
+## Related
+
+- [Ollama Setup](ollama.md) — another local provider (native Ollama API)
+- [OpenAI-Compatible](openai-compatible.md) — generic OpenAI API servers (LM Studio, vLLM, …)
+- [AI Providers](ai-providers.md) — all provider options
+- [API Configuration](../3-USER-GUIDE/api-configuration.md) — credentials UI walkthrough

--- a/docs/5-CONFIGURATION/openai-compatible.md
+++ b/docs/5-CONFIGURATION/openai-compatible.md
@@ -26,6 +26,7 @@ Open Notebook can connect to any server using this format.
 | **Text Generation WebUI** | Full-featured local inference | https://github.com/oobabooga/text-generation-webui |
 | **vLLM** | High-performance serving | https://github.com/vllm-project/vllm |
 | **Ollama** | Simple local models | (Use native Ollama provider instead) |
+| **oMLX** | Apple Silicon / MLX | (Use native oMLX provider instead) |
 | **LocalAI** | Local AI inference | https://github.com/mudler/LocalAI |
 | **llama.cpp server** | Lightweight inference | https://github.com/ggerganov/llama.cpp |
 
@@ -400,3 +401,4 @@ Use OpenAI-compatible when:
 - **[Local STT Setup](local-stt.md)** - Speech-to-text with Speaches
 - **[AI Providers](ai-providers.md)** - All provider options
 - **[Ollama Setup](ollama.md)** - Native Ollama integration
+- **[oMLX Setup](omlx.md)** - Native oMLX (Apple Silicon) integration

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -74,6 +74,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   elevenlabs: 'ElevenLabs',
   deepgram: 'Deepgram',
   ollama: 'Ollama',
+  omlx: 'oMLX',
   azure: 'Azure OpenAI',
   vertex: 'Google Vertex AI',
   openai_compatible: 'OpenAI Compatible',
@@ -85,7 +86,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 const ALL_PROVIDERS = [
   'openai', 'anthropic', 'google', 'groq', 'mistral', 'deepseek',
   'xai', 'openrouter', 'dashscope', 'minimax', 'voyage', 'elevenlabs', 'deepgram', 'ollama',
-  'azure', 'vertex', 'openai_compatible',
+  'omlx', 'azure', 'vertex', 'openai_compatible',
 ]
 
 // Default modalities per provider
@@ -102,6 +103,7 @@ const PROVIDER_MODALITIES: Record<string, ModelType[]> = {
   elevenlabs: ['text_to_speech', 'speech_to_text'],
   deepgram: ['text_to_speech'],
   ollama: ['language', 'embedding'],
+  omlx: ['language', 'embedding'],
   azure: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
   vertex: ['language', 'embedding', 'text_to_speech'],
   openai_compatible: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
@@ -122,6 +124,8 @@ const PROVIDER_DOCS: Record<string, string> = {
   voyage: 'https://dash.voyageai.com/api-keys',
   elevenlabs: 'https://elevenlabs.io/app/settings/api-keys',
   deepgram: 'https://console.deepgram.com/',
+  ollama: 'https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/ollama.md',
+  omlx: 'https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/omlx.md',
   azure: 'https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI',
   vertex: 'https://cloud.google.com/vertex-ai/docs/start/cloud-environment',
   openai_compatible: 'https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/openai-compatible.md',
@@ -175,8 +179,9 @@ function CredentialFormDialog({
 
   const isVertex = provider === 'vertex'
   const isOllama = provider === 'ollama'
+  const isOmlx = provider === 'omlx'
   const isOpenAICompatible = provider === 'openai_compatible'
-  const requiresApiKey = !isVertex && !isOllama && !isOpenAICompatible
+  const requiresApiKey = !isVertex && !isOllama && !isOmlx && !isOpenAICompatible
 
   const [name, setName] = useState('')
   const [apiKey, setApiKey] = useState('')
@@ -373,7 +378,13 @@ function CredentialFormDialog({
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
-                placeholder={isOllama ? 'http://localhost:11434' : 'https://api.example.com/v1'}
+                placeholder={
+                  isOllama
+                    ? 'http://localhost:11434'
+                    : isOmlx
+                      ? 'http://localhost:11435/v1'
+                      : 'https://api.example.com/v1'
+                }
                 disabled={isSubmitting}
               />
               <p className="text-xs text-muted-foreground">{t('apiKeys.baseUrlOverrideHint')}</p>

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -14,7 +14,10 @@ from typing import Optional, Tuple
 import httpx
 from loguru import logger
 
-from open_notebook.utils.url_validation import validate_url
+from open_notebook.utils.url_validation import (
+    prepare_pinned_http_target,
+    validate_url,
+)
 
 
 def _is_vertex_credentials_file_error(exc: Exception) -> bool:
@@ -185,19 +188,23 @@ async def _test_ollama_connection(base_url: str) -> Tuple[bool, str]:
 async def _test_openai_compatible_connection(base_url: str, api_key: Optional[str] = None) -> Tuple[bool, str]:
     """Test OpenAI-compatible server connectivity."""
     try:
-        # Re-validate at request time (see _test_azure_connection for why).
-        await validate_url(base_url, "openai_compatible")
-        headers = {}
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-
+        # Pin DNS at request time (closes rebinding TOCTOU left by validate_url alone).
         trimmed = base_url.rstrip("/")
         models_url = (
             trimmed if trimmed.endswith("/models") else f"{trimmed}/models"
         )
+        target = await prepare_pinned_http_target(models_url, "openai_compatible")
+        headers = dict(target.headers)
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Try /models endpoint (standard OpenAI-compatible)
-            response = await client.get(models_url, headers=headers)
+            response = await client.get(
+                target.url,
+                headers=headers,
+                extensions=target.extensions,
+            )
 
             if response.status_code == 200:
                 data = response.json()

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -70,6 +70,7 @@ TEST_MODELS = {
     "elevenlabs": ("eleven_multilingual_v2", "text_to_speech"),
     "deepgram": ("aura-2-thalia-en", "text_to_speech"),
     "ollama": (None, "language"),  # Dynamic - will use first available model
+    "omlx": (None, "language"),  # Dynamic - OpenAI-compatible /models ping
     # Complex providers with additional configuration
     "vertex": ("gemini-flash-latest", "language"),  # Uses Google Vertex AI
     "azure": ("gpt-35-turbo", "language"),  # Azure OpenAI deployment name

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -191,9 +191,13 @@ async def _test_openai_compatible_connection(base_url: str, api_key: Optional[st
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
+        trimmed = base_url.rstrip("/")
+        models_url = (
+            trimmed if trimmed.endswith("/models") else f"{trimmed}/models"
+        )
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Try /models endpoint (standard OpenAI-compatible)
-            response = await client.get(f"{base_url}/models", headers=headers)
+            response = await client.get(models_url, headers=headers)
 
             if response.status_code == 200:
                 data = response.json()

--- a/open_notebook/ai/key_provider.py
+++ b/open_notebook/ai/key_provider.py
@@ -266,11 +266,12 @@ async def _provision_omlx() -> bool:
         os.environ["OPENAI_COMPATIBLE_API_KEY"] = key
         logger.debug("Set OMLX_API_KEY / OPENAI_COMPATIBLE_API_KEY from Credential")
         any_set = True
-    if cred.base_url:
-        os.environ["OMLX_API_BASE"] = cred.base_url
-        os.environ["OPENAI_COMPATIBLE_BASE_URL"] = cred.base_url
-        logger.debug("Set OMLX_API_BASE / OPENAI_COMPATIBLE_BASE_URL from Credential")
-        any_set = True
+    # Default matches test/discovery fallback when Base URL was left blank
+    base_url = cred.base_url or "http://localhost:11435/v1"
+    os.environ["OMLX_API_BASE"] = base_url
+    os.environ["OPENAI_COMPATIBLE_BASE_URL"] = base_url
+    logger.debug("Set OMLX_API_BASE / OPENAI_COMPATIBLE_BASE_URL from Credential")
+    any_set = True
 
     return any_set
 

--- a/open_notebook/ai/key_provider.py
+++ b/open_notebook/ai/key_provider.py
@@ -64,6 +64,10 @@ PROVIDER_CONFIG = {
     "ollama": {
         "env_var": "OLLAMA_API_BASE",
     },
+    # oMLX: optional API key (when started with --api-key); base URL via OMLX_API_BASE
+    "omlx": {
+        "env_var": "OMLX_API_KEY",
+    },
     "dashscope": {
         "env_var": "DASHSCOPE_API_KEY",
     },
@@ -243,6 +247,34 @@ async def _provision_openai_compatible() -> bool:
     return any_set
 
 
+async def _provision_omlx() -> bool:
+    """
+    Set environment variables for oMLX from DB config.
+
+    oMLX speaks the OpenAI API, so we also mirror into OPENAI_COMPATIBLE_*
+    for Esperanto env-var fallback after provider remapping.
+    """
+    any_set = False
+
+    cred = await _get_default_credential("omlx")
+    if not cred:
+        return False
+
+    if cred.api_key:
+        key = cred.api_key.get_secret_value()
+        os.environ["OMLX_API_KEY"] = key
+        os.environ["OPENAI_COMPATIBLE_API_KEY"] = key
+        logger.debug("Set OMLX_API_KEY / OPENAI_COMPATIBLE_API_KEY from Credential")
+        any_set = True
+    if cred.base_url:
+        os.environ["OMLX_API_BASE"] = cred.base_url
+        os.environ["OPENAI_COMPATIBLE_BASE_URL"] = cred.base_url
+        logger.debug("Set OMLX_API_BASE / OPENAI_COMPATIBLE_BASE_URL from Credential")
+        any_set = True
+
+    return any_set
+
+
 async def provision_provider_keys(provider: str) -> bool:
     """
     Provision environment variables from database for a specific provider.
@@ -275,6 +307,8 @@ async def provision_provider_keys(provider: str) -> bool:
         return await _provision_azure()
     elif provider_lower in ("openai-compatible", "openai_compatible"):
         return await _provision_openai_compatible()
+    elif provider_lower == "omlx":
+        return await _provision_omlx()
 
     # Handle simple providers
     return await _provision_simple_provider(provider_lower)
@@ -303,5 +337,6 @@ async def provision_all_keys() -> dict[str, bool]:
     results["vertex"] = await provision_provider_keys("vertex")
     results["azure"] = await provision_provider_keys("azure")
     results["openai_compatible"] = await provision_provider_keys("openai_compatible")
+    results["omlx"] = await provision_provider_keys("omlx")
 
     return results

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -16,7 +16,7 @@ from loguru import logger
 from open_notebook.ai.models import Model
 from open_notebook.database.repository import repo_query
 from open_notebook.domain.credential import Credential
-from open_notebook.utils.url_validation import validate_url
+from open_notebook.utils.url_validation import prepare_pinned_http_target
 
 
 @dataclass
@@ -372,23 +372,23 @@ async def discover_omlx_models() -> List[DiscoveredModel]:
 
     models = []
     try:
-        # Re-validate at request time: hostname may later resolve to a
-        # link-local address (DNS rebinding). Matches ollama/openai_compatible
-        # credential discovery flows.
-        await validate_url(base_url, "omlx")
+        # Resolve+validate once and pin the vetted IP so httpx cannot
+        # re-resolve to a metadata address (DNS rebinding TOCTOU).
         trimmed = base_url.rstrip("/")
         models_url = (
             trimmed if trimmed.endswith("/models") else f"{trimmed}/models"
         )
+        target = await prepare_pinned_http_target(models_url, "omlx")
         async with httpx.AsyncClient() as client:
-            headers = {}
+            headers = dict(target.headers)
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
 
             response = await client.get(
-                models_url,
+                target.url,
                 headers=headers,
                 timeout=30.0,
+                extensions=target.extensions,
             )
             response.raise_for_status()
             data = response.json()

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -16,6 +16,7 @@ from loguru import logger
 from open_notebook.ai.models import Model
 from open_notebook.database.repository import repo_query
 from open_notebook.domain.credential import Credential
+from open_notebook.utils.url_validation import validate_url
 
 
 @dataclass
@@ -371,13 +372,21 @@ async def discover_omlx_models() -> List[DiscoveredModel]:
 
     models = []
     try:
+        # Re-validate at request time: hostname may later resolve to a
+        # link-local address (DNS rebinding). Matches ollama/openai_compatible
+        # credential discovery flows.
+        await validate_url(base_url, "omlx")
+        trimmed = base_url.rstrip("/")
+        models_url = (
+            trimmed if trimmed.endswith("/models") else f"{trimmed}/models"
+        )
         async with httpx.AsyncClient() as client:
             headers = {}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
 
             response = await client.get(
-                f"{base_url}/models",
+                models_url,
                 headers=headers,
                 timeout=30.0,
             )

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -101,6 +101,20 @@ OLLAMA_MODEL_TYPES = {
     "embedding": ["nomic-embed", "mxbai-embed", "all-minilm", "bge-", "e5-"],
 }
 
+# oMLX serves MLX models over an OpenAI-compatible API; embedding names often
+# include bge-/embed markers similar to Ollama local models.
+OMLX_MODEL_TYPES = {
+    "embedding": [
+        "nomic-embed",
+        "mxbai-embed",
+        "all-minilm",
+        "bge-",
+        "e5-",
+        "embed",
+        "embedding",
+    ],
+}
+
 MISTRAL_MODEL_TYPES = {
     "language": [
         "mistral",
@@ -166,6 +180,7 @@ def classify_model_type(model_name: str, provider: str) -> str:
         "openai": OPENAI_MODEL_TYPES,
         "google": GOOGLE_MODEL_TYPES,
         "ollama": OLLAMA_MODEL_TYPES,
+        "omlx": OMLX_MODEL_TYPES,
         "mistral": MISTRAL_MODEL_TYPES,
         "groq": GROQ_MODEL_TYPES,
         "deepseek": DEEPSEEK_MODEL_TYPES,
@@ -320,6 +335,72 @@ async def discover_ollama_models() -> List[DiscoveredModel]:
                     )
     except Exception as e:
         logger.warning(f"Failed to discover Ollama models: {e}")
+
+    return models
+
+
+async def discover_omlx_models() -> List[DiscoveredModel]:
+    """
+    Fetch available models from a local oMLX server (OpenAI-compatible /v1).
+
+    Default base URL is http://localhost:11435/v1 to avoid SurrealDB's port 8000.
+    """
+    api_key = None
+    base_url = None
+
+    try:
+        credentials = await Credential.get_by_provider("omlx")
+        if credentials:
+            cred = credentials[0]
+            config = cred.to_esperanto_config()
+            api_key = config.get("api_key")
+            base_url = config.get("base_url", "").rstrip("/")
+    except Exception as e:
+        logger.warning(f"Failed to read omlx config from Credential: {e}")
+
+    if not api_key:
+        api_key = os.environ.get("OMLX_API_KEY")
+    if not base_url:
+        base_url = os.environ.get(
+            "OMLX_API_BASE", "http://localhost:11435/v1"
+        ).rstrip("/")
+
+    if not base_url:
+        logger.warning("No base_url configured for omlx provider")
+        return []
+
+    models = []
+    try:
+        async with httpx.AsyncClient() as client:
+            headers = {}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            response = await client.get(
+                f"{base_url}/models",
+                headers=headers,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            for model in data.get("data", []):
+                model_id = model.get("id", "")
+                if model_id:
+                    model_type = classify_model_type(model_id, "omlx")
+                    models.append(
+                        DiscoveredModel(
+                            name=model_id,
+                            provider="omlx",
+                            model_type=model_type,
+                        )
+                    )
+    except httpx.HTTPStatusError as e:
+        logger.warning(
+            f"Failed to discover omlx models: HTTP {e.response.status_code}"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to discover omlx models: {e}")
 
     return models
 
@@ -721,6 +802,7 @@ PROVIDER_DISCOVERY_FUNCTIONS = {
     "anthropic": discover_anthropic_models,
     "google": discover_google_models,
     "ollama": discover_ollama_models,
+    "omlx": discover_omlx_models,
     "groq": discover_groq_models,
     "mistral": discover_mistral_models,
     "deepseek": discover_deepseek_models,

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -17,7 +17,7 @@ from open_notebook.utils.url_validation import validate_url
 ModelType = Union[LanguageModel, EmbeddingModel, SpeechToTextModel, TextToSpeechModel]
 
 # Config keys from Credential.to_esperanto_config() that may carry a
-# user-configured URL (ollama/azure/openai_compatible/vertex).
+# user-configured URL (ollama/omlx/azure/openai_compatible/vertex).
 _URL_CONFIG_KEYS = (
     "base_url",
     "endpoint",
@@ -26,6 +26,20 @@ _URL_CONFIG_KEYS = (
     "endpoint_stt",
     "endpoint_tts",
 )
+
+
+def to_esperanto_provider(provider: str) -> str:
+    """
+    Normalize a stored provider name for Esperanto's AIFactory.
+
+    DB/UI use underscores (openai_compatible) and first-class aliases
+    (omlx) that Esperanto does not know natively. Esperanto expects
+    hyphenated names and openai-compatible for OpenAI API servers.
+    """
+    normalized = provider.replace("_", "-")
+    if normalized == "omlx":
+        return "openai-compatible"
+    return normalized
 
 
 async def _revalidate_config_urls(config: dict, provider: str) -> None:
@@ -178,8 +192,8 @@ class ModelManager:
         # Merge any additional kwargs (e.g. temperature)
         config.update(kwargs)
 
-        # Normalize provider name: DB stores underscores but Esperanto expects hyphens
-        provider = model.provider.replace("_", "-")
+        # Normalize for Esperanto (underscores→hyphens; omlx→openai-compatible)
+        provider = to_esperanto_provider(model.provider)
 
         # Create model based on type (Esperanto will cache the instance)
         if model.type == "language":

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -114,6 +114,9 @@ class Credential(ObjectModel):
             # For Azure, base_url from the UI form maps to endpoint
             if self.provider and self.provider.lower() == "azure" and not self.endpoint:
                 config["endpoint"] = self.base_url
+        elif self.provider and self.provider.lower() == "omlx":
+            # Match test/discovery fallback so models work without a saved Base URL
+            config["base_url"] = "http://localhost:11435/v1"
         if self.endpoint:
             config["endpoint"] = self.endpoint
         if self.api_version:

--- a/open_notebook/utils/url_validation.py
+++ b/open_notebook/utils/url_validation.py
@@ -160,12 +160,14 @@ async def prepare_pinned_http_target(url: str, provider: str) -> PinnedHttpTarge
     # Prefer IPv4 when available (simpler URL form; same vetted set).
     pinned_ip = next((ip for ip in safe_ips if ":" not in ip), safe_ips[0])
     host_for_url = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+    # HTTP Host / TLS SNI must be ASCII; IDNA-encode internationalized names.
+    ascii_hostname = hostname.encode("idna").decode("ascii")
     if parsed.port is not None:
         netloc = f"{host_for_url}:{parsed.port}"
-        host_header = f"{hostname}:{parsed.port}"
+        host_header = f"{ascii_hostname}:{parsed.port}"
     else:
         netloc = host_for_url
-        host_header = hostname
+        host_header = ascii_hostname
 
     pinned_url = urlunparse(
         (
@@ -179,7 +181,7 @@ async def prepare_pinned_http_target(url: str, provider: str) -> PinnedHttpTarge
     )
     extensions: Dict[str, Any] = {}
     if parsed.scheme == "https":
-        extensions["sni_hostname"] = hostname
+        extensions["sni_hostname"] = ascii_hostname
 
     return PinnedHttpTarget(
         url=pinned_url,
@@ -232,8 +234,13 @@ def _reject_dangerous_ip(
         )
 
     # Block AWS's IMDSv6 metadata address - a Unique Local Address, not
-    # link-local, so it needs its own explicit check.
-    if ip == _AWS_IMDS_V6_ADDRESS:
+    # link-local, so it needs its own explicit check. Compare without scope
+    # ID so scoped forms (fd00:ec2::254%eth0) cannot bypass the sentinel.
+    is_aws_imds_v6 = (
+        isinstance(ip, ipaddress.IPv6Address)
+        and int(ip) == int(_AWS_IMDS_V6_ADDRESS)
+    )
+    if is_aws_imds_v6:
         if resolved:
             raise ValueError(
                 f"Hostname '{hostname}' resolves to the AWS IMDSv6 metadata address "

--- a/open_notebook/utils/url_validation.py
+++ b/open_notebook/utils/url_validation.py
@@ -6,17 +6,38 @@ layer (credential create/update, source-URL ingestion) and by open_notebook's
 own AI layer (connection_tester.py, ModelManager) to re-validate a
 provider-configured URL immediately before it is actually used - closing most
 of the DNS-rebinding TOCTOU window left by validating only once, at save time.
+
+For outbound HTTP to user-supplied hostnames, prefer
+``prepare_pinned_http_target``: it resolves DNS once, rejects dangerous
+addresses, and returns a URL pinned to the vetted IP so httpx cannot
+re-resolve to a metadata endpoint (while Host/SNI stay on the original host).
 """
 
 import asyncio
 import ipaddress
 import socket
-from urllib.parse import urlparse
+from dataclasses import dataclass, field
+from typing import Any, Dict
+from urllib.parse import urlparse, urlunparse
 
 # AWS's IMDSv6 metadata endpoint. Unlike the IPv4 metadata address
 # (169.254.169.254), this is a Unique Local Address, not link-local, so it is
 # not caught by ip.is_link_local and must be checked explicitly.
 _AWS_IMDS_V6_ADDRESS = ipaddress.ip_address("fd00:ec2::254")
+
+
+@dataclass(frozen=True)
+class PinnedHttpTarget:
+    """Outbound request target pinned to a DNS-vetted IP address.
+
+    Pass ``url`` / ``headers`` / ``extensions`` to httpx so the TCP connection
+    uses the pinned address while Host and TLS SNI still use the original
+    hostname.
+    """
+
+    url: str
+    headers: Dict[str, str] = field(default_factory=dict)
+    extensions: Dict[str, Any] = field(default_factory=dict)
 
 
 async def validate_url(url: str, provider: str) -> None:
@@ -74,17 +95,7 @@ async def validate_url(url: str, provider: str) -> None:
                 # doesn't stall every other concurrent request (this is
                 # called on the hot path of model provisioning, potentially
                 # once per chat message/transformation).
-                resolved_ips = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
-                for family, _, _, _, sockaddr in resolved_ips:
-                    ip_addr = sockaddr[0]
-                    try:
-                        parsed_ip = ipaddress.ip_address(ip_addr)
-                        _reject_dangerous_ip(parsed_ip, hostname, resolved=True)
-                    except ValueError as inner_ve:
-                        if "link-local" in str(inner_ve).lower() or "metadata" in str(inner_ve).lower():
-                            raise
-                        # Skip non-IP addresses (e.g., IPv6 zones)
-                        continue
+                await _resolve_safe_ips(hostname)
             except socket.gaierror:
                 # Could not resolve hostname - allow it since the URL may be
                 # valid in the deployment environment (e.g., Azure endpoints,
@@ -95,6 +106,104 @@ async def validate_url(url: str, provider: str) -> None:
         raise
     except Exception:
         raise ValueError("Invalid URL format. Check server logs for details.")
+
+
+async def prepare_pinned_http_target(url: str, provider: str) -> PinnedHttpTarget:
+    """
+    Validate ``url``, resolve DNS once, and pin the outbound target to a vetted IP.
+
+    Unlike ``validate_url`` alone (which still leaves a DNS-rebinding window
+    because httpx resolves again at connect time), this rewrites the request
+    URL to the vetted address and sets Host / ``sni_hostname`` so routing and
+    TLS verification keep the original hostname.
+
+    ``provider`` is accepted for call-site parity with ``validate_url``.
+
+    Raises:
+        ValueError: If the URL is invalid, resolves to a blocked address, or
+            cannot be resolved for an outbound request.
+    """
+    if not url or not url.strip():
+        raise ValueError("Invalid URL: hostname could not be determined.")
+
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Invalid URL scheme: '{parsed.scheme}'. Only http and https are allowed."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Invalid URL: hostname could not be determined.")
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+        _reject_dangerous_ip(ip, hostname)
+        # Already an IP literal — no rewrite / Host / SNI override needed.
+        return PinnedHttpTarget(url=url.strip())
+    except ValueError as ve:
+        if "Link-local" in str(ve) or "Invalid URL" in str(ve) or "metadata" in str(ve):
+            raise
+
+    try:
+        safe_ips = await _resolve_safe_ips(hostname)
+    except socket.gaierror as exc:
+        raise ValueError(
+            f"Could not resolve hostname '{hostname}' for outbound request."
+        ) from exc
+
+    if not safe_ips:
+        raise ValueError(
+            f"Could not resolve hostname '{hostname}' for outbound request."
+        )
+
+    # Prefer IPv4 when available (simpler URL form; same vetted set).
+    pinned_ip = next((ip for ip in safe_ips if ":" not in ip), safe_ips[0])
+    host_for_url = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+    if parsed.port is not None:
+        netloc = f"{host_for_url}:{parsed.port}"
+        host_header = f"{hostname}:{parsed.port}"
+    else:
+        netloc = host_for_url
+        host_header = hostname
+
+    pinned_url = urlunparse(
+        (
+            parsed.scheme,
+            netloc,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+    extensions: Dict[str, Any] = {}
+    if parsed.scheme == "https":
+        extensions["sni_hostname"] = hostname
+
+    return PinnedHttpTarget(
+        url=pinned_url,
+        headers={"Host": host_header},
+        extensions=extensions,
+    )
+
+
+async def _resolve_safe_ips(hostname: str) -> list[str]:
+    """Resolve ``hostname`` and return safe IP strings; raise on blocked addresses."""
+    resolved_ips = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+    safe: list[str] = []
+    for _family, _, _, _, sockaddr in resolved_ips:
+        ip_addr = sockaddr[0]
+        try:
+            parsed_ip = ipaddress.ip_address(ip_addr)
+            _reject_dangerous_ip(parsed_ip, hostname, resolved=True)
+            safe.append(ip_addr)
+        except ValueError as inner_ve:
+            if "link-local" in str(inner_ve).lower() or "metadata" in str(inner_ve).lower():
+                raise
+            # Skip non-IP addresses (e.g., IPv6 zones)
+            continue
+    return safe
 
 
 def _reject_dangerous_ip(

--- a/tests/test_credential_provider_validation.py
+++ b/tests/test_credential_provider_validation.py
@@ -26,6 +26,7 @@ KNOWN_GOOD_PROVIDERS = [
     "elevenlabs",
     "deepgram",
     "ollama",
+    "omlx",
     "azure",
     "vertex",
     "openai_compatible",

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -280,5 +280,53 @@ class TestAudioMatrixWiring:
         assert TEST_MODELS["vertex"] == ("gemini-flash-latest", "language")
 
 
+class TestOmlxProviderWiring:
+    """First-class oMLX provider (maps to Esperanto openai-compatible)."""
+
+    def test_modalities_and_env_config(self):
+        from api.credentials_service import PROVIDER_ENV_CONFIG, PROVIDER_MODALITIES
+        from open_notebook.ai.connection_tester import TEST_MODELS
+
+        assert PROVIDER_MODALITIES["omlx"] == ["language", "embedding"]
+        assert PROVIDER_ENV_CONFIG["omlx"]["required"] == ["OMLX_API_BASE"]
+        assert "OMLX_API_KEY" in PROVIDER_ENV_CONFIG["omlx"]["optional"]
+        assert TEST_MODELS["omlx"] == (None, "language")
+
+    def test_create_credential_from_env(self, monkeypatch):
+        from api.credentials_service import create_credential_from_env
+
+        monkeypatch.setenv("OMLX_API_BASE", "http://localhost:11435/v1")
+        monkeypatch.setenv("OMLX_API_KEY", "test-key")
+        cred = create_credential_from_env("omlx")
+        assert cred.provider == "omlx"
+        assert cred.base_url == "http://localhost:11435/v1"
+        assert cred.api_key is not None
+        assert cred.api_key.get_secret_value() == "test-key"
+        assert set(cred.modalities) == {"language", "embedding"}
+
+    def test_create_credential_from_env_without_api_key(self, monkeypatch):
+        from api.credentials_service import create_credential_from_env
+
+        monkeypatch.setenv("OMLX_API_BASE", "http://localhost:11435/v1")
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+        cred = create_credential_from_env("omlx")
+        assert cred.api_key is None
+        assert cred.base_url == "http://localhost:11435/v1"
+
+    def test_classify_embedding_models(self):
+        from open_notebook.ai.model_discovery import classify_model_type
+
+        assert classify_model_type("bge-m3", "omlx") == "embedding"
+        assert classify_model_type("nomic-embed-text", "omlx") == "embedding"
+        assert classify_model_type("llama-3.2-3b", "omlx") == "language"
+
+    def test_esperanto_provider_remap(self):
+        from open_notebook.ai.models import to_esperanto_provider
+
+        assert to_esperanto_provider("omlx") == "openai-compatible"
+        assert to_esperanto_provider("openai_compatible") == "openai-compatible"
+        assert to_esperanto_provider("ollama") == "ollama"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -157,6 +157,7 @@ class TestCredentialModelDiscovery:
     @pytest.mark.asyncio
     async def test_model_discovery_base_url_can_include_models_path(self, monkeypatch):
         """Model discovery should not append /models twice."""
+        from open_notebook.utils.url_validation import PinnedHttpTarget
 
         requests = []
 
@@ -167,7 +168,7 @@ class TestCredentialModelDiscovery:
             async def __aexit__(self, exc_type, exc, tb):
                 return None
 
-            async def get(self, url, headers=None, timeout=None):
+            async def get(self, url, headers=None, timeout=None, extensions=None):
                 requests.append(url)
                 return httpx.Response(
                     200,
@@ -175,7 +176,13 @@ class TestCredentialModelDiscovery:
                     request=httpx.Request("GET", url, headers=headers or {}),
                 )
 
+        async def fake_prepare_pinned(url, provider):
+            return PinnedHttpTarget(url=url)
+
         monkeypatch.setattr(credentials_service.httpx, "AsyncClient", FakeAsyncClient)
+        monkeypatch.setattr(
+            credentials_service, "prepare_pinned_http_target", fake_prepare_pinned
+        )
 
         await credentials_service.discover_with_config(
             "openai_compatible",
@@ -358,6 +365,7 @@ class TestOmlxProviderWiring:
     async def test_discover_omlx_models_avoids_double_models_path(self, monkeypatch):
         """Global oMLX discovery should not append /models twice."""
         from open_notebook.ai import model_discovery
+        from open_notebook.utils.url_validation import PinnedHttpTarget
 
         requests = []
 
@@ -368,7 +376,7 @@ class TestOmlxProviderWiring:
             async def __aexit__(self, exc_type, exc, tb):
                 return None
 
-            async def get(self, url, headers=None, timeout=None):
+            async def get(self, url, headers=None, timeout=None, extensions=None):
                 requests.append(url)
                 return httpx.Response(
                     200,
@@ -379,13 +387,15 @@ class TestOmlxProviderWiring:
         async def fake_get_by_provider(provider):
             return []
 
-        async def fake_validate_url(url, provider):
-            return None
+        async def fake_prepare_pinned(url, provider):
+            return PinnedHttpTarget(url=url)
 
         monkeypatch.setattr(
             model_discovery.Credential, "get_by_provider", fake_get_by_provider
         )
-        monkeypatch.setattr(model_discovery, "validate_url", fake_validate_url)
+        monkeypatch.setattr(
+            model_discovery, "prepare_pinned_http_target", fake_prepare_pinned
+        )
         monkeypatch.setattr(model_discovery.httpx, "AsyncClient", FakeAsyncClient)
         monkeypatch.setenv("OMLX_API_BASE", "http://localhost:11435/v1/models/")
         monkeypatch.delenv("OMLX_API_KEY", raising=False)
@@ -399,28 +409,30 @@ class TestOmlxProviderWiring:
 
     @pytest.mark.asyncio
     async def test_discover_omlx_models_revalidates_url(self, monkeypatch):
-        """DNS-rebinding guard: validate_url runs immediately before the request."""
+        """DNS-rebinding guard: pin helper runs immediately before the request."""
         from open_notebook.ai import model_discovery
 
-        validated = []
+        pinned = []
 
         async def fake_get_by_provider(provider):
             return []
 
-        async def fake_validate_url(url, provider):
-            validated.append((url, provider))
+        async def fake_prepare_pinned(url, provider):
+            pinned.append((url, provider))
             raise ValueError("Blocked URL")
 
         monkeypatch.setattr(
             model_discovery.Credential, "get_by_provider", fake_get_by_provider
         )
-        monkeypatch.setattr(model_discovery, "validate_url", fake_validate_url)
+        monkeypatch.setattr(
+            model_discovery, "prepare_pinned_http_target", fake_prepare_pinned
+        )
         monkeypatch.setenv("OMLX_API_BASE", "http://evil.example/v1")
         monkeypatch.delenv("OMLX_API_KEY", raising=False)
 
         models = await model_discovery.discover_omlx_models()
 
-        assert validated == [("http://evil.example/v1", "omlx")]
+        assert pinned == [("http://evil.example/v1/models", "omlx")]
         assert models == []
 
 

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -313,6 +313,33 @@ class TestOmlxProviderWiring:
         assert cred.api_key is None
         assert cred.base_url == "http://localhost:11435/v1"
 
+    def test_create_credential_from_env_defaults_base_url(self, monkeypatch):
+        from api.credentials_service import create_credential_from_env
+
+        monkeypatch.delenv("OMLX_API_BASE", raising=False)
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+        cred = create_credential_from_env("omlx")
+        assert cred.base_url == "http://localhost:11435/v1"
+
+    def test_to_esperanto_config_defaults_base_url(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(name="Local oMLX", provider="omlx", modalities=["language"])
+        config = cred.to_esperanto_config()
+        assert config["base_url"] == "http://localhost:11435/v1"
+
+    def test_to_esperanto_config_keeps_explicit_base_url(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(
+            name="Remote oMLX",
+            provider="omlx",
+            modalities=["language"],
+            base_url="http://192.168.1.10:11435/v1",
+        )
+        config = cred.to_esperanto_config()
+        assert config["base_url"] == "http://192.168.1.10:11435/v1"
+
     def test_classify_embedding_models(self):
         from open_notebook.ai.model_discovery import classify_model_type
 
@@ -326,6 +353,75 @@ class TestOmlxProviderWiring:
         assert to_esperanto_provider("omlx") == "openai-compatible"
         assert to_esperanto_provider("openai_compatible") == "openai-compatible"
         assert to_esperanto_provider("ollama") == "ollama"
+
+    @pytest.mark.asyncio
+    async def test_discover_omlx_models_avoids_double_models_path(self, monkeypatch):
+        """Global oMLX discovery should not append /models twice."""
+        from open_notebook.ai import model_discovery
+
+        requests = []
+
+        class FakeAsyncClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def get(self, url, headers=None, timeout=None):
+                requests.append(url)
+                return httpx.Response(
+                    200,
+                    json={"data": [{"id": "llama-3.2-3b"}]},
+                    request=httpx.Request("GET", url, headers=headers or {}),
+                )
+
+        async def fake_get_by_provider(provider):
+            return []
+
+        async def fake_validate_url(url, provider):
+            return None
+
+        monkeypatch.setattr(
+            model_discovery.Credential, "get_by_provider", fake_get_by_provider
+        )
+        monkeypatch.setattr(model_discovery, "validate_url", fake_validate_url)
+        monkeypatch.setattr(model_discovery.httpx, "AsyncClient", FakeAsyncClient)
+        monkeypatch.setenv("OMLX_API_BASE", "http://localhost:11435/v1/models/")
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+
+        models = await model_discovery.discover_omlx_models()
+
+        assert requests == ["http://localhost:11435/v1/models"]
+        assert len(models) == 1
+        assert models[0].name == "llama-3.2-3b"
+        assert models[0].provider == "omlx"
+
+    @pytest.mark.asyncio
+    async def test_discover_omlx_models_revalidates_url(self, monkeypatch):
+        """DNS-rebinding guard: validate_url runs immediately before the request."""
+        from open_notebook.ai import model_discovery
+
+        validated = []
+
+        async def fake_get_by_provider(provider):
+            return []
+
+        async def fake_validate_url(url, provider):
+            validated.append((url, provider))
+            raise ValueError("Blocked URL")
+
+        monkeypatch.setattr(
+            model_discovery.Credential, "get_by_provider", fake_get_by_provider
+        )
+        monkeypatch.setattr(model_discovery, "validate_url", fake_validate_url)
+        monkeypatch.setenv("OMLX_API_BASE", "http://evil.example/v1")
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+
+        models = await model_discovery.discover_omlx_models()
+
+        assert validated == [("http://evil.example/v1", "omlx")]
+        assert models == []
 
 
 if __name__ == "__main__":

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -147,6 +147,19 @@ class TestUrlValidation:
         await validate_url("http://[::ffff:192.168.1.1]", "openai")
         # Should not raise - private IPs allowed for self-hosted
 
+    async def test_aws_imds_v6_rejected(self):
+        """AWS IMDSv6 metadata address must be rejected."""
+        with pytest.raises(ValueError, match="IMDSv6|metadata"):
+            await validate_url("http://[fd00:ec2::254]/", "openai")
+
+    async def test_scoped_aws_imds_v6_rejected(self):
+        """Scoped IMDSv6 (fd00:ec2::254%eth0) must not bypass the sentinel check."""
+        with pytest.raises(ValueError, match="IMDSv6|metadata"):
+            await validate_url("http://[fd00:ec2::254%eth0]/", "openai")
+
+        with pytest.raises(ValueError, match="IMDSv6|metadata"):
+            await validate_url("http://[fd00:ec2::254%25eth0]/", "openai")
+
 
 class TestPinnedHttpTarget:
     """DNS pinning closes the validate-then-httpx rebinding window."""
@@ -163,6 +176,18 @@ class TestPinnedHttpTarget:
         with pytest.raises(ValueError, match="Link-local"):
             await prepare_pinned_http_target(
                 "http://169.254.169.254/latest/meta-data", "omlx"
+            )
+
+    async def test_scoped_aws_imds_v6_rejected(self):
+        """Scoped IMDSv6 literals must be rejected before pinning returns a target."""
+        with pytest.raises(ValueError, match="IMDSv6|metadata"):
+            await prepare_pinned_http_target(
+                "http://[fd00:ec2::254%eth0]/", "omlx"
+            )
+
+        with pytest.raises(ValueError, match="IMDSv6|metadata"):
+            await prepare_pinned_http_target(
+                "http://[fd00:ec2::254%25eth0]/", "omlx"
             )
 
     async def test_hostname_pinned_to_resolved_ip(self):
@@ -196,6 +221,23 @@ class TestPinnedHttpTarget:
         assert target.url == "https://93.184.216.34/v1/models"
         assert target.headers == {"Host": "api.example.com"}
         assert target.extensions == {"sni_hostname": "api.example.com"}
+
+    async def test_unicode_hostname_idna_encoded_for_host_and_sni(self):
+        """Internationalized hostnames must use ASCII IDNA for Host and SNI."""
+        fake_addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        ]
+        with patch(
+            "open_notebook.utils.url_validation.socket.getaddrinfo",
+            return_value=fake_addrs,
+        ):
+            target = await prepare_pinned_http_target(
+                "https://bücher.example/v1/models", "openai_compatible"
+            )
+
+        assert target.url == "https://93.184.216.34/v1/models"
+        assert target.headers == {"Host": "xn--bcher-kva.example"}
+        assert target.extensions == {"sni_hostname": "xn--bcher-kva.example"}
 
     async def test_hostname_resolving_to_link_local_rejected(self):
         fake_addrs = [

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -126,6 +126,13 @@ class TestUrlValidation:
         await validate_url("http://192.168.1.1:8080", "openai_compatible")
         # Should not raise
 
+    async def test_omlx_urls(self):
+        """oMLX (local OpenAI-compatible) URLs should be validated."""
+        await validate_url("http://localhost:11435/v1", "omlx")
+        await validate_url("http://127.0.0.1:11435/v1", "omlx")
+        await validate_url("http://host.docker.internal:11435/v1", "omlx")
+        # Should not raise
+
     async def test_ipv4_mapped_ipv6_link_local_rejected(self):
         """IPv4-mapped IPv6 addresses pointing to link-local should be rejected."""
         with pytest.raises(ValueError, match="Link-local addresses"):

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -16,9 +16,13 @@ loop - see open_notebook/utils/url_validation.py), so every test here is
 async too.
 """
 
+import socket
+from unittest.mock import patch
+
 import pytest
 
 from api.credentials_service import validate_url
+from open_notebook.utils.url_validation import prepare_pinned_http_target
 
 pytestmark = pytest.mark.asyncio
 
@@ -142,3 +146,66 @@ class TestUrlValidation:
         """IPv4-mapped IPv6 addresses pointing to private IPs should be allowed."""
         await validate_url("http://[::ffff:192.168.1.1]", "openai")
         # Should not raise - private IPs allowed for self-hosted
+
+
+class TestPinnedHttpTarget:
+    """DNS pinning closes the validate-then-httpx rebinding window."""
+
+    async def test_ip_literal_unchanged(self):
+        target = await prepare_pinned_http_target(
+            "http://127.0.0.1:11435/v1/models", "omlx"
+        )
+        assert target.url == "http://127.0.0.1:11435/v1/models"
+        assert target.headers == {}
+        assert target.extensions == {}
+
+    async def test_link_local_ip_rejected(self):
+        with pytest.raises(ValueError, match="Link-local"):
+            await prepare_pinned_http_target(
+                "http://169.254.169.254/latest/meta-data", "omlx"
+            )
+
+    async def test_hostname_pinned_to_resolved_ip(self):
+        fake_addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.50", 0)),
+        ]
+        with patch(
+            "open_notebook.utils.url_validation.socket.getaddrinfo",
+            return_value=fake_addrs,
+        ):
+            target = await prepare_pinned_http_target(
+                "http://omlx.local:11435/v1/models", "omlx"
+            )
+
+        assert target.url == "http://192.168.1.50:11435/v1/models"
+        assert target.headers == {"Host": "omlx.local:11435"}
+        assert target.extensions == {}
+
+    async def test_https_sets_sni_hostname(self):
+        fake_addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        ]
+        with patch(
+            "open_notebook.utils.url_validation.socket.getaddrinfo",
+            return_value=fake_addrs,
+        ):
+            target = await prepare_pinned_http_target(
+                "https://api.example.com/v1/models", "openai_compatible"
+            )
+
+        assert target.url == "https://93.184.216.34/v1/models"
+        assert target.headers == {"Host": "api.example.com"}
+        assert target.extensions == {"sni_hostname": "api.example.com"}
+
+    async def test_hostname_resolving_to_link_local_rejected(self):
+        fake_addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0)),
+        ]
+        with patch(
+            "open_notebook.utils.url_validation.socket.getaddrinfo",
+            return_value=fake_addrs,
+        ):
+            with pytest.raises(ValueError, match="link-local"):
+                await prepare_pinned_http_target(
+                    "http://evil.example/v1/models", "omlx"
+                )


### PR DESCRIPTION
## Description

Adds first-class **oMLX** provider support in Settings (alongside Ollama and other providers). oMLX is an OpenAI-compatible local inference server for Apple Silicon; at runtime credentials map to Esperanto’s `openai-compatible` provider. Default base URL is `http://localhost:11435/v1` to avoid conflicting with SurrealDB on port `8000`. Supports language and embedding models, with docs for setup/configuration.

## Related Issue

Fixes #1048

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [ ] Tested locally with Docker
- [x] Tested locally with development setup
- [x] Added new unit tests
- [x] Existing tests pass (`uv run pytest`)
- [ ] Manual testing performed (describe below)

**Test Details:**

```text
$ uv run pytest tests/test_credential_provider_validation.py tests/test_credentials_api.py tests/test_url_validation.py -q --tb=line
...................................................................      [100%]
67 passed, 7 warnings in 1.11s
```

(Prior run on this branch also reported 67 passed; re-confirmed for this PR.)

Ruff passed (`uv run ruff check . --fix`). Mypy reports ~210 pre-existing errors on main; none introduced by the oMLX changes.

## Design Alignment

**Which design principles does this PR support?** (See [VISION.md](https://github.com/lfnovo/open-notebook/blob/main/VISION.md))

- [x] Privacy First
- [ ] Simplicity Over Features
- [ ] API-First Architecture
- [x] Multi-Provider Flexibility
- [ ] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**

oMLX is a local, self-hosted inference option (privacy-preserving) and expands multi-provider flexibility with a dedicated Settings entry and sensible defaults, without requiring a cloud API key.

## Checklist

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [x] My code follows TypeScript best practices (Frontend)
- [x] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran linting: `make ruff` or `ruff check . --fix`
- [x] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [x] I have updated the relevant documentation in `/docs` (if applicable)
- [x] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

N/A (provider wiring + docs; Settings entry follows existing provider UI patterns)

## Additional Context

- Default URL uses port **11435** deliberately so it does not collide with SurrealDB on **8000**.
- Runtime provider id remains Esperanto `openai-compatible`; `omlx` is the first-class credential/Settings identity.
- Ruff passed (`uv run ruff check . --fix`). Mypy reports ~210 pre-existing errors on main; none introduced by the oMLX changes.

## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](https://github.com/lfnovo/open-notebook/blob/main/docs/7-DEVELOPMENT/contributing.md)
- [x] I have read [VISION.md](https://github.com/lfnovo/open-notebook/blob/main/VISION.md)
- [x] This PR addresses an approved issue assigned to me, **or** it's a small obvious fix (typo, docs, tiny bug) that doesn't need one — for anything bigger without an issue, mark this PR as draft and open the issue (triage takes 1–2 days)
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")

---

**Thank you for contributing to Open Notebook!**

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->