### PR TITLE
chore(deps): consolidate dev tooling so plain uv sync provides mypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
         run: uv python install
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync
 
       - name: Run mypy
         run: uv run python -m mypy .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `uv sync` alone now provides the full dev toolchain: the legacy `[project.optional-dependencies].dev` list was merged into `[dependency-groups].dev` (mypy included — the documented `uv run python -m mypy .` previously failed on a fresh clone), Jupyter-only packages moved to a separate `notebooks` group, and the CI typecheck job no longer needs `--extra dev` (#1101)
 - Optional model defaults (transformation, tools, large context, TTS, STT) can now be cleared: `PUT /api/models/defaults` honors explicit `null` (field absent still means "keep"; chat and embedding defaults reject `null`), and the default-model selects offer a "None" / "Use fallback (chat default)" option for the optional defaults (#1091)
 - `docker-compose.yml` now uses the YAML list (exec) form for the SurrealDB `command`, so `SURREAL_USER` / `SURREAL_PASSWORD` values containing spaces are passed as single arguments instead of being split; the mirrored snippets in the installation docs and README (which had drifted — no credential interpolation, SurrealDB port published on all interfaces) are back in sync with the shipped file (#1093)
 - zh-CN and zh-TW podcast toast descriptions (speaker/episode profile created/updated/deleted/duplicated) now include the profile name via the `{{name}}` placeholder, matching the other 12 locales (#1084)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,28 +55,23 @@ package-dir = {"open_notebook" = "open_notebook"}
 open_notebook = ["ai/assets/*"]
 
 
-[project.optional-dependencies]
-dev = [
-    "ipykernel>=6.29.5",
-    "ruff>=0.5.5",
-    "mypy>=1.11.1",
-    "types-requests>=2.32.0.20241016",
-    "ipywidgets>=8.1.5",
-    "pre-commit>=4.0.1",
-    "pytest>=9.0.3",
-]
-
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = [
+    "mypy>=1.11.1",
     "pre-commit>=4.1.0",
+    "pytest>=9.0.3",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.14.13",
     "types-requests>=2.32.4.20250913",
+]
+notebooks = [
+    "ipykernel>=6.29.5",
+    "ipywidgets>=8.1.5",
 ]
 
 [tool.isort]

--- a/uv.lock
+++ b/uv.lock
@@ -2073,24 +2073,19 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
-    { name = "ruff" },
-    { name = "types-requests" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-requests" },
+]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
 ]
 
 [package.metadata]
@@ -2101,8 +2096,6 @@ requires-dist = [
     { name = "esperanto", specifier = ">=2.20.0,<3" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
-    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
-    { name = "ipywidgets", marker = "extra == 'dev'", specifier = ">=8.1.5" },
     { name = "langchain", specifier = ">=1.3.9,<2" },
     { name = "langchain-anthropic", specifier = ">=1.4.6,<2" },
     { name = "langchain-core", specifier = ">=1.4.6,<2" },
@@ -2115,31 +2108,31 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.5,<2" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.1,<4" },
     { name = "loguru", specifier = ">=0.7.2" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.1" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "podcast-creator", specifier = ">=0.12.0,<1" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1" },
     { name = "pycountry", specifier = ">=26.2.16" },
     { name = "pydantic", specifier = ">=2.9.2" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.5" },
     { name = "surreal-commands", specifier = ">=1.3.1,<2" },
     { name = "surrealdb", specifier = ">=1.0.4" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "tomli", specifier = ">=2.0.2" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.20241016" },
     { name = "uvicorn", specifier = ">=0.24.0" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.11.1" },
     { name = "pre-commit", specifier = ">=4.1.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
+]
+notebooks = [
+    { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "ipywidgets", specifier = ">=8.1.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
Found while verifying PR #1085 locally: the documented dev command `uv run python -m mypy .` fails on a fresh clone.

**Root cause**: the dev toolchain drifted across two lists — the legacy `[project.optional-dependencies].dev` (mypy, ipykernel/ipywidgets, stale pins) and the modern `[dependency-groups].dev` (pytest plugins, current pins). Plain `uv sync` installs only the dependency group, so mypy was never available locally; CI's typecheck job masked the gap with `uv sync --extra dev`.

**Change**:
- Merge mypy and pytest into `[dependency-groups].dev` (single source of truth)
- Move Jupyter-only packages (ipykernel, ipywidgets) to a non-default `notebooks` group — they were only used by the exploration notebooks, not by any code path
- Delete the legacy `[project.optional-dependencies].dev`
- CI typecheck job: `uv sync --extra dev` → `uv sync` (only reference to the legacy extras in the repo)
- `uv lock` refreshed

## Testing
- Fresh `uv sync` → `uv run python -m mypy .` works: 0 errors in 119 files
- `uv run pytest tests/` 469 passed; `ruff check .` clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

