### PR TITLE
refactor(ai): table-driven model discovery, real Anthropic listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release confidence process, documented and executable: `.github/RELEASE_PROCESS.md` now covers the risk-based test matrix (buckets A/B/C), the Docker image gate, the fix-loop re-test policy and the communication/credits/retro structure, backed by a new decision record (ADR-005) and versioned tooling under `scripts/release-test/` — `make release-test TAG= OLD_TAG=` runs fresh-install + upgrade scenarios against real images, and `make release-stack TAG= [DUMP=]` boots a browsable, isolated release-candidate stack (optionally with a copy of dev data) for manual verification
 
 ### Changed
+- Model discovery is now table-driven: the eight providers with OpenAI-compatible `/models` endpoints (OpenAI, Groq, Mistral, DeepSeek, xAI, OpenRouter, DashScope, MiniMax) share one generic discovery function configured by `OPENAI_COMPAT_PROVIDERS`, replacing eight near-identical copies (provider-specific quirks like Mistral's capability flags and OpenRouter's descriptions are preserved as hooks)
 - Re-enabled the ruff rules for unused imports (`F401`), unused local variables (`F841`) and bare `except:` (`E722`) that were ignored to silence legacy Streamlit-era noise, and cleaned up the remaining fallout (10 unused imports, 2 unused test variables; no bare excepts remained)
 - Chat, source chat, Ask and transformation prompts now steer models to write math as `$$...$$` (display) / `$...$` (inline) so formulas render via KaTeX, reserving fenced `latex` code blocks for when the user explicitly asks for the LaTeX source (#1051)
+
+### Fixed
+- Anthropic models are now discovered live from `GET https://api.anthropic.com/v1/models` (paginated) instead of a hardcoded claude-3-era list — the code comment claiming "Anthropic doesn't have a model listing API" was wrong. A refreshed static list (current Claude 4.x/5 aliases) remains as a fallback when the API call fails, and the credential-based discovery path (`discover_with_config`) uses the same live-with-fallback logic
 
 ### Removed
 - Dead Streamlit-era service layer (~2,000 lines): `api/client.py` (a synchronous HTTP client that called the app's own API) and 13 `api/*_service.py` wrappers that consumed the app's own HTTP API — none were imported by any router, command or test. Also removed the toy `process_text`/`analyze_data` demo commands (`commands/example_commands.py`) from the background worker

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -15,7 +15,11 @@ from loguru import logger
 from pydantic import SecretStr
 
 from api.models import CredentialResponse
-from open_notebook.ai.model_discovery import classify_model_type
+from open_notebook.ai.model_discovery import (
+    ANTHROPIC_FALLBACK_MODELS,
+    classify_model_type,
+    fetch_anthropic_model_ids,
+)
 from open_notebook.domain.credential import Credential
 from open_notebook.utils.encryption import get_secret_from_env
 from open_notebook.utils.url_validation import validate_url
@@ -385,15 +389,6 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
 
     # Static model lists for providers without a listing API
     STATIC_MODELS: Dict[str, List[str]] = {
-        "anthropic": [
-            "claude-opus-4-20250514",
-            "claude-sonnet-4-20250514",
-            "claude-3-5-sonnet-20241022",
-            "claude-3-5-haiku-20241022",
-            "claude-3-opus-20240229",
-            "claude-3-sonnet-20240229",
-            "claude-3-haiku-20240307",
-        ],
         "voyage": [
             "voyage-3", "voyage-3-lite", "voyage-code-3",
             "voyage-finance-2", "voyage-law-2", "voyage-multilingual-2",
@@ -418,6 +413,18 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
             {"name": m, "provider": provider}
             for m in STATIC_MODELS[provider]
         ]
+
+    if provider == "anthropic":
+        if not api_key:
+            return []
+        try:
+            model_names = await fetch_anthropic_model_ids(api_key)
+        except Exception as e:
+            logger.warning(
+                f"Failed to discover Anthropic models, using static fallback: {e}"
+            )
+            model_names = list(ANTHROPIC_FALLBACK_MODELS)
+        return [{"name": m, "provider": "anthropic"} for m in model_names]
 
     # API-based discovery URLs (OpenAI-style /models endpoints)
     url_map = {

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -8,7 +8,7 @@ AI providers and automatically register them in the database.
 import asyncio
 import os
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
 import httpx
 from loguru import logger
@@ -51,18 +51,18 @@ OPENAI_MODEL_TYPES = {
     "text_to_speech": ["tts"],
 }
 
-ANTHROPIC_MODELS = {
-    # Static list since Anthropic doesn't have a model listing API
-    "language": [
-        "claude-opus-4-20250514",
-        "claude-sonnet-4-20250514",
-        "claude-3-5-sonnet-20241022",
-        "claude-3-5-haiku-20241022",
-        "claude-3-opus-20240229",
-        "claude-3-sonnet-20240229",
-        "claude-3-haiku-20240307",
-    ],
-}
+# Fallback list used only when Anthropic's model listing API
+# (GET https://api.anthropic.com/v1/models) is unreachable or errors.
+ANTHROPIC_FALLBACK_MODELS = [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+]
 
 GOOGLE_MODEL_TYPES = {
     "language": ["gemini", "palm", "bison", "chat"],
@@ -191,13 +191,77 @@ def classify_model_type(model_name: str, provider: str) -> str:
 
 
 # =============================================================================
-# Provider-Specific Model Discovery Functions
+# OpenAI-Compatible Provider Discovery (table-driven)
 # =============================================================================
+# All of these providers expose the same endpoint shape:
+#   GET {url} with "Authorization: Bearer {key}" -> {"data": [{"id": ...}, ...]}
+# Only the URL, the env var holding the key, and small per-provider quirks
+# differ, so they share one generic discovery function driven by this table.
 
 
-async def discover_openai_models() -> List[DiscoveredModel]:
-    """Fetch available models from OpenAI API."""
-    api_key = os.environ.get("OPENAI_API_KEY")
+def _classify_mistral(model: dict) -> str:
+    """Mistral quirk: trust the capabilities flag over name-based patterns."""
+    if model.get("capabilities", {}).get("completion_chat"):
+        return "language"
+    return classify_model_type(model.get("id", ""), "mistral")
+
+
+@dataclass(frozen=True)
+class ProviderDiscoverySpec:
+    """Spec for a provider with an OpenAI-compatible /models endpoint."""
+
+    url: str
+    env_var: str
+    # Optional quirk hooks; defaults are classify_model_type(id, provider)
+    # and no description.
+    classify: Optional[Callable[[dict], str]] = None
+    description: Optional[Callable[[dict], Optional[str]]] = None
+
+
+OPENAI_COMPAT_PROVIDERS: Dict[str, ProviderDiscoverySpec] = {
+    "openai": ProviderDiscoverySpec(
+        url="https://api.openai.com/v1/models",
+        env_var="OPENAI_API_KEY",
+    ),
+    "groq": ProviderDiscoverySpec(
+        url="https://api.groq.com/openai/v1/models",
+        env_var="GROQ_API_KEY",
+    ),
+    "mistral": ProviderDiscoverySpec(
+        url="https://api.mistral.ai/v1/models",
+        env_var="MISTRAL_API_KEY",
+        classify=_classify_mistral,
+    ),
+    "deepseek": ProviderDiscoverySpec(
+        url="https://api.deepseek.com/models",
+        env_var="DEEPSEEK_API_KEY",
+    ),
+    "xai": ProviderDiscoverySpec(
+        url="https://api.x.ai/v1/models",
+        env_var="XAI_API_KEY",
+    ),
+    "openrouter": ProviderDiscoverySpec(
+        url="https://openrouter.ai/api/v1/models",
+        env_var="OPENROUTER_API_KEY",
+        # OpenRouter models are typically language models
+        classify=lambda model: "language",
+        description=lambda model: model.get("name"),
+    ),
+    "dashscope": ProviderDiscoverySpec(
+        url="https://dashscope.aliyuncs.com/compatible-mode/v1/models",
+        env_var="DASHSCOPE_API_KEY",
+    ),
+    "minimax": ProviderDiscoverySpec(
+        url="https://api.minimax.io/v1/models",
+        env_var="MINIMAX_API_KEY",
+    ),
+}
+
+
+async def discover_openai_compatible_provider(provider: str) -> List[DiscoveredModel]:
+    """Fetch available models from a provider with an OpenAI-compatible API."""
+    spec = OPENAI_COMPAT_PROVIDERS[provider]
+    api_key = os.environ.get(spec.env_var)
     if not api_key:
         return []
 
@@ -205,7 +269,7 @@ async def discover_openai_models() -> List[DiscoveredModel]:
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                "https://api.openai.com/v1/models",
+                spec.url,
                 headers={"Authorization": f"Bearer {api_key}"},
                 timeout=30.0,
             )
@@ -214,38 +278,112 @@ async def discover_openai_models() -> List[DiscoveredModel]:
 
             for model in data.get("data", []):
                 model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "openai")
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="openai",
-                            model_type=model_type,
-                        )
+                if not model_id:
+                    continue
+                if spec.classify is not None:
+                    model_type = spec.classify(model)
+                else:
+                    model_type = classify_model_type(model_id, provider)
+                description = (
+                    spec.description(model) if spec.description is not None else None
+                )
+                models.append(
+                    DiscoveredModel(
+                        name=model_id,
+                        provider=provider,
+                        model_type=model_type,
+                        description=description,
                     )
+                )
     except Exception as e:
-        logger.warning(f"Failed to discover OpenAI models: {e}")
+        logger.warning(f"Failed to discover {provider} models: {e}")
 
     return models
 
 
+def _make_openai_compat_discoverer(
+    provider: str,
+) -> Callable[[], Awaitable[List[DiscoveredModel]]]:
+    async def _discover() -> List[DiscoveredModel]:
+        return await discover_openai_compatible_provider(provider)
+
+    _discover.__name__ = f"discover_{provider}_models"
+    _discover.__doc__ = f"Fetch available models from the {provider} API."
+    return _discover
+
+
+# Kept as module-level names so existing imports/patches keep working.
+discover_openai_models = _make_openai_compat_discoverer("openai")
+discover_groq_models = _make_openai_compat_discoverer("groq")
+discover_mistral_models = _make_openai_compat_discoverer("mistral")
+discover_deepseek_models = _make_openai_compat_discoverer("deepseek")
+discover_xai_models = _make_openai_compat_discoverer("xai")
+discover_openrouter_models = _make_openai_compat_discoverer("openrouter")
+discover_dashscope_models = _make_openai_compat_discoverer("dashscope")
+discover_minimax_models = _make_openai_compat_discoverer("minimax")
+
+
+# =============================================================================
+# Bespoke Provider Discovery Functions
+# =============================================================================
+
+
+async def fetch_anthropic_model_ids(api_key: str) -> List[str]:
+    """
+    Fetch model ids from Anthropic's model listing API.
+
+    Uses GET https://api.anthropic.com/v1/models with pagination
+    (after_id/has_more cursors). Raises on any HTTP or network error —
+    callers decide whether to fall back to ANTHROPIC_FALLBACK_MODELS.
+    """
+    model_ids: List[str] = []
+    params: Dict[str, str] = {"limit": "100"}
+    async with httpx.AsyncClient() as client:
+        # Hard page cap as a safety net against a misbehaving cursor.
+        for _ in range(20):
+            response = await client.get(
+                "https://api.anthropic.com/v1/models",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                },
+                params=params,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            for model in data.get("data", []):
+                model_id = model.get("id", "")
+                if model_id:
+                    model_ids.append(model_id)
+            if not data.get("has_more") or not data.get("last_id"):
+                break
+            params["after_id"] = data["last_id"]
+    return model_ids
+
+
 async def discover_anthropic_models() -> List[DiscoveredModel]:
-    """Return static list of Anthropic models (no discovery API available)."""
+    """Fetch available models from Anthropic's model listing API."""
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         return []
 
-    # Anthropic doesn't have a model listing API, so we use a static list
-    models = []
-    for model_name in ANTHROPIC_MODELS.get("language", []):
-        models.append(
-            DiscoveredModel(
-                name=model_name,
-                provider="anthropic",
-                model_type="language",
-            )
+    try:
+        model_names = await fetch_anthropic_model_ids(api_key)
+    except Exception as e:
+        logger.warning(
+            f"Failed to discover Anthropic models, using static fallback: {e}"
         )
-    return models
+        model_names = list(ANTHROPIC_FALLBACK_MODELS)
+
+    return [
+        DiscoveredModel(
+            name=model_name,
+            provider="anthropic",
+            model_type=classify_model_type(model_name, "anthropic"),
+        )
+        for model_name in model_names
+    ]
 
 
 async def discover_google_models() -> List[DiscoveredModel]:
@@ -320,182 +458,6 @@ async def discover_ollama_models() -> List[DiscoveredModel]:
                     )
     except Exception as e:
         logger.warning(f"Failed to discover Ollama models: {e}")
-
-    return models
-
-
-async def discover_groq_models() -> List[DiscoveredModel]:
-    """Fetch available models from Groq API."""
-    api_key = os.environ.get("GROQ_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://api.groq.com/openai/v1/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "groq")
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="groq",
-                            model_type=model_type,
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover Groq models: {e}")
-
-    return models
-
-
-async def discover_mistral_models() -> List[DiscoveredModel]:
-    """Fetch available models from Mistral API."""
-    api_key = os.environ.get("MISTRAL_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://api.mistral.ai/v1/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "mistral")
-                    # Check capabilities if available
-                    capabilities = model.get("capabilities", {})
-                    if capabilities.get("completion_chat"):
-                        model_type = "language"
-
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="mistral",
-                            model_type=model_type,
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover Mistral models: {e}")
-
-    return models
-
-
-async def discover_deepseek_models() -> List[DiscoveredModel]:
-    """Fetch available models from DeepSeek API."""
-    api_key = os.environ.get("DEEPSEEK_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://api.deepseek.com/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "deepseek")
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="deepseek",
-                            model_type=model_type,
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover DeepSeek models: {e}")
-
-    return models
-
-
-async def discover_xai_models() -> List[DiscoveredModel]:
-    """Fetch available models from xAI API."""
-    api_key = os.environ.get("XAI_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://api.x.ai/v1/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "xai")
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="xai",
-                            model_type=model_type,
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover xAI models: {e}")
-
-    return models
-
-
-async def discover_openrouter_models() -> List[DiscoveredModel]:
-    """Fetch available models from OpenRouter API."""
-    api_key = os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://openrouter.ai/api/v1/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    # OpenRouter models are typically language models
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="openrouter",
-                            model_type="language",
-                            description=model.get("name"),
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover OpenRouter models: {e}")
 
     return models
 
@@ -577,74 +539,6 @@ async def discover_deepgram_models() -> List[DiscoveredModel]:
         DiscoveredModel(name=m, provider="deepgram", model_type="text_to_speech")
         for m in deepgram_voices
     ]
-
-
-async def discover_dashscope_models() -> List[DiscoveredModel]:
-    """Fetch available models from DashScope (Qwen) API."""
-    api_key = os.environ.get("DASHSCOPE_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://dashscope.aliyuncs.com/compatible-mode/v1/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "dashscope")
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="dashscope",
-                            model_type=model_type,
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover DashScope models: {e}")
-
-    return models
-
-
-async def discover_minimax_models() -> List[DiscoveredModel]:
-    """Fetch available models from MiniMax API."""
-    api_key = os.environ.get("MINIMAX_API_KEY")
-    if not api_key:
-        return []
-
-    models = []
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://api.minimax.io/v1/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            for model in data.get("data", []):
-                model_id = model.get("id", "")
-                if model_id:
-                    model_type = classify_model_type(model_id, "minimax")
-                    models.append(
-                        DiscoveredModel(
-                            name=model_id,
-                            provider="minimax",
-                            model_type=model_type,
-                        )
-                    )
-    except Exception as e:
-        logger.warning(f"Failed to discover MiniMax models: {e}")
-
-    return models
 
 
 async def discover_openai_compatible_models() -> List[DiscoveredModel]:

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -1,0 +1,295 @@
+"""
+Tests for open_notebook.ai.model_discovery.
+
+Covers the table-driven OpenAI-compatible discovery path and the
+Anthropic model-listing API discovery (with static fallback).
+All HTTP calls are mocked — no real provider APIs are hit.
+"""
+
+import httpx
+import pytest
+
+from open_notebook.ai import model_discovery
+from open_notebook.ai.model_discovery import (
+    ANTHROPIC_FALLBACK_MODELS,
+    OPENAI_COMPAT_PROVIDERS,
+    PROVIDER_DISCOVERY_FUNCTIONS,
+    discover_anthropic_models,
+    discover_openai_compatible_provider,
+)
+
+
+def make_fake_client(handler):
+    """Build a fake httpx.AsyncClient class whose .get() delegates to handler."""
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, headers=None, params=None, timeout=None):
+            return handler(url=url, headers=headers, params=params, timeout=timeout)
+
+    return FakeAsyncClient
+
+
+def json_response(url, payload, status_code=200):
+    return httpx.Response(
+        status_code, json=payload, request=httpx.Request("GET", url)
+    )
+
+
+class TestOpenAICompatTable:
+    """The provider table must keep covering every collapsed provider."""
+
+    def test_table_covers_all_openai_compatible_providers(self):
+        assert set(OPENAI_COMPAT_PROVIDERS) == {
+            "openai",
+            "groq",
+            "mistral",
+            "deepseek",
+            "xai",
+            "openrouter",
+            "dashscope",
+            "minimax",
+        }
+
+    def test_provider_discovery_functions_keys_unchanged(self):
+        assert set(PROVIDER_DISCOVERY_FUNCTIONS) == {
+            "openai",
+            "anthropic",
+            "google",
+            "ollama",
+            "groq",
+            "mistral",
+            "deepseek",
+            "xai",
+            "openrouter",
+            "voyage",
+            "elevenlabs",
+            "deepgram",
+            "openai_compatible",
+            "dashscope",
+            "minimax",
+            "azure",
+            "vertex",
+        }
+        # Azure/Vertex intentionally have no env-based discovery
+        assert PROVIDER_DISCOVERY_FUNCTIONS["azure"] is None
+        assert PROVIDER_DISCOVERY_FUNCTIONS["vertex"] is None
+
+    def test_module_level_names_preserved(self):
+        for provider in OPENAI_COMPAT_PROVIDERS:
+            func = getattr(model_discovery, f"discover_{provider}_models")
+            assert callable(func)
+            assert PROVIDER_DISCOVERY_FUNCTIONS[provider] is func
+
+
+class TestGenericOpenAICompatDiscovery:
+    @pytest.mark.asyncio
+    async def test_discovery_uses_spec_url_and_bearer_key(self, monkeypatch):
+        requests = []
+
+        def handler(url, headers, params, timeout):
+            requests.append({"url": url, "headers": headers, "timeout": timeout})
+            return json_response(
+                url, {"data": [{"id": "whisper-large-v3"}, {"id": "llama-3.3-70b"}]}
+            )
+
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await discover_openai_compatible_provider("groq")
+
+        assert requests == [
+            {
+                "url": "https://api.groq.com/openai/v1/models",
+                "headers": {"Authorization": "Bearer gsk-test"},
+                "timeout": 30.0,
+            }
+        ]
+        assert [(m.name, m.provider, m.model_type) for m in models] == [
+            ("whisper-large-v3", "groq", "speech_to_text"),
+            ("llama-3.3-70b", "groq", "language"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_missing_env_key_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        assert await discover_openai_compatible_provider("deepseek") == []
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_empty(self, monkeypatch):
+        def handler(url, headers, params, timeout):
+            return json_response(url, {"error": "nope"}, status_code=500)
+
+        monkeypatch.setenv("XAI_API_KEY", "xai-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        assert await discover_openai_compatible_provider("xai") == []
+
+    @pytest.mark.asyncio
+    async def test_mistral_capabilities_quirk(self, monkeypatch):
+        def handler(url, headers, params, timeout):
+            return json_response(
+                url,
+                {
+                    "data": [
+                        # capabilities flag wins over name-based classification
+                        {"id": "magistral-medium", "capabilities": {"completion_chat": True}},
+                        # no chat capability -> falls back to name patterns
+                        {"id": "mistral-embed", "capabilities": {"completion_chat": False}},
+                    ]
+                },
+            )
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "mk-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await discover_openai_compatible_provider("mistral")
+        assert [(m.name, m.model_type) for m in models] == [
+            ("magistral-medium", "language"),
+            ("mistral-embed", "embedding"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_openrouter_quirk_language_and_description(self, monkeypatch):
+        def handler(url, headers, params, timeout):
+            return json_response(
+                url,
+                {"data": [{"id": "acme/embedding-x", "name": "Acme Embedding X"}]},
+            )
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await discover_openai_compatible_provider("openrouter")
+        assert len(models) == 1
+        # OpenRouter models are always registered as language models
+        assert models[0].model_type == "language"
+        assert models[0].description == "Acme Embedding X"
+
+
+class TestAnthropicDiscovery:
+    @pytest.mark.asyncio
+    async def test_missing_key_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert await discover_anthropic_models() == []
+
+    @pytest.mark.asyncio
+    async def test_discovery_paginates_and_sends_anthropic_headers(self, monkeypatch):
+        requests = []
+
+        def handler(url, headers, params, timeout):
+            requests.append({"url": url, "headers": headers, "params": dict(params)})
+            if "after_id" not in params:
+                return json_response(
+                    url,
+                    {
+                        "data": [{"id": "claude-opus-4-8"}],
+                        "has_more": True,
+                        "last_id": "claude-opus-4-8",
+                    },
+                )
+            return json_response(
+                url,
+                {
+                    "data": [{"id": "claude-haiku-4-5"}],
+                    "has_more": False,
+                    "last_id": "claude-haiku-4-5",
+                },
+            )
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await discover_anthropic_models()
+
+        assert len(requests) == 2
+        assert all(
+            r["url"] == "https://api.anthropic.com/v1/models" for r in requests
+        )
+        assert requests[0]["headers"] == {
+            "x-api-key": "sk-ant-test",
+            "anthropic-version": "2023-06-01",
+        }
+        assert requests[1]["params"]["after_id"] == "claude-opus-4-8"
+
+        assert [(m.name, m.provider, m.model_type) for m in models] == [
+            ("claude-opus-4-8", "anthropic", "language"),
+            ("claude-haiku-4-5", "anthropic", "language"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_api_failure_falls_back_to_static_list(self, monkeypatch):
+        def handler(url, headers, params, timeout):
+            return json_response(url, {"error": "boom"}, status_code=500)
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await discover_anthropic_models()
+
+        assert [m.name for m in models] == list(ANTHROPIC_FALLBACK_MODELS)
+        assert all(m.provider == "anthropic" for m in models)
+        assert all(m.model_type == "language" for m in models)
+
+
+class TestCredentialServiceAnthropicDiscovery:
+    """discover_with_config must use the same live-API-with-fallback path."""
+
+    @pytest.mark.asyncio
+    async def test_discover_with_config_uses_anthropic_api(self, monkeypatch):
+        from api import credentials_service
+
+        def handler(url, headers, params, timeout):
+            assert url == "https://api.anthropic.com/v1/models"
+            return json_response(
+                url, {"data": [{"id": "claude-sonnet-4-6"}], "has_more": False}
+            )
+
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await credentials_service.discover_with_config(
+            "anthropic", {"api_key": "sk-ant-test"}
+        )
+        assert models == [{"name": "claude-sonnet-4-6", "provider": "anthropic"}]
+
+    @pytest.mark.asyncio
+    async def test_discover_with_config_falls_back_on_error(self, monkeypatch):
+        from api import credentials_service
+
+        def handler(url, headers, params, timeout):
+            return json_response(url, {"error": "boom"}, status_code=503)
+
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await credentials_service.discover_with_config(
+            "anthropic", {"api_key": "sk-ant-test"}
+        )
+        assert [m["name"] for m in models] == list(ANTHROPIC_FALLBACK_MODELS)
+
+    @pytest.mark.asyncio
+    async def test_discover_with_config_requires_key(self):
+        from api import credentials_service
+
+        models = await credentials_service.discover_with_config("anthropic", {})
+        assert models == []


### PR DESCRIPTION
## What

Two changes to model discovery (`open_notebook/ai/model_discovery.py`):

### Table-driven discovery for OpenAI-compatible providers

The eight providers whose discovery functions were structural clones — read env key → `GET {url}/models` with a Bearer header → iterate `data["data"]` → `classify_model_type()` — now share one generic `discover_openai_compatible_provider()` driven by an `OPENAI_COMPAT_PROVIDERS: dict[str, ProviderDiscoverySpec]` table (url + env var + optional quirk hooks):

- **In the table:** openai, groq, mistral, deepseek, xai, openrouter, dashscope, minimax
- **Quirks preserved as hooks:** Mistral's `capabilities.completion_chat` override; OpenRouter's fixed `language` type + `name` description
- **Still bespoke** (genuinely different endpoints/shapes): anthropic, google, ollama, openai_compatible, and the static-list providers (voyage, elevenlabs, deepgram)

Module-level names (`discover_openai_models`, `discover_groq_models`, …) and all `PROVIDER_DISCOVERY_FUNCTIONS` keys are preserved, so the public API is unchanged. Adding a new OpenAI-compatible provider is now one table entry.

### Real Anthropic model listing

The hardcoded `ANTHROPIC_MODELS` list was claude-3-era stale, and its comment ("Anthropic doesn't have a model listing API") is factually wrong — `GET https://api.anthropic.com/v1/models` exists (`x-api-key` + `anthropic-version: 2023-06-01`, paginated via `has_more`/`last_id`).

- `discover_anthropic_models()` now fetches the live list (with pagination and a page cap safety net)
- On any API failure it falls back to a refreshed static list (`ANTHROPIC_FALLBACK_MODELS`: current Claude 4.x/5 aliases — opus-4-8 through haiku-4-5)
- `api/credentials_service.py::discover_with_config` carried a second copy of the same stale list; it now reuses the shared `fetch_anthropic_model_ids()` with the same fallback

## Size

`model_discovery.py`: 889 → 790 lines; net diff across the two source files: +193 / −292.

## Verification

- `uv run pytest tests/` — 417 passed (was 404 on main; 13 new tests in `tests/test_model_discovery.py` covering the table-driven path, provider quirks, Anthropic pagination + headers, fallback-on-error, and the `discover_with_config` anthropic path — all HTTP mocked, no real API calls)
- `ruff check .` — clean
- `mypy` — identical error set to main (22 pre-existing errors in unrelated code, none introduced)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

