### PR TITLE
fix(docker): bind the frontend to 0.0.0.0 even when the runtime injects HOSTNAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Docker images now force the Next.js frontend to bind to `0.0.0.0` in the supervisord command itself, so container runtimes that inject `HOSTNAME` (e.g. Podman pods, where it resolves to `127.0.1.1`) can no longer make the UI unreachable. The `HOSTNAME` variable is no longer honored as a frontend bind override — set the new `FRONTEND_BIND_HOST` variable instead (#994)
+
 ## [1.12.0] - 2026-07-12
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,6 @@ ENV UV_NO_SYNC=1
 ENV VIRTUAL_ENV=/app/.venv
 # Point the app at the pre-baked tiktoken encoding (see open_notebook/config.py)
 ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
-# Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
-ENV HOSTNAME=0.0.0.0
 # Bind the API to all interfaces (IPv4). Set API_HOST=:: for IPv6 dual-stack environments
 ENV API_HOST=0.0.0.0
 

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -13,7 +13,7 @@ Comprehensive list of all environment variables available in Open Notebook.
 | `API_CLIENT_TIMEOUT` | No | 300 | Client timeout in seconds (how long to wait for API response) |
 | `OPEN_NOTEBOOK_PASSWORD` | No | None | Password to protect Open Notebook instance |
 | `OPEN_NOTEBOOK_ENCRYPTION_KEY` | **Yes** | None | Secret string to encrypt credentials stored in database (any string works). **Required** for the credential system. Supports Docker secrets via `_FILE` suffix. |
-| `HOSTNAME` | No | `0.0.0.0` (in Docker) | Network interface for Next.js to bind to. Default `0.0.0.0` ensures accessibility from reverse proxies |
+| `FRONTEND_BIND_HOST` | No | `0.0.0.0` (in Docker) | Network interface for Next.js to bind to. Default `0.0.0.0` ensures accessibility from reverse proxies. (Replaces `HOSTNAME`, which container runtimes such as Podman override with the container/pod hostname, causing Next.js to bind to the wrong address) |
 | `API_HOST` | No | `0.0.0.0` (in Docker) | Network interface for the API (uvicorn) to bind to. Set to `::` for IPv6 dual-stack environments (listens on IPv6 and, on Linux defaults, IPv4 too) |
 | `OPEN_NOTEBOOK_MAX_UPLOAD_SIZE_MB` | No | 100 | Maximum request body size (in MB) the API will accept, enforced before auth/routing. Raise this if you need to upload larger audio/video files. A fronting reverse proxy's own limit (e.g. nginx `client_max_body_size`) still applies and should be raised to match. |
 

--- a/docs/5-CONFIGURATION/reverse-proxy.md
+++ b/docs/5-CONFIGURATION/reverse-proxy.md
@@ -128,7 +128,7 @@ API_URL=https://your-domain.com
 
 **Important**: Set `API_URL` to your public URL (with https://).
 
-**Note on HOSTNAME**: The Docker images set `HOSTNAME=0.0.0.0` by default, which ensures Next.js binds to all interfaces and is accessible from reverse proxies. You typically don't need to set this manually.
+**Note on the bind address**: The Docker images bind Next.js to `0.0.0.0` by default, which ensures it listens on all interfaces and is accessible from reverse proxies. You typically don't need to change this; if you do, set `FRONTEND_BIND_HOST` (the `HOSTNAME` variable is unreliable because container runtimes such as Podman override it with the container/pod hostname).
 
 ---
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -31,7 +31,10 @@ autostart=true
 startsecs=3
 
 [program:frontend]
-command=bash -c "/app/scripts/wait-for-api.sh && node server.js"
+; HOSTNAME must be forced here: container runtimes inject HOSTNAME=<container/pod
+; hostname> at runtime (Podman pods override the image's ENV HOSTNAME=0.0.0.0),
+; making Next.js bind to the wrong address (#994). Override with FRONTEND_BIND_HOST.
+command=bash -c "/app/scripts/wait-for-api.sh && HOSTNAME=${FRONTEND_BIND_HOST:-0.0.0.0} node server.js"
 directory=/app/frontend
 environment=NODE_ENV="production",PORT="8502"
 passenv=API_URL,NEXT_PUBLIC_API_URL,INTERNAL_API_URL


### PR DESCRIPTION
Rebuilt against the post-v1.12.0 layout (the Docker build convergence in #1066 replaced the two Dockerfiles and removed `supervisord.single.conf`, so the original diff no longer applied).

**Root cause** (empirically verified): container runtimes inject `HOSTNAME=<container/pod hostname>` at runtime. Docker lets the image's `ENV HOSTNAME=0.0.0.0` win, but Podman's injection overrides image ENV — and inside a pod the hostname resolves to `127.0.1.1`, so the Next.js standalone server bound to the wrong address and the UI became unreachable (full diagnosis in #994).

**Fix**: set `HOSTNAME` explicitly in the supervisord frontend command — `HOSTNAME=${FRONTEND_BIND_HOST:-0.0.0.0} node server.js` — which beats any injected value, with `FRONTEND_BIND_HOST` as the supported override knob. Removes the now-dead `ENV HOSTNAME` from the Dockerfile and updates the environment reference and reverse-proxy docs accordingly.

Closes #994

## Testing
- Verified earlier on the original branch by simulating the Podman scenario in a Linux container: injected `HOSTNAME=open-notebook` ends up as `0.0.0.0` for the final process, and `FRONTEND_BIND_HOST=::` overrides correctly; both configs parsed with real supervisord (the `${...}` expansion survives supervisord's %-handling and reaches bash intact)
- Rebuilt diff is a 1:1 port of that verified change to the single-Dockerfile layout