### PR TITLE
docs: record v1.12.0 retro learnings in the release process

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -15,7 +15,10 @@ It was redesigned during the v1.11.0 release ([ADR-005](../docs/7-DEVELOPMENT/de
 - Major releases are planned with a milestone when they include breaking
   changes or migrations that need user coordination.
 - Use the `in-dev-build` label for changes available in development images and
-  `released` for shipped work.
+  `released` for shipped work. (The `released` label was recreated during
+  v1.12.0 — it had been dropped from the curated label taxonomy while this
+  document still required it. If a label this document references is missing,
+  recreate it rather than skipping the step.)
 
 ## Normal Flow
 
@@ -155,3 +158,17 @@ accepted improvements immediately — update this document, the scripts under
   dump — `rc-stack.sh` handles both.
 - **Multiple local SurrealDB instances**: check which one the dev `.env`
   actually points at (`SURREAL_URL`) before exporting data.
+- **Dev-machine ports may belong to other projects**: check who owns
+  3000/5055/8000 (`lsof -nP -iTCP:<port> -sTCP:LISTEN` + the process cwd)
+  before starting or killing anything. The frontend runs fine on an alternate
+  port for smoke testing (`PORT=3001 npm run dev`) — pass the URL to the
+  smoke agent.
+- **Manual error-path checklist items must be validated against the code
+  first**: some "missing configuration" scenarios are deliberate fallbacks,
+  not errors (e.g. transformation and tools defaults fall back to the chat
+  default). Confirm the expected behavior in the provisioning code before
+  putting "should show an error" on the bucket-C checklist.
+- **The test suite runs against the live dev database** when a developer
+  `.env` is loaded. During bucket A, snapshot record counts per table before
+  and after the suite (e.g. credentials count) — a diff means a test is
+  leaking writes (this caught 48 leaked `Test` credentials in v1.12.0).


### PR DESCRIPTION
Retro output from the v1.12.0 release run, applied while fresh (per the process's own Retro section):

- **Known Gotchas** gains three entries learned this run: dev-machine ports may belong to other projects (check ownership before starting/killing; frontend smoke-tests fine on `PORT=3001`); error-path checklist items must be validated against the provisioning fallback code first (transformation/tools deliberately fall back to the chat default); and a dev-DB record-count diff during bucket A catches tests leaking writes (caught 48 leaked credentials this run, fixed in #1090).
- The `released` label had been dropped from the label taxonomy while the process still mandates it — recreated during this release; the doc now says to recreate rather than skip.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

