### PR TITLE
chore(lint): re-enable F401/F841/E722 and fix fallout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release confidence process, documented and executable: `.github/RELEASE_PROCESS.md` now covers the risk-based test matrix (buckets A/B/C), the Docker image gate, the fix-loop re-test policy and the communication/credits/retro structure, backed by a new decision record (ADR-005) and versioned tooling under `scripts/release-test/` — `make release-test TAG= OLD_TAG=` runs fresh-install + upgrade scenarios against real images, and `make release-stack TAG= [DUMP=]` boots a browsable, isolated release-candidate stack (optionally with a copy of dev data) for manual verification
 
 ### Changed
+- Re-enabled the ruff rules for unused imports (`F401`), unused local variables (`F841`) and bare `except:` (`E722`) that were ignored to silence legacy Streamlit-era noise, and cleaned up the remaining fallout (10 unused imports, 2 unused test variables; no bare excepts remained)
 - Chat, source chat, Ask and transformation prompts now steer models to write math as `$$...$$` (display) / `$...$` (inline) so formulas render via KaTeX, reserving fenced `latex` code blocks for when the user explicitly asks for the LaTeX source (#1051)
 
 ### Removed

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -8,7 +8,7 @@ All functions raise ValueError for business errors (router converts to HTTPExcep
 """
 
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import httpx
 from loguru import logger

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import time
 import tomllib
 from pathlib import Path

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -15,7 +15,6 @@ Usage:
     await cred.save()
 """
 
-from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional
 
 from loguru import logger

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -1,8 +1,7 @@
-import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/open_notebook/domain/provider_config.py
+++ b/open_notebook/domain/provider_config.py
@@ -12,7 +12,7 @@ is set. If not set, keys are stored as plain text with a warning logged.
 from datetime import datetime
 from typing import ClassVar, Dict, List, Optional
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, SecretStr
 
 from open_notebook.database.repository import ensure_record_id, repo_query, repo_upsert
 from open_notebook.domain.base import RecordModel

--- a/open_notebook/graphs/chat.py
+++ b/open_notebook/graphs/chat.py
@@ -3,7 +3,7 @@ import sqlite3
 from typing import Annotated, Optional
 
 from ai_prompter import Prompter
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, START, StateGraph

--- a/open_notebook/graphs/source_chat.py
+++ b/open_notebook/graphs/source_chat.py
@@ -3,7 +3,7 @@ import sqlite3
 from typing import Annotated, Dict, List, Optional
 
 from ai_prompter import Prompter
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, START, StateGraph

--- a/open_notebook/utils/embedding.py
+++ b/open_notebook/utils/embedding.py
@@ -12,7 +12,7 @@ to ensure consistent behavior and proper handling of large content.
 
 import asyncio
 import os
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 import numpy as np
 from loguru import logger
@@ -45,11 +45,6 @@ def _get_embedding_batch_size() -> int:
 EMBEDDING_BATCH_SIZE = _get_embedding_batch_size()
 EMBEDDING_MAX_RETRIES = 3
 EMBEDDING_RETRY_DELAY = 2  # seconds
-
-# Lazy import to avoid circular dependency:
-# utils -> embedding -> models -> key_provider -> provider_config -> utils
-if TYPE_CHECKING:
-    from open_notebook.ai.models import ModelManager
 
 
 async def mean_pool_embeddings(embeddings: List[List[float]]) -> List[float]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,7 @@ select = ["E", "F", "I"]
 ignore = [
     "E501",  # line too long
     "E402",  # module level import not at top of file (Streamlit requires this pattern)
-    "E722",  # do not use bare except (legacy code pattern)
-    "F401",  # imported but unused (may be used in type hints or re-exports)
     "F541",  # f-string without placeholders
-    "F841",  # local variable assigned but never used
 ]
 
 [tool.uv]

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -241,7 +241,7 @@ class TestGenerateEmbedding:
     @pytest.mark.asyncio
     async def test_batching(self):
         """Test that large input is split into batches of EMBEDDING_BATCH_SIZE."""
-        from unittest.mock import AsyncMock, MagicMock, call, patch
+        from unittest.mock import AsyncMock, MagicMock, patch
 
         from open_notebook.utils.embedding import EMBEDDING_BATCH_SIZE
 

--- a/tests/test_models_api.py
+++ b/tests/test_models_api.py
@@ -85,7 +85,7 @@ class TestModelCreation:
         mock_repo_query.return_value = []
 
         # Patch the save method on the Model class
-        with patch.object(Model, "save", new_callable=AsyncMock) as mock_save:
+        with patch.object(Model, "save", new_callable=AsyncMock):
             # Attempt to create same model name with different provider (anthropic)
             response = client.post(
                 "/api/models",
@@ -105,7 +105,7 @@ class TestModelCreation:
         mock_repo_query.return_value = []
 
         # Patch the save method on the Model class
-        with patch.object(Model, "save", new_callable=AsyncMock) as mock_save:
+        with patch.object(Model, "save", new_callable=AsyncMock):
             # Attempt to create same model name with different type (embedding instead of language)
             response = client.post(
                 "/api/models",


### PR DESCRIPTION
## Summary

`pyproject.toml` ignored `E722` (bare except), `F401` (unused imports) and `F841` (unused local variables) to silence legacy Streamlit-era noise. That code is gone from main, so this re-enables the three rules and fixes the small remaining fallout.

## Fallout fixed

| Rule | Count | Fix |
|---|---|---|
| F401 unused imports | 10 | Removed (`api/credentials_service.py`, `api/routers/config.py`, `open_notebook/domain/{credential,notebook,provider_config}.py`, `open_notebook/graphs/{chat,source_chat}.py`, `open_notebook/utils/embedding.py`, `tests/test_embedding.py`) |
| F841 unused variables | 2 | Dropped unused `as mock_save` bindings in `tests/test_models_api.py` |
| E722 bare except | 0 | None remained in the codebase |

Notes:
- No `noqa` was needed: none of the flagged imports were `__init__.py` re-exports or side-effect imports (command registration in `commands/__init__.py` and model subclass registration were untouched).
- The `TYPE_CHECKING` import of `ModelManager` in `open_notebook/utils/embedding.py` was unused even as a type hint, so the now-empty `if TYPE_CHECKING:` block was removed too.

## Verification

- `ruff check .` — clean
- `uv run pytest tests/` — 403 passed (same as main)
- `mypy .` — 197 pre-existing errors, identical count to main
- Smoke test: `python -c "import commands; import api.main"` — all background commands still register (embed_note, embed_insight, embed_source, create_insight, rebuild_embeddings, generate_podcast)
- `uv.lock` untouched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

