### PR TITLE
refactor(commands): extract shared embedding core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Anthropic models are now discovered live from `GET https://api.anthropic.com/v1/models` (paginated) instead of a hardcoded claude-3-era list — the code comment claiming "Anthropic doesn't have a model listing API" was wrong. A refreshed static list (current Claude 4.x/5 aliases) remains as a fallback when the API call fails, and the credential-based discovery path (`discover_with_config`) uses the same live-with-fallback logic
+- Deduplicated the embedding commands (`commands/embedding_commands.py`, ~100 lines less): `embed_note`/`embed_insight`/`embed_source` now share one load→embed→write core with a single error-handling epilogue, the rebuild command uses one submission-loop helper for all three kinds, and the thrice-copied `full_model_dump()` moved to `open_notebook/utils/model_utils.py`. Pure refactor — same outputs, logs and retry behavior
 
 ### Removed
 - Dead Streamlit-era service layer (~2,000 lines): `api/client.py` (a synchronous HTTP client that called the app's own API) and 13 `api/*_service.py` wrappers that consumed the app's own HTTP API — none were imported by any router, command or test. Also removed the toy `process_text`/`analyze_data` demo commands (`commands/example_commands.py`) from the background worker

--- a/commands/embedding_commands.py
+++ b/commands/embedding_commands.py
@@ -1,8 +1,16 @@
 import time
-from typing import Dict, List, Literal, Optional
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+)
 
 from loguru import logger
-from pydantic import BaseModel
 from surreal_commands import CommandInput, CommandOutput, command, submit_command
 
 from open_notebook.ai.models import model_manager
@@ -12,16 +20,21 @@ from open_notebook.exceptions import ConfigurationError
 from open_notebook.utils.chunking import ContentType, chunk_text, detect_content_type
 from open_notebook.utils.embedding import generate_embedding, generate_embeddings
 
-
-def full_model_dump(model):
-    if isinstance(model, BaseModel):
-        return model.model_dump()
-    elif isinstance(model, dict):
-        return {k: full_model_dump(v) for k, v in model.items()}
-    elif isinstance(model, list):
-        return [full_model_dump(item) for item in model]
-    else:
-        return model
+# NOTE: `stop_on` below can never trigger in practice — each command catches
+# ValueError internally and returns success=False instead of raising, so the
+# retry layer never sees it. Kept as-is on purpose; to be revisited in a
+# dedicated error-handling PR.
+EMBED_RETRY_CONFIG = {
+    "max_attempts": 5,
+    "wait_strategy": "exponential_jitter",
+    "wait_min": 1,
+    "wait_max": 60,
+    "stop_on": [
+        ValueError,
+        ConfigurationError,
+    ],  # Don't retry validation/config errors
+    "retry_log_level": "debug",
+}
 
 
 def get_command_id(input_data: CommandInput) -> str:
@@ -29,6 +42,96 @@ def get_command_id(input_data: CommandInput) -> str:
     if input_data.execution_context:
         return str(input_data.execution_context.command_id)
     return "unknown"
