### PR TITLE
chore(release): cut v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.12.0] - 2026-07-12
 
 ### Added
 - Docs: cubic platform mechanics recorded as comments in `cubic.yaml` (agent limits, config precedence, memory/learning) and a "Merging PR Batches" playbook added to the maintainer guide (squash policy, CHANGELOG conflict resolution, fork rebases, competing-PR checks) (#1086)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-notebook"
-version = "1.11.0"
+version = "1.12.0"
 description = "An open source implementation of a research assistant, inspired by Google Notebook LM"
 authors = [
     {name = "Luis Novo", email = "lfnovo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -2040,7 +2040,7 @@ wheels = [
 
 [[package]]
 name = "open-notebook"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
Release cut for v1.12.0 — the July 2026 maintainability release.

- Bump `pyproject.toml` to 1.12.0 (+ lockfile version line)
- Date the `[Unreleased]` changelog section as `[1.12.0] - 2026-07-12`

Confidence process results (per `.github/RELEASE_PROCESS.md`):
- Changelog audit: complete (#1088) — all 25 commits since v1.11.0 represented with PR refs
- Bucket A: backend 462 passed / ruff / mypy 0 errors; frontend lint/test/build green
- smoke-e2e: GO — 15/15 API, 7/7 UI, zero console errors (report in `.harness/smoke-report.md`)
- Image gate: 28/28 — fresh install + upgrade from published 1.11.0
- Dependabot: zero open alerts
- Fix loop: empty (no release regressions found)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

