### PR TITLE
docs: record ADR-006 — migration granularity follows merge granularity

### DIFF
--- a/docs/7-DEVELOPMENT/change-playbooks.md
+++ b/docs/7-DEVELOPMENT/change-playbooks.md
@@ -122,6 +122,7 @@ Step-by-step guides for common types of changes in the Open Notebook codebase. E
 **Important:**
 - Migrations are numbered and run in order
 - They're tracked in the `_sbl_migrations` table — won't re-run
+- One migration per PR that needs one, numbered in merge order; never consolidate after a migration lands on main (dev images apply it immediately) — see [ADR-006](decisions/ADR-006-migration-granularity.md)
 - For destructive changes (DROP FIELD), consider data preservation
 - Test with existing data, not just empty database
 

--- a/docs/7-DEVELOPMENT/decisions/ADR-006-migration-granularity.md
+++ b/docs/7-DEVELOPMENT/decisions/ADR-006-migration-granularity.md
@@ -1,0 +1,35 @@
+# ADR-006: Migration granularity follows merge granularity, not release granularity
+
+- **Status**: Accepted
+- **Date**: 2026-07
+- **Related**: #1085 (first case decided under this policy), #1031 (surreal-basics migration runner — policy carries over), [change-playbooks.md](../change-playbooks.md) (Database Migration playbook)
+
+## Context
+
+Multiple issues in the same release cycle can each need a schema migration. The intuitive worry: merging them one by one produces several small migrations (19, 20, 21, 22…) inside a single release, which "feels" messier than one consolidated migration per release.
+
+Two facts about this project shape the decision:
+
+1. Migrations run **automatically at API startup**, in sequence, tracked in `_sbl_migrations`. Users upgrading across any version span run all pending migrations transparently — they never see the count.
+2. A `v1-dev` image is published on **every push to main**. A migration is therefore effectively *released the moment it lands on main* — dev-image users apply it immediately, before any versioned release exists.
+
+## Decision
+
+**One migration per PR that needs one; numbers allocated in merge order; never consolidate after a migration has touched main.**
+
+- Each migration lives in the PR that motivates it, with its `_down` counterpart, reviewed together with the code that requires it.
+- Multiple small migrations per release is the normal, healthy state — not a smell.
+- Consolidation is only allowed **before merge**, as a development-time choice: when two in-flight PRs touch the *same table*, coordinate them (stack the PRs, or fold the schema change into the first one to land).
+- Branch protection's strict mode makes number collisions between parallel PRs surface as a required update-branch before merge; renumbering is part of that rebase.
+
+## Alternatives considered
+
+- **One consolidated migration per release** — rejected: post-hoc squashing breaks every `v1-dev` user whose `_sbl_migrations` already recorded the individual migrations, and it decouples schema changes from the PRs that explain them.
+- **Batch migrations in a release branch** — rejected for the same dev-image reason, plus it would hold merged features hostage to release timing.
+
+## Consequences
+
+- Release notes may list several migrations; that is an implementation detail, not a user-facing cost.
+- Debugging stays cheap: "migration 21 broke it" is bisectable; a slice of a consolidated release migration is not.
+- If parallel batches make number collisions frequent, add a cheap CI check (duplicate or gapped numbers fail the build).
+- When the migration runner moves to surreal-basics (#1031), this policy transfers unchanged — it is about granularity and immutability-after-main, not about the runner.

--- a/docs/7-DEVELOPMENT/decisions/README.md
+++ b/docs/7-DEVELOPMENT/decisions/README.md
@@ -46,5 +46,7 @@ What this makes easier, what it makes harder, what to watch. (bullets)
 | [ADR-002](ADR-002-external-libraries.md) | Delegate platform/media support to focused external libraries | Accepted |
 | [ADR-003](ADR-003-streamlit-to-nextjs.md) | Migrate the UI from Streamlit to Next.js | Accepted |
 | [ADR-004](ADR-004-background-workers.md) | Long-running work runs on background workers | Accepted |
+| [ADR-005](ADR-005-release-confidence-process.md) | Releases pass a risk-based confidence process, gated on the real image | Accepted |
+| [ADR-006](ADR-006-migration-granularity.md) | Migration granularity follows merge granularity, not release granularity | Accepted |
 | [PDR-001](PDR-001-single-user-first.md) | Single-user first; don't preclude multi-user | Accepted |
 | [PDR-002](PDR-002-provider-agnostic-core.md) | Provider-agnostic core by default | Accepted |


### PR DESCRIPTION
Documents the migration policy discussed today, prompted by PR #1085's migration-19 question:

- **One migration per PR that needs one**, reviewed with the code that motivates it, with its `_down` counterpart
- **Numbers allocated in merge order** — strict mode surfaces collisions between parallel PRs as a required update-branch
- **Never consolidate after a migration lands on main**: `v1-dev` images publish on every push, so a migration is effectively released when merged — post-hoc squashing would desync `_sbl_migrations` for dev-image users
- Consolidation is a **development-time** choice only, when in-flight PRs touch the same table

Also cross-references the ADR from the Database Migration playbook and adds the missing ADR-005 row to the decisions index.

## Testing
- `scripts/check_md_links.py` passes (all relative links resolve)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