+
+
+async def _embed_record(
+    input_data: CommandInput,
+    *,
+    kind: str,
+    record_id: str,
+    embed: Callable[[], Awaitable[Tuple[Dict[str, Any], str]]],
+) -> Tuple[Optional[Dict[str, Any]], float, Optional[str]]:
+    """
+    Shared core for the embed_* commands: run the embedding work with the
+    common logging and error-handling epilogue.
+
+    Args:
+        input_data: The command input (used for command_id logging).
+        kind: Record kind for log messages ("note", "insight", "source").
+        record_id: The record being embedded.
+        embed: Async callable doing the actual load/validate/embed/write work.
+            Returns (extra_output_fields, success_log_detail).
+
+    Returns:
+        (extra_output_fields, processing_time, error_message)
+        extra_output_fields is None and error_message is set on permanent
+        (ValueError) failure. Transient failures re-raise so the retry layer
+        can handle them.
+    """
+    start_time = time.time()
+
+    try:
+        logger.info(f"Starting embedding for {kind}: {record_id}")
+
+        extra_fields, log_detail = await embed()
+
+        processing_time = time.time() - start_time
+        logger.info(
+            f"Successfully embedded {kind} {record_id}{log_detail} in {processing_time:.2f}s"
+        )
+        return extra_fields, processing_time, None
+
+    except ValueError as e:
+        # Permanent failure - don't retry
+        processing_time = time.time() - start_time
+        cmd_id = get_command_id(input_data)
+        logger.error(f"Failed to embed {kind} {record_id} (command: {cmd_id}): {e}")
+        return None, processing_time, str(e)
+    except Exception as e:
+        # Transient failure - will be retried (surreal-commands logs final failure)
+        cmd_id = get_command_id(input_data)
+        logger.debug(
+            f"Transient error embedding {kind} {record_id} (command: {cmd_id}): {e}"
+        )
+        raise
+
+
+async def _embed_markdown_record(
+    input_data: CommandInput,
+    *,
+    label: str,
+    record_id: str,
+    loader: Callable[[str], Awaitable[Any]],
+) -> Tuple[Dict[str, Any], str]:
+    """
+    Load a record, validate its content, embed it as markdown and UPSERT the
+    embedding back onto the record. Shared by embed_note and embed_insight.
+    """
+    # 1. Load record
+    record = await loader(record_id)
+    if not record:
+        raise ValueError(f"{label} '{record_id}' not found")
+
+    if not record.content or not record.content.strip():
+        raise ValueError(f"{label} '{record_id}' has no content to embed")
+
+    # 2. Generate embedding (auto-chunks + mean pools if needed)
+    # Notes and insights are typically markdown content
+    cmd_id = get_command_id(input_data)
+    embedding = await generate_embedding(
+        record.content, content_type=ContentType.MARKDOWN, command_id=cmd_id
+    )
+
+    # 3. UPSERT embedding into the record
+    await repo_query(
+        "UPDATE $record_id SET embedding = $embedding",
+        {
+            "record_id": ensure_record_id(record_id),
+            "embedding": embedding,
+        },
+    )
+
+    return {}, ""
 
 
 class RebuildEmbeddingsInput(CommandInput):
@@ -48,11 +151,6 @@ class RebuildEmbeddingsOutput(CommandOutput):
     insights_submitted: int = 0
     processing_time: float
     error_message: Optional[str] = None
-
-
-# =============================================================================
-# NEW EMBEDDING COMMANDS (Phase 3)
-# =============================================================================
 
 
 class CreateInsightInput(CommandInput):
@@ -118,21 +216,7 @@ class EmbedSourceOutput(CommandOutput):
     error_message: Optional[str] = None
 
 
-@command(
-    "embed_note",
-    app="open_notebook",
-    retry={
-        "max_attempts": 5,
-        "wait_strategy": "exponential_jitter",
-        "wait_min": 1,
-        "wait_max": 60,
-        "stop_on": [
-            ValueError,
-            ConfigurationError,
-        ],  # Don't retry validation/config errors
-        "retry_log_level": "debug",
-    },
-)
+@command("embed_note", app="open_notebook", retry=EMBED_RETRY_CONFIG)
 async def embed_note_command(input_data: EmbedNoteInput) -> EmbedNoteOutput:
     """
     Generate and store embedding for a single note.
@@ -150,84 +234,31 @@ async def embed_note_command(input_data: EmbedNoteInput) -> EmbedNoteOutput:
     - Uses exponential-jitter backoff (1-60s)
     - Does NOT retry permanent failures (ValueError for validation errors)
     """
-    start_time = time.time()
 
