### PR TITLE
test: stop the credential validation test from writing to the live database

### DIFF
--- a/tests/test_credential_provider_validation.py
+++ b/tests/test_credential_provider_validation.py
@@ -188,11 +188,25 @@ class TestCreateCredentialEndpointRejectsBadProvider:
     def test_post_credentials_with_valid_provider_passes_validation(
         self, client, monkeypatch
     ):
-        """Doesn't assert overall success (that needs DB/encryption setup,
-        covered elsewhere) - just that a valid provider clears the 422
-        validation gate and reaches actual route logic."""
+        """Doesn't assert overall success - just that a valid provider clears
+        the 422 validation gate and reaches actual route logic.
+
+        The encryption-key gate is forced to fail so the request never reaches
+        the persistence layer: without this, running the suite with a real
+        `.env` (SURREAL_URL + encryption key set) wrote a "Test" credential to
+        the live dev database on every run.
+        """
+        from api.routers import credentials as credentials_router
+
+        def _no_key():
+            raise ValueError("encryption key intentionally absent in tests")
+
+        monkeypatch.setattr(credentials_router, "require_encryption_key", _no_key)
         response = client.post(
             "/api/credentials",
             json={"name": "Test", "provider": "openai", "api_key": "sk-test"},
         )
+        # Provider validation happens before the route body runs; the forced
+        # key failure maps to a non-422 error, proving validation was cleared
+        # without persisting anything.
         assert response.status_code != 422


### PR DESCRIPTION
Running `uv run pytest tests/` with a normal developer `.env` (real `SURREAL_URL` + `OPEN_NOTEBOOK_ENCRYPTION_KEY`) wrote a `Test` openai credential to the live dev database on every run — `test_post_credentials_with_valid_provider_passes_validation` posts through the real route and the route persisted it. 48 leftover credentials were found (and deleted) in a dev database today.

Fix: monkeypatch `require_encryption_key` to raise, so the request still proves the provider validation gate is cleared (non-422) but can never reach the persistence layer.

Verified: full suite passes (462) and the dev credential count is unchanged after two consecutive full-suite runs against a live `.env`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