-    try:
-        logger.info(f"Starting embedding for note: {input_data.note_id}")
-
-        # 1. Load note
-        note = await Note.get(input_data.note_id)
-        if not note:
-            raise ValueError(f"Note '{input_data.note_id}' not found")
-
-        if not note.content or not note.content.strip():
-            raise ValueError(f"Note '{input_data.note_id}' has no content to embed")
-
-        # 2. Generate embedding (auto-chunks + mean pools if needed)
-        # Notes are typically markdown content
-        cmd_id = get_command_id(input_data)
-        embedding = await generate_embedding(
-            note.content, content_type=ContentType.MARKDOWN, command_id=cmd_id
+    async def embed() -> Tuple[Dict[str, Any], str]:
+        return await _embed_markdown_record(
+            input_data,
+            label="Note",
+            record_id=input_data.note_id,
+            loader=Note.get,
         )
 
-        # 3. UPSERT embedding into note record
-        await repo_query(
-            "UPDATE $note_id SET embedding = $embedding",
-            {
-                "note_id": ensure_record_id(input_data.note_id),
-                "embedding": embedding,
-            },
-        )
+    _, processing_time, error_message = await _embed_record(
+        input_data,
+        kind="note",
+        record_id=input_data.note_id,
+        embed=embed,
+    )
 
-        processing_time = time.time() - start_time
-        logger.info(
-            f"Successfully embedded note {input_data.note_id} in {processing_time:.2f}s"
-        )
-
-        return EmbedNoteOutput(
-            success=True,
-            note_id=input_data.note_id,
-            processing_time=processing_time,
-        )
-
-    except ValueError as e:
-        # Permanent failure - don't retry
-        processing_time = time.time() - start_time
-        cmd_id = get_command_id(input_data)
-        logger.error(
-            f"Failed to embed note {input_data.note_id} (command: {cmd_id}): {e}"
-        )
-        return EmbedNoteOutput(
-            success=False,
-            note_id=input_data.note_id,
-            processing_time=processing_time,
-            error_message=str(e),
-        )
-    except Exception as e:
-        # Transient failure - will be retried (surreal-commands logs final failure)
-        cmd_id = get_command_id(input_data)
-        logger.debug(
-            f"Transient error embedding note {input_data.note_id} "
-            f"(command: {cmd_id}): {e}"
-        )
-        raise
+    return EmbedNoteOutput(
+        success=error_message is None,
+        note_id=input_data.note_id,
+        processing_time=processing_time,
+        error_message=error_message,
+    )
 
 
-@command(
-    "embed_insight",
-    app="open_notebook",
-    retry={
-        "max_attempts": 5,
-        "wait_strategy": "exponential_jitter",
-        "wait_min": 1,
-        "wait_max": 60,
-        "stop_on": [
-            ValueError,
-            ConfigurationError,
-        ],  # Don't retry validation/config errors
-        "retry_log_level": "debug",
-    },
-)
+@command("embed_insight", app="open_notebook", retry=EMBED_RETRY_CONFIG)
 async def embed_insight_command(input_data: EmbedInsightInput) -> EmbedInsightOutput:
     """
     Generate and store embedding for a single source insight.
@@ -245,86 +276,31 @@ async def embed_insight_command(input_data: EmbedInsightInput) -> EmbedInsightOu
     - Uses exponential-jitter backoff (1-60s)
     - Does NOT retry permanent failures (ValueError for validation errors)
     """
-    start_time = time.time()
 
-    try:
-        logger.info(f"Starting embedding for insight: {input_data.insight_id}")
-
-        # 1. Load insight
-        insight = await SourceInsight.get(input_data.insight_id)
-        if not insight:
-            raise ValueError(f"Insight '{input_data.insight_id}' not found")
-
-        if not insight.content or not insight.content.strip():
-            raise ValueError(
-                f"Insight '{input_data.insight_id}' has no content to embed"
-            )
-
-        # 2. Generate embedding (auto-chunks + mean pools if needed)
-        # Insights are typically markdown content (generated by LLM)
-        cmd_id = get_command_id(input_data)
-        embedding = await generate_embedding(
-            insight.content, content_type=ContentType.MARKDOWN, command_id=cmd_id
+    async def embed() -> Tuple[Dict[str, Any], str]:
+        return await _embed_markdown_record(
+            input_data,
+            label="Insight",
+            record_id=input_data.insight_id,
+            loader=SourceInsight.get,
         )
 
-        # 3. UPSERT embedding into insight record
-        await repo_query(
-            "UPDATE $insight_id SET embedding = $embedding",
-            {
-                "insight_id": ensure_record_id(input_data.insight_id),
-                "embedding": embedding,
-            },
-        )
+    _, processing_time, error_message = await _embed_record(
+        input_data,
+        kind="insight",
+        record_id=input_data.insight_id,
+        embed=embed,
+    )
 
-        processing_time = time.time() - start_time
-        logger.info(
-            f"Successfully embedded insight {input_data.insight_id} in {processing_time:.2f}s"
-        )
-
-        return EmbedInsightOutput(
-            success=True,
-            insight_id=input_data.insight_id,
-            processing_time=processing_time,
-        )
-
-    except ValueError as e:
-        # Permanent failure - don't retry
-        processing_time = time.time() - start_time
-        cmd_id = get_command_id(input_data)
-        logger.error(
-            f"Failed to embed insight {input_data.insight_id} (command: {cmd_id}): {e}"
-        )
-        return EmbedInsightOutput(
-            success=False,
-            insight_id=input_data.insight_id,
-            processing_time=processing_time,
-            error_message=str(e),
-        )
-    except Exception as e:
-        # Transient failure - will be retried (surreal-commands logs final failure)
-        cmd_id = get_command_id(input_data)
-        logger.debug(
-            f"Transient error embedding insight {input_data.insight_id} "
-            f"(command: {cmd_id}): {e}"
-        )
-        raise
+    return EmbedInsightOutput(
+        success=error_message is None,
+        insight_id=input_data.insight_id,
+        processing_time=processing_time,
+        error_message=error_message,
+    )
 
 
-@command(
-    "embed_source",
-    app="open_notebook",
-    retry={
-        "max_attempts": 5,
-        "wait_strategy": "exponential_jitter",
-        "wait_min": 1,
-        "wait_max": 60,
-        "stop_on": [
-            ValueError,
-            ConfigurationError,
-        ],  # Don't retry validation/config errors
-        "retry_log_level": "debug",
-    },
-)
+@command("embed_source", app="open_notebook", retry=EMBED_RETRY_CONFIG)
 async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutput:
     """
     Generate and store embeddings for a source document.
@@ -345,11 +321,8 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
     - Uses exponential-jitter backoff (1-60s)
     - Does NOT retry permanent failures (ValueError for validation errors)
     """
-    start_time = time.time()
 
-    try:
-        logger.info(f"Starting embedding for source: {input_data.source_id}")
-
+    async def embed() -> Tuple[Dict[str, Any], str]:
         # 1. Load source
         source = await Source.get(input_data.source_id)
         if not source:
@@ -412,58 +385,25 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
         logger.debug(f"Inserting {len(records)} source_embedding records")
         await repo_insert("source_embedding", records)
 
-        processing_time = time.time() - start_time
-        logger.info(
-            f"Successfully embedded source {input_data.source_id}: "
-            f"{total_chunks} chunks in {processing_time:.2f}s"
-        )
+        return {"chunks_created": total_chunks}, f": {total_chunks} chunks"
 
-        return EmbedSourceOutput(
-            success=True,
-            source_id=input_data.source_id,
-            chunks_created=total_chunks,
-            processing_time=processing_time,
-        )
+    extra_fields, processing_time, error_message = await _embed_record(
+        input_data,
+        kind="source",
+        record_id=input_data.source_id,
+        embed=embed,
+    )
 
-    except ValueError as e:
-        # Permanent failure - don't retry
-        processing_time = time.time() - start_time
-        cmd_id = get_command_id(input_data)
-        logger.error(
-            f"Failed to embed source {input_data.source_id} (command: {cmd_id}): {e}"
-        )
-        return EmbedSourceOutput(
-            success=False,
-            source_id=input_data.source_id,
-            chunks_created=0,
-            processing_time=processing_time,
-            error_message=str(e),
-        )
-    except Exception as e:
-        # Transient failure - will be retried (surreal-commands logs final failure)
-        cmd_id = get_command_id(input_data)
-        logger.debug(
-            f"Transient error embedding source {input_data.source_id} "
-            f"(command: {cmd_id}): {e}"
-        )
-        raise
+    return EmbedSourceOutput(
+        success=error_message is None,
+        source_id=input_data.source_id,
+        chunks_created=(extra_fields or {}).get("chunks_created", 0),
+        processing_time=processing_time,
+        error_message=error_message,
+    )
 
 
-@command(
-    "create_insight",
-    app="open_notebook",
-    retry={
-        "max_attempts": 5,
-        "wait_strategy": "exponential_jitter",
-        "wait_min": 1,
-        "wait_max": 60,
-        "stop_on": [
-            ValueError,
-            ConfigurationError,
-        ],  # Don't retry validation/config errors
-        "retry_log_level": "debug",
-    },
-)
+@command("create_insight", app="open_notebook", retry=EMBED_RETRY_CONFIG)
 async def create_insight_command(
     input_data: CreateInsightInput,
 ) -> CreateInsightOutput:
@@ -631,6 +571,37 @@ async def collect_items_for_rebuild(
     return items
 
 
+def _submit_embedding_jobs(
+    kind: str, command_name: str, id_field: str, item_ids: List[str]
+) -> Tuple[int, int]:
+    """
+    Submit one embedding command per item, logging progress every 50 items.
+
+    Returns:
+        (submitted_count, failed_count)
+    """
+    logger.info(f"\nSubmitting {len(item_ids)} {kind} embedding jobs...")
+    submitted = 0
+    failed = 0
+    for idx, item_id in enumerate(item_ids, 1):
+        try:
+            submit_command(
+                "open_notebook",
+                command_name,
+                {id_field: item_id},
+            )
+            submitted += 1
+
+            if idx % 50 == 0 or idx == len(item_ids):
+                logger.info(f"  Progress: {idx}/{len(item_ids)} {kind} jobs submitted")
+
+        except Exception as e:
+            logger.error(f"Failed to submit {command_name} for {item_id}: {e}")
+            failed += 1
+
+    return submitted, failed
+
+
 @command("rebuild_embeddings", app="open_notebook", retry=None)
 async def rebuild_embeddings_command(
     input_data: RebuildEmbeddingsInput,
@@ -693,71 +664,17 @@ async def rebuild_embeddings_command(
                 processing_time=time.time() - start_time,
             )
 
-        # Initialize counters
-        sources_submitted = 0
-        notes_submitted = 0
-        insights_submitted = 0
-        failed_submissions = 0
-
-        # Submit embed_source commands for sources
-        logger.info(f"\nSubmitting {len(items['sources'])} source embedding jobs...")
-        for idx, source_id in enumerate(items["sources"], 1):
-            try:
-                submit_command(
-                    "open_notebook",
-                    "embed_source",
-                    {"source_id": source_id},
-                )
-                sources_submitted += 1
-
-                if idx % 50 == 0 or idx == len(items["sources"]):
-                    logger.info(
-                        f"  Progress: {idx}/{len(items['sources'])} source jobs submitted"
-                    )
-
-            except Exception as e:
-                logger.error(f"Failed to submit embed_source for {source_id}: {e}")
-                failed_submissions += 1
-
-        # Submit embed_note commands for notes
-        logger.info(f"\nSubmitting {len(items['notes'])} note embedding jobs...")
-        for idx, note_id in enumerate(items["notes"], 1):
-            try:
-                submit_command(
-                    "open_notebook",
-                    "embed_note",
-                    {"note_id": note_id},
-                )
-                notes_submitted += 1
-
-                if idx % 50 == 0 or idx == len(items["notes"]):
-                    logger.info(
-                        f"  Progress: {idx}/{len(items['notes'])} note jobs submitted"
-                    )
-
-            except Exception as e:
-                logger.error(f"Failed to submit embed_note for {note_id}: {e}")
-                failed_submissions += 1
-
-        # Submit embed_insight commands for insights
-        logger.info(f"\nSubmitting {len(items['insights'])} insight embedding jobs...")
-        for idx, insight_id in enumerate(items["insights"], 1):
-            try:
-                submit_command(
-                    "open_notebook",
-                    "embed_insight",
-                    {"insight_id": insight_id},
-                )
-                insights_submitted += 1
-
-                if idx % 50 == 0 or idx == len(items["insights"]):
-                    logger.info(
-                        f"  Progress: {idx}/{len(items['insights'])} insight jobs submitted"
-                    )
-
-            except Exception as e:
-                logger.error(f"Failed to submit embed_insight for {insight_id}: {e}")
-                failed_submissions += 1
+        # Submit one embedding command per item, per kind
+        sources_submitted, sources_failed = _submit_embedding_jobs(
+            "source", "embed_source", "source_id", items["sources"]
+        )
+        notes_submitted, notes_failed = _submit_embedding_jobs(
+            "note", "embed_note", "note_id", items["notes"]
+        )
+        insights_submitted, insights_failed = _submit_embedding_jobs(
+            "insight", "embed_insight", "insight_id", items["insights"]
+        )
+        failed_submissions = sources_failed + notes_failed + insights_failed
 
         processing_time = time.time() - start_time
         jobs_submitted = sources_submitted + notes_submitted + insights_submitted

--- a/commands/podcast_commands.py
+++ b/commands/podcast_commands.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Optional
 
 from loguru import logger
-from pydantic import BaseModel
 from surreal_commands import CommandInput, CommandOutput, command
 
 from open_notebook.config import DATA_FOLDER
@@ -15,6 +14,7 @@ from open_notebook.podcasts.models import (
     SpeakerProfile,
     _resolve_model_config,
 )
+from open_notebook.utils.model_utils import full_model_dump
 
 try:
     from podcast_creator import configure, create_podcast
@@ -35,17 +35,6 @@ def build_episode_output_dir(data_folder: str) -> tuple[str, Path]:
     episode_dir_name = str(uuid.uuid4())
     output_dir = Path(f"{data_folder}/podcasts/episodes/{episode_dir_name}")
     return episode_dir_name, output_dir
-
-
-def full_model_dump(model):
-    if isinstance(model, BaseModel):
-        return model.model_dump()
-    elif isinstance(model, dict):
-        return {k: full_model_dump(v) for k, v in model.items()}
-    elif isinstance(model, list):
-        return [full_model_dump(item) for item in model]
-    else:
-        return model
 
 
 class PodcastGenerationInput(CommandInput):

--- a/commands/source_commands.py
+++ b/commands/source_commands.py
@@ -2,7 +2,6 @@ import time
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
-from pydantic import BaseModel
 from surreal_commands import CommandInput, CommandOutput, command
 
 from open_notebook.database.repository import ensure_record_id
@@ -16,17 +15,6 @@ try:
 except ImportError as e:
     logger.error(f"Failed to import graphs: {e}")
     raise ValueError("graphs not available")
-
-
-def full_model_dump(model):
-    if isinstance(model, BaseModel):
-        return model.model_dump()
-    elif isinstance(model, dict):
-        return {k: full_model_dump(v) for k, v in model.items()}
-    elif isinstance(model, list):
-        return [full_model_dump(item) for item in model]
-    else:
-        return model
 
 
 class SourceProcessingInput(CommandInput):

--- a/open_notebook/utils/__init__.py
+++ b/open_notebook/utils/__init__.py
@@ -26,6 +26,7 @@ from .encryption import (
     decrypt_value,
     encrypt_value,
 )
+from .model_utils import full_model_dump
 from .text_utils import (
     clean_thinking_content,
     parse_thinking_content,
@@ -66,4 +67,6 @@ __all__ = [
     # Encryption utils
     "decrypt_value",
     "encrypt_value",
+    # Model utils
+    "full_model_dump",
 ]

--- a/open_notebook/utils/model_utils.py
+++ b/open_notebook/utils/model_utils.py
@@ -1,0 +1,15 @@
+"""Utilities for working with Pydantic models."""
+
+from pydantic import BaseModel
+
+
+def full_model_dump(model):
+    """Recursively dump Pydantic models nested inside dicts/lists to plain data."""
+    if isinstance(model, BaseModel):
+        return model.model_dump()
+    elif isinstance(model, dict):
+        return {k: full_model_dump(v) for k, v in model.items()}
+    elif isinstance(model, list):
+        return [full_model_dump(item) for item in model]
+    else:
+        return model


### PR DESCRIPTION
## Summary

Deduplicates `commands/embedding_commands.py` (and the thrice-copied `full_model_dump`). Pure refactor — behavior-identical: same outputs, same `success=False` paths, same log messages, same retry configuration.

- **Shared embed core**: `embed_note` / `embed_insight` / `embed_source` were structural clones (load → validate → embed → UPSERT + an identical ~20-line ValueError/Exception epilogue ×3). They now run through one `_embed_record(...)` runner holding the epilogue; note and insight additionally share `_embed_markdown_record(...)` for their identical bodies.
- **Rebuild loop unified**: `rebuild_embeddings_command` submitted jobs via three copy-pasted loops — now one `_submit_embedding_jobs(kind, command_name, id_field, ids)` helper (same progress/error log messages).
- **Shared retry config**: the four embed-family commands reuse a single `EMBED_RETRY_CONFIG` dict. Added a `# NOTE:` marking that `stop_on: [ValueError, ...]` can never trigger today (commands catch ValueError internally and return `success=False`) — intentionally preserved as-is for a future error-handling PR.
- **`full_model_dump()`**: was copy-pasted in `embedding_commands.py`, `podcast_commands.py` and `source_commands.py`, but only `podcast_commands` actually used it. Moved to `open_notebook/utils/model_utils.py` (exported from `open_notebook.utils`), imported in `podcast_commands`; the two dead copies were removed rather than re-imported (F401 is enforced again as of #1062).

Line delta: **+232 / −319** overall; `embedding_commands.py` alone drops from 799 to ~636 lines.

## Verification

- `uv run pytest tests/` — 403 passed
- `ruff check .` — clean; `ruff format` — clean
- `uv run python -m mypy commands/ open_notebook/utils/` — 8 pre-existing errors, identical count and locations as `main` (none in touched lines)
- Import smoke test: `import commands` registers all 8 commands with retry configs identical to main (verified via the surreal-commands registry)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

