### PR TITLE
fix(frontend): shared "content no longer exists" state for orphan references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Clicking a chat/Ask citation that points at a deleted source, insight, or note now shows a shared, friendly "this content no longer exists" state in all three dialogs (instead of a raw error, a blank dialog, or an empty editable note editor), 404 lookups are no longer retried, and non-404 failures show a distinct "unable to load" message (#455)
 - Source insights now get `created`/`updated` timestamps stamped at creation (migration 19 mirrors the defaults used by the other tables), and the insights API returns `null` — instead of the literal string `"None"` — for legacy insights that predate the migration (#1045)
 - `uv sync` alone now provides the full dev toolchain: the legacy `[project.optional-dependencies].dev` list was merged into `[dependency-groups].dev` (mypy included — the documented `uv run python -m mypy .` previously failed on a fresh clone), Jupyter-only packages moved to a separate `notebooks` group, and the CI typecheck job no longer needs `--extra dev` (#1101)
 - Optional model defaults (transformation, tools, large context, TTS, STT) can now be cleared: `PUT /api/models/defaults` honors explicit `null` (field absent still means "keep"; chat and embedding defaults reject `null`), and the default-model selects offer a "None" / "Use fallback (chat default)" option for the optional defaults (#1091)

--- a/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NoteEditorDialog } from './NoteEditorDialog'
+import { useNote } from '@/lib/hooks/use-notes'
+
+// useTranslation is mocked globally in setup.ts (t returns the key string)
+
+vi.mock('@/lib/hooks/use-notes', () => ({
+  useNote: vi.fn(),
+  useCreateNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useUpdateNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}))
+
+vi.mock('@/components/ui/markdown-editor', () => ({
+  MarkdownEditor: ({ value }: { value: string }) => (
+    <textarea data-testid="markdown-editor" defaultValue={value} />
+  ),
+}))
+
+const mockUseNote = vi.mocked(useNote)
+
+const notFoundError = Object.assign(new Error('Request failed with status code 404'), {
+  isAxiosError: true,
+  response: { status: 404 },
+})
+
+const networkError = Object.assign(new Error('Network Error'), {
+  isAxiosError: true,
+  response: undefined,
+})
+
+type UseNoteResult = ReturnType<typeof useNote>
+
+const asResult = (value: Partial<UseNoteResult>) => value as UseNoteResult
+
+function renderDialog(props: Partial<Parameters<typeof NoteEditorDialog>[0]> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NoteEditorDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        notebookId=""
+        note={{ id: 'note-1', title: null, content: null }}
+        {...props}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe('NoteEditorDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the shared not-found state instead of the editor when the note returns 404', () => {
+    mockUseNote.mockReturnValue(
+      asResult({ data: undefined, isLoading: false, isError: true, error: notFoundError })
+    )
+
+    renderDialog()
+
+    expect(screen.getByTestId('content-unavailable')).toBeInTheDocument()
+    expect(screen.getByText('common.contentUnavailable.notFoundTitle')).toBeInTheDocument()
+    // The editor is gated: no ghost editing or saving
+    expect(screen.queryByTestId('markdown-editor')).not.toBeInTheDocument()
+    expect(screen.queryByText('sources.saveNote')).not.toBeInTheDocument()
+  })
+
+  it('shows the shared load-error state for non-404 failures', () => {
+    mockUseNote.mockReturnValue(
+      asResult({ data: undefined, isLoading: false, isError: true, error: networkError })
+    )
+
+    renderDialog()
+
+    expect(screen.getByText('common.contentUnavailable.errorTitle')).toBeInTheDocument()
+    expect(screen.queryByTestId('markdown-editor')).not.toBeInTheDocument()
+  })
+
+  it('closes the dialog from the not-found state close button', () => {
+    mockUseNote.mockReturnValue(
+      asResult({ data: undefined, isLoading: false, isError: true, error: notFoundError })
+    )
+    const onOpenChange = vi.fn()
+
+    renderDialog({ onOpenChange })
+
+    within(screen.getByTestId('content-unavailable')).getByText('common.close').click()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('renders the editor when the note loads successfully', () => {
+    mockUseNote.mockReturnValue(
+      asResult({
+        data: {
+          id: 'note-1',
+          title: 'My note',
+          content: 'Note body',
+          note_type: 'human',
+          created: '2026-01-01T00:00:00Z',
+          updated: '2026-01-01T00:00:00Z',
+        } as UseNoteResult['data'],
+        isLoading: false,
+        isError: false,
+        error: null,
+      })
+    )
+
+    renderDialog()
+
+    expect(screen.getByTestId('markdown-editor')).toBeInTheDocument()
+    expect(screen.getByText('sources.saveNote')).toBeInTheDocument()
+    expect(screen.queryByTestId('content-unavailable')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
@@ -13,6 +13,8 @@ import { MarkdownEditor } from '@/components/ui/markdown-editor'
 import { InlineEdit } from '@/components/common/InlineEdit'
 import { cn } from "@/lib/utils";
 import { useTranslation } from '@/lib/hooks/use-translation'
+import { ContentUnavailable } from '@/components/common/ContentUnavailable'
+import { isNotFoundError } from '@/lib/utils/error-handler'
 
 const createNoteSchema = z.object({
   title: z.string().optional(),
@@ -40,7 +42,16 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
     ? (note.id.includes(':') ? note.id : `note:${note.id}`)
     : ''
 
-  const { data: fetchedNote, isLoading: noteLoading } = useNote(noteIdWithPrefix, { enabled: open && !!note?.id })
+  const {
+    data: fetchedNote,
+    isLoading: noteLoading,
+    isError: noteError,
+    error: noteFetchError,
+  } = useNote(noteIdWithPrefix, { enabled: open && !!note?.id })
+  // When editing, a failed fetch means we must not render the editor: the
+  // note may have been deleted (dangling chat/ask references) and offering
+  // an empty editor would invite ghost edits.
+  const noteUnavailable = isEditing && noteError
   const isSaving = isEditing ? updateNote.isPending : createNote.isPending
   const {
     handleSubmit,
@@ -126,6 +137,12 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
         <DialogTitle className="sr-only">
           {isEditing ? t('sources.editNote') : t('sources.createNote')}
         </DialogTitle>
+        {noteUnavailable ? (
+          <ContentUnavailable
+            variant={isNotFoundError(noteFetchError) ? 'not-found' : 'error'}
+            onClose={handleClose}
+          />
+        ) : (
         <form onSubmit={handleSubmit(onSubmit)} className="flex flex-1 min-h-0 flex-col min-w-0">
           {isEditing && noteLoading ? (
             <div className="flex-1 flex items-center justify-center py-10">
@@ -191,6 +208,7 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
             </Button>
           </div>
         </form>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/app/(dashboard)/sources/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/sources/[id]/page.tsx
@@ -44,6 +44,7 @@ export default function SourceDetailPage() {
         {/* Left column - Source detail */}
         <div className="overflow-y-auto px-4 pb-6">
           <SourceDetailContent
+            key={sourceId}
             sourceId={sourceId}
             showChatButton={false}
             onClose={handleBack}

--- a/frontend/src/components/common/ContentUnavailable.tsx
+++ b/frontend/src/components/common/ContentUnavailable.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { AlertCircle, FileQuestion } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/common/EmptyState'
+import { useTranslation } from '@/lib/hooks/use-translation'
+
+interface ContentUnavailableProps {
+  /**
+   * 'not-found' — the item was deleted or no longer exists (HTTP 404).
+   * 'error' — the item could not be loaded (network/server failure).
+   */
+  variant: 'not-found' | 'error'
+  onClose?: () => void
+}
+
+/**
+ * Shared friendly state for content that cannot be displayed.
+ *
+ * Used by the source, note and insight dialogs so that dangling references
+ * (e.g. citations in old chat messages pointing at deleted items) render the
+ * exact same explanation everywhere instead of a blank dialog or a raw error.
+ */
+export function ContentUnavailable({ variant, onClose }: ContentUnavailableProps) {
+  const { t } = useTranslation()
+  const notFound = variant === 'not-found'
+
+  return (
+    <div
+      className="flex h-full flex-col justify-center px-6"
+      data-testid="content-unavailable"
+    >
+      <EmptyState
+        icon={notFound ? FileQuestion : AlertCircle}
+        title={
+          notFound
+            ? t('common.contentUnavailable.notFoundTitle')
+            : t('common.contentUnavailable.errorTitle')
+        }
+        description={
+          notFound
+            ? t('common.contentUnavailable.notFoundDescription')
+            : t('common.contentUnavailable.errorDescription')
+        }
+        action={
+          onClose && (
+            <Button variant="outline" size="sm" onClick={onClose}>
+              {t('common.close')}
+            </Button>
+          )
+        }
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/sources/SourceDetailContent.test.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SourceDetailContent } from './SourceDetailContent'
+import { sourcesApi } from '@/lib/api/sources'
+
+// useTranslation is mocked globally in setup.ts (t returns the key string)
+
+vi.mock('@/lib/api/sources', () => ({
+  sourcesApi: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/api/insights', () => ({
+  insightsApi: {
+    listForSource: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+vi.mock('@/lib/api/transformations', () => ({
+  transformationsApi: {
+    list: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+vi.mock('@/lib/api/embedding', () => ({
+  embeddingApi: {
+    embedSource: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/sources/SourceInsightDialog', () => ({
+  SourceInsightDialog: () => null,
+}))
+
+vi.mock('@/components/sources/NotebookAssociations', () => ({
+  NotebookAssociations: () => null,
+}))
+
+const mockSourcesGet = vi.mocked(sourcesApi.get)
+
+const notFoundError = Object.assign(new Error('Request failed with status code 404'), {
+  isAxiosError: true,
+  response: { status: 404 },
+})
+
+const networkError = Object.assign(new Error('Network Error'), {
+  isAxiosError: true,
+  response: undefined,
+})
+
+function renderContent(onClose?: () => void) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SourceDetailContent sourceId="source:missing" onClose={onClose} />
+    </QueryClientProvider>
+  )
+}
+
+describe('SourceDetailContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the shared not-found state when the source returns 404', async () => {
+    mockSourcesGet.mockRejectedValue(notFoundError)
+
+    renderContent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-unavailable')).toBeInTheDocument()
+    })
+    expect(screen.getByText('common.contentUnavailable.notFoundTitle')).toBeInTheDocument()
+    expect(screen.getByText('common.contentUnavailable.notFoundDescription')).toBeInTheDocument()
+  })
+
+  it('shows the shared load-error state for non-404 failures', async () => {
+    mockSourcesGet.mockRejectedValue(networkError)
+
+    renderContent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-unavailable')).toBeInTheDocument()
+    })
+    expect(screen.getByText('common.contentUnavailable.errorTitle')).toBeInTheDocument()
+    expect(
+      screen.queryByText('common.contentUnavailable.notFoundTitle')
+    ).not.toBeInTheDocument()
+  })
+
+  it('invokes onClose from the not-found close button', async () => {
+    mockSourcesGet.mockRejectedValue(notFoundError)
+    const onClose = vi.fn()
+
+    renderContent(onClose)
+
+    await waitFor(() => {
+      expect(screen.getByText('common.close')).toBeInTheDocument()
+    })
+    screen.getByText('common.close').click()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/sources/SourceDetailContent.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { isAxiosError } from 'axios'
 import { MarkdownRenderer } from '@/components/ui/markdown-renderer'
 import { sourcesApi } from '@/lib/api/sources'
 import { insightsApi, SourceInsightResponse } from '@/lib/api/insights'
@@ -11,6 +10,8 @@ import { embeddingApi } from '@/lib/api/embedding'
 import { SourceDetailResponse } from '@/lib/types/api'
 import { Transformation } from '@/lib/types/transformations'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
+import { ContentUnavailable } from '@/components/common/ContentUnavailable'
+import { isNotFoundError } from '@/lib/utils/error-handler'
 import { InlineEdit } from '@/components/common/InlineEdit'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -100,7 +101,7 @@ export function SourceDetailContent({
   const [loading, setLoading] = useState(true)
   const [loadingInsights, setLoadingInsights] = useState(false)
   const [creatingInsight, setCreatingInsight] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [loadError, setLoadError] = useState<'not-found' | 'error' | null>(null)
   const [copied, setCopied] = useState(false)
   const [isEmbedding, setIsEmbedding] = useState(false)
   const [isDownloadingFile, setIsDownloadingFile] = useState(false)
@@ -112,6 +113,7 @@ export function SourceDetailContent({
   const fetchSource = useCallback(async () => {
     try {
       setLoading(true)
+      setLoadError(null)
       const data = await sourcesApi.get(sourceId)
       setSource(data)
       if (typeof data.file_available === 'boolean') {
@@ -123,11 +125,13 @@ export function SourceDetailContent({
       }
     } catch (err) {
       console.error('Failed to fetch source:', err)
-      setError(t('sources.loadFailed'))
+      // A 404 means the source was deleted (e.g. a dangling chat/ask
+      // reference) — handled by the shared "content no longer exists" state.
+      setLoadError(isNotFoundError(err) ? 'not-found' : 'error')
     } finally {
       setLoading(false)
     }
-  }, [sourceId, t])
+  }, [sourceId])
 
   const fetchInsights = useCallback(async () => {
     try {
@@ -301,7 +305,7 @@ export function SourceDetailContent({
       toast.success(t('common.success'))
     } catch (err) {
       console.error('Failed to download file:', err)
-      if (isAxiosError(err) && err.response?.status === 404) {
+      if (isNotFoundError(err)) {
         setFileAvailable(false)
         toast.error(t('sources.fileUnavailable'))
       } else {
@@ -389,11 +393,12 @@ export function SourceDetailContent({
     )
   }
 
-  if (error || !source) {
+  if (loadError || !source) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
-        <p className="text-red-500">{error || t('sources.notFound')}</p>
-      </div>
+      <ContentUnavailable
+        variant={loadError ?? 'error'}
+        onClose={onClose}
+      />
     )
   }
 

--- a/frontend/src/components/sources/SourceDialog.tsx
+++ b/frontend/src/components/sources/SourceDialog.tsx
@@ -48,7 +48,9 @@ export function SourceDialog({ open, onOpenChange, sourceId }: SourceDialogProps
 
         {/* Source detail content */}
         <div className="flex-1 overflow-y-auto min-h-0">
+          {/* Keyed by source so state (loading/not-found) resets per source */}
           <SourceDetailContent
+            key={sourceIdWithPrefix}
             sourceId={sourceIdWithPrefix}
             showChatButton={true}
             onChatClick={handleChatClick}

--- a/frontend/src/components/sources/SourceInsightDialog.test.tsx
+++ b/frontend/src/components/sources/SourceInsightDialog.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SourceInsightDialog } from './SourceInsightDialog'
+import { useInsight } from '@/lib/hooks/use-insights'
+
+// useTranslation is mocked globally in setup.ts (t returns the key string)
+
+vi.mock('@/lib/hooks/use-insights', () => ({
+  useInsight: vi.fn(),
+}))
+
+vi.mock('@/lib/hooks/use-modal-manager', () => ({
+  useModalManager: () => ({ openModal: vi.fn() }),
+}))
+
+const mockUseInsight = vi.mocked(useInsight)
+
+const notFoundError = Object.assign(new Error('Request failed with status code 404'), {
+  isAxiosError: true,
+  response: { status: 404 },
+})
+
+const networkError = Object.assign(new Error('Network Error'), {
+  isAxiosError: true,
+  response: undefined,
+})
+
+type UseInsightResult = ReturnType<typeof useInsight>
+
+const asResult = (value: Partial<UseInsightResult>) => value as UseInsightResult
+
+describe('SourceInsightDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the shared not-found state when the insight returns 404', () => {
+    mockUseInsight.mockReturnValue(
+      asResult({ data: undefined, isLoading: false, isError: true, error: notFoundError })
+    )
+
+    render(
+      <SourceInsightDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        insight={{ id: 'insight-1', insight_type: '', content: '' }}
+      />
+    )
+
+    expect(screen.getByTestId('content-unavailable')).toBeInTheDocument()
+    expect(screen.getByText('common.contentUnavailable.notFoundTitle')).toBeInTheDocument()
+    expect(screen.getByText('common.contentUnavailable.notFoundDescription')).toBeInTheDocument()
+    // No ghost fallback content and no "view source" affordance
+    expect(screen.queryByText('sources.viewSource')).not.toBeInTheDocument()
+  })
+
+  it('shows the shared load-error state for non-404 failures', () => {
+    mockUseInsight.mockReturnValue(
+      asResult({ data: undefined, isLoading: false, isError: true, error: networkError })
+    )
+
+    render(
+      <SourceInsightDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        insight={{ id: 'insight-1', insight_type: '', content: '' }}
+      />
+    )
+
+    expect(screen.getByText('common.contentUnavailable.errorTitle')).toBeInTheDocument()
+    expect(
+      screen.queryByText('common.contentUnavailable.notFoundTitle')
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes the dialog from the not-found state close button', () => {
+    mockUseInsight.mockReturnValue(
+      asResult({ data: undefined, isLoading: false, isError: true, error: notFoundError })
+    )
+    const onOpenChange = vi.fn()
+
+    render(
+      <SourceInsightDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        insight={{ id: 'insight-1', insight_type: '', content: '' }}
+      />
+    )
+
+    within(screen.getByTestId('content-unavailable')).getByText('common.close').click()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('renders the insight content when the fetch succeeds', () => {
+    mockUseInsight.mockReturnValue(
+      asResult({
+        data: {
+          id: 'insight-1',
+          source_id: 'source:1',
+          insight_type: 'summary',
+          content: 'Fetched insight content',
+          created: null,
+          updated: null,
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      })
+    )
+
+    render(
+      <SourceInsightDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        insight={{ id: 'insight-1', insight_type: '', content: '' }}
+      />
+    )
+
+    expect(screen.getByText('Fetched insight content')).toBeInTheDocument()
+    expect(screen.queryByTestId('content-unavailable')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/sources/SourceInsightDialog.tsx
+++ b/frontend/src/components/sources/SourceInsightDialog.tsx
@@ -9,6 +9,8 @@ import {MarkdownRenderer} from '@/components/ui/markdown-renderer'
 import { useInsight } from '@/lib/hooks/use-insights'
 import { useModalManager } from '@/lib/hooks/use-modal-manager'
 import { useTranslation } from '@/lib/hooks/use-translation'
+import { ContentUnavailable } from '@/components/common/ContentUnavailable'
+import { isNotFoundError } from '@/lib/utils/error-handler'
 
 interface SourceInsightDialogProps {
   open: boolean
@@ -34,13 +36,15 @@ export function SourceInsightDialog({ open, onOpenChange, insight, onDelete }: S
     ? (insight.id.includes(':') ? insight.id : `source_insight:${insight.id}`)
     : ''
 
-  const { data: fetchedInsight, isLoading } = useInsight(insightIdWithPrefix, { enabled: open && !!insight?.id })
+  const { data: fetchedInsight, isLoading, isError, error } = useInsight(insightIdWithPrefix, { enabled: open && !!insight?.id })
 
-  // Use fetched data if available, otherwise fall back to passed-in insight
-  const displayInsight = fetchedInsight ?? insight
+  // Use fetched data if available, otherwise fall back to passed-in insight.
+  // On fetch error there is nothing trustworthy to show (the passed-in data
+  // may reference a deleted item), so every derived field goes blank here.
+  const displayInsight = isError ? undefined : (fetchedInsight ?? insight)
 
   // Get source_id from fetched data (preferred) or passed-in insight
-  const sourceId = fetchedInsight?.source_id ?? insight?.source_id
+  const sourceId = displayInsight?.source_id
 
   const handleViewSource = () => {
     if (sourceId) {
@@ -123,6 +127,11 @@ export function SourceInsightDialog({ open, onOpenChange, insight, onDelete }: S
               <div className="flex items-center justify-center py-10">
                 <span className="text-sm text-muted-foreground">{t('common.loading')}</span>
               </div>
+            ) : isError ? (
+              <ContentUnavailable
+                variant={isNotFoundError(error) ? 'not-found' : 'error'}
+                onClose={() => onOpenChange(false)}
+              />
             ) : displayInsight ? (
               <MarkdownRenderer>
                 {displayInsight.content}

--- a/frontend/src/lib/api/query-client.ts
+++ b/frontend/src/lib/api/query-client.ts
@@ -1,11 +1,14 @@
 import { QueryClient } from '@tanstack/react-query'
+import { isNotFoundError } from '@/lib/utils/error-handler'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 5 * 60 * 1000, // 5 minutes
       gcTime: 10 * 60 * 1000, // 10 minutes
-      retry: 2,
+      // Retry transient failures, but never retry 404s: the item was
+      // deleted (or never existed) and retrying cannot change that.
+      retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 2,
       refetchOnWindowFocus: false,
     },
     mutations: {

--- a/frontend/src/lib/locales/bn-IN/index.ts
+++ b/frontend/src/lib/locales/bn-IN/index.ts
@@ -111,6 +111,12 @@ export const bnIN = {
     finalAnswer: "চূড়ান্ত উত্তর",
     notebookLabel: "নোটবুক: {{name}}",
     itemNotFound: "এই {{type}} খুঁজে পাওয়া যায়নি",
+    contentUnavailable: {
+      notFoundTitle: "এই কন্টেন্টটি আর নেই",
+      notFoundDescription: "এটি মুছে ফেলা হয়ে থাকতে পারে। পুরনো বার্তার রেফারেন্স ইতিমধ্যে সরিয়ে ফেলা কন্টেন্টের দিকে নির্দেশ করতে পারে।",
+      errorTitle: "এই কন্টেন্ট লোড করা যায়নি",
+      errorDescription: "লোড করার সময় কিছু ভুল হয়েছে। আবার চেষ্টা করুন।",
+    },
     accessibility: {
       transformationViews: "ট্রান্সফরমেশন ভিউ",
       searchKB: "আপনার জ্ঞানভান্ডার জিজ্ঞাসা বা অনুসন্ধান করুন",
@@ -393,7 +399,6 @@ export const bnIN = {
     manageNotebooks: "নোটবুক পরিচালনা করুন",
     manageNotebooksDesc: "এই উৎস কোন নোটবুকে রয়েছে তা পরিচালনা করুন",
     noNotebooksAvailable: "কোন নোটবুক উপলব্ধ নয়",
-    loadFailed: "উৎসের বিবরণ লোড করতে ব্যর্থ",
     removeFromNotebook: "নোটবুক থেকে সরান",
     retryProcessing: "প্রক্রিয়াকরণ পুনরায় চেষ্টা করুন",
     refreshContent: "বিষয়বস্তু রিফ্রেশ করুন",
@@ -421,7 +426,6 @@ export const bnIN = {
     embeddingNever: "এমবেডিং অক্ষম",
     embeddingNeverDesc: "আপনার সেটিংস এমবেডিং এড়িয়ে যাওয়ার জন্য কনফিগার করা। এই উৎসের জন্য ভেক্টর সার্চ উপলব্ধ থাকবে না।",
     changeInSettings: "আপনি এটি সেটিংসে পরিবর্তন করতে পারেন",
-    notFound: "উৎস পাওয়া যায়নি",
     noContent: "কোন কন্টেন্ট উপলব্ধ নয়",
     insightsDesc: "মডেল বিশ্লেষণ থেকে তৈরি অন্তর্দৃষ্টি",
     uploadedFile: "আপলোড করা ফাইল",

--- a/frontend/src/lib/locales/ca-ES/index.ts
+++ b/frontend/src/lib/locales/ca-ES/index.ts
@@ -111,6 +111,12 @@ export const caES = {
     finalAnswer: "Resposta final",
     notebookLabel: "Quadern: {{name}}",
     itemNotFound: "No s'ha pogut trobar aquest {{type}}",
+    contentUnavailable: {
+      notFoundTitle: "Aquest contingut ja no existeix",
+      notFoundDescription: "Pot haver estat eliminat. Les referències en missatges antics poden apuntar a contingut que ja s'ha eliminat.",
+      errorTitle: "No s'ha pogut carregar aquest contingut",
+      errorDescription: "Alguna cosa ha fallat en carregar-lo. Torna-ho a provar.",
+    },
     accessibility: {
       transformationViews: "Vistes de transformació",
       searchKB: "Pregunta o cerca a la base de coneixement",
@@ -393,7 +399,6 @@ export const caES = {
     manageNotebooks: "Gestiona els quaderns",
     manageNotebooksDesc: "Gestiona quins quaderns contenen aquesta font",
     noNotebooksAvailable: "No hi ha quaderns disponibles",
-    loadFailed: "Ha fallat la càrrega dels detalls de la font",
     removeFromNotebook: "Elimina del quadern",
     retryProcessing: "Torna a processar",
     refreshContent: "Actualitza el contingut",
@@ -421,7 +426,6 @@ export const caES = {
     embeddingNever: "La incrustació està desactivada",
     embeddingNeverDesc: "La configuració actual omet la incrustació. La cerca vectorial no estarà disponible per a aquesta font.",
     changeInSettings: "Pots canviar-ho a la Configuració",
-    notFound: "No s'ha trobat la font",
     noContent: "No hi ha contingut disponible",
     insightsDesc: "Anàlisis generades per l'anàlisi del model",
     uploadedFile: "Fitxer carregat",

--- a/frontend/src/lib/locales/de-DE/index.ts
+++ b/frontend/src/lib/locales/de-DE/index.ts
@@ -114,6 +114,12 @@ export const deDE = {
     finalAnswer: "Endgültige Antwort",
     notebookLabel: "Notebook: {{name}}",
     itemNotFound: "{{type}} konnte nicht gefunden werden",
+    contentUnavailable: {
+      notFoundTitle: "Dieser Inhalt existiert nicht mehr",
+      notFoundDescription: "Er wurde möglicherweise gelöscht. Verweise in älteren Nachrichten können auf inzwischen entfernte Inhalte zeigen.",
+      errorTitle: "Dieser Inhalt konnte nicht geladen werden",
+      errorDescription: "Beim Laden ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+    },
     accessibility: {
       transformationViews: "Transformationsansichten",
       searchKB: "Wissensbasis fragen oder durchsuchen",
@@ -396,7 +402,6 @@ export const deDE = {
     manageNotebooks: "Notebooks verwalten",
     manageNotebooksDesc: "Verwalte, welche Notebooks diese Quelle enthalten",
     noNotebooksAvailable: "Keine Notebooks verfügbar",
-    loadFailed: "Quellendetails konnten nicht geladen werden",
     removeFromNotebook: "Aus Notebook entfernen",
     retryProcessing: "Verarbeitung erneut versuchen",
     refreshContent: "Inhalt aktualisieren",
@@ -424,7 +429,6 @@ export const deDE = {
     embeddingNever: "Einbettung deaktiviert",
     embeddingNeverDesc: "Deine Einstellungen sind so konfiguriert, dass Einbettung übersprungen wird. Die Vektorsuche ist für diese Quelle nicht verfügbar.",
     changeInSettings: "Du kannst das in den Einstellungen ändern",
-    notFound: "Quelle nicht gefunden",
     noContent: "Kein Inhalt verfügbar",
     insightsDesc: "Erkenntnisse aus der Modellanalyse",
     uploadedFile: "Hochgeladene Datei",

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -109,6 +109,12 @@ export const enUS = {
     finalAnswer: "Final Answer",
     notebookLabel: "Notebook: {{name}}",
     itemNotFound: "This {{type}} could not be found",
+    contentUnavailable: {
+      notFoundTitle: "This content no longer exists",
+      notFoundDescription: "It may have been deleted. References in older messages can point to content that has since been removed.",
+      errorTitle: "Unable to load this content",
+      errorDescription: "Something went wrong while loading it. Please try again.",
+    },
     accessibility: {
       transformationViews: "Transformation views",
       searchKB: "Ask or search your knowledge base",
@@ -391,7 +397,6 @@ export const enUS = {
     manageNotebooks: "Manage Notebooks",
     manageNotebooksDesc: "Manage which notebooks contain this source",
     noNotebooksAvailable: "No notebooks available",
-    loadFailed: "Failed to load source details",
     removeFromNotebook: "Remove from Notebook",
     retryProcessing: "Retry Processing",
     refreshContent: "Refresh content",
@@ -419,7 +424,6 @@ export const enUS = {
     embeddingNever: "Embedding disabled",
     embeddingNeverDesc: "Your settings are configured to skip embedding. Vector search won't be available for this source.",
     changeInSettings: "You can change this in Settings",
-    notFound: "Source not found",
     noContent: "No content available",
     insightsDesc: "Insights generated from model analysis",
     uploadedFile: "Uploaded file",

--- a/frontend/src/lib/locales/es-ES/index.ts
+++ b/frontend/src/lib/locales/es-ES/index.ts
@@ -111,6 +111,12 @@ export const esES = {
     finalAnswer: "Respuesta final",
     notebookLabel: "Cuaderno: {{name}}",
     itemNotFound: "No se pudo encontrar este {{type}}",
+    contentUnavailable: {
+      notFoundTitle: "Este contenido ya no existe",
+      notFoundDescription: "Puede que haya sido eliminado. Las referencias en mensajes antiguos pueden apuntar a contenido que ya fue eliminado.",
+      errorTitle: "No se pudo cargar este contenido",
+      errorDescription: "Algo salió mal al cargarlo. Inténtalo de nuevo.",
+    },
     accessibility: {
       transformationViews: "Vistas de transformación",
       searchKB: "Pregunta o busca en tu base de conocimiento",
@@ -393,7 +399,6 @@ export const esES = {
     manageNotebooks: "Gestionar cuadernos",
     manageNotebooksDesc: "Gestiona qué cuadernos contienen esta fuente",
     noNotebooksAvailable: "No hay cuadernos disponibles",
-    loadFailed: "Error al cargar los detalles de la fuente",
     removeFromNotebook: "Quitar del cuaderno",
     retryProcessing: "Reintentar procesamiento",
     refreshContent: "Actualizar contenido",
@@ -421,7 +426,6 @@ export const esES = {
     embeddingNever: "Embedding deshabilitado",
     embeddingNeverDesc: "Tu configuración está establecida para omitir el embedding. La búsqueda vectorial no estará disponible para esta fuente.",
     changeInSettings: "Puedes cambiar esto en Configuración",
-    notFound: "Fuente no encontrada",
     noContent: "No hay contenido disponible",
     insightsDesc: "Análisis generados a partir del análisis del modelo",
     uploadedFile: "Archivo subido",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -111,6 +111,12 @@ export const frFR = {
     finalAnswer: "Réponse finale",
     notebookLabel: "Carnet : {{name}}",
     itemNotFound: "Ce {{type}} est introuvable",
+    contentUnavailable: {
+      notFoundTitle: "Ce contenu n'existe plus",
+      notFoundDescription: "Il a peut-être été supprimé. Les références dans les anciens messages peuvent pointer vers du contenu qui a depuis été supprimé.",
+      errorTitle: "Impossible de charger ce contenu",
+      errorDescription: "Une erreur s'est produite lors du chargement. Veuillez réessayer.",
+    },
     accessibility: {
       transformationViews: "Vues de transformation",
       searchKB: "Interroger ou fouiller votre base de connaissances",
@@ -393,7 +399,6 @@ export const frFR = {
     manageNotebooks: "Gérer les carnets",
     manageNotebooksDesc: "Gérer quels carnets contiennent cette source",
     noNotebooksAvailable: "Aucun carnet disponible",
-    loadFailed: "Échec du chargement des détails de la source",
     removeFromNotebook: "Retirer du carnet",
     retryProcessing: "Réessayer le traitement",
     refreshContent: "Actualiser le contenu",
@@ -421,7 +426,6 @@ export const frFR = {
     embeddingNever: "Indexation désactivée",
     embeddingNeverDesc: "Vos paramètres sont configurés pour ignorer l'indexation. La recherche vectorielle ne sera pas disponible pour cette source.",
     changeInSettings: "Vous pouvez modifier cela dans les Paramètres",
-    notFound: "Source introuvable",
     noContent: "Aucun contenu disponible",
     insightsDesc: "Aperçus générés par l'analyse du modèle",
     uploadedFile: "Fichier téléchargé",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -111,6 +111,12 @@ export const itIT = {
     finalAnswer: "Risposta finale",
     notebookLabel: "Quaderno: {{name}}",
     itemNotFound: "Questo {{type}} non è stato trovato",
+    contentUnavailable: {
+      notFoundTitle: "Questo contenuto non esiste più",
+      notFoundDescription: "Potrebbe essere stato eliminato. I riferimenti nei messaggi meno recenti possono puntare a contenuti ormai rimossi.",
+      errorTitle: "Impossibile caricare questo contenuto",
+      errorDescription: "Si è verificato un errore durante il caricamento. Riprova.",
+    },
     accessibility: {
       transformationViews: "Viste trasformazioni",
       searchKB: "Chiedi o cerca nella tua base di conoscenza",
@@ -393,7 +399,6 @@ export const itIT = {
     manageNotebooks: "Gestisci quaderni",
     manageNotebooksDesc: "Gestisci quali quaderni contengono questa fonte",
     noNotebooksAvailable: "Nessun quaderno disponibile",
-    loadFailed: "Impossibile caricare i dettagli della fonte",
     removeFromNotebook: "Rimuovi dal quaderno",
     retryProcessing: "Riprova elaborazione",
     refreshContent: "Aggiorna contenuto",
@@ -421,7 +426,6 @@ export const itIT = {
     embeddingNever: "Indicizzazione disabilitata",
     embeddingNeverDesc: "Le tue impostazioni sono configurate per saltare l'indicizzazione. La ricerca vettoriale non sarà disponibile per questa fonte.",
     changeInSettings: "Puoi modificare questo nelle Impostazioni",
-    notFound: "Fonte non trovata",
     noContent: "Nessun contenuto disponibile",
     insightsDesc: "Approfondimenti generati dall'analisi del modello",
     uploadedFile: "File caricato",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -111,6 +111,12 @@ export const jaJP = {
     finalAnswer: "最終回答",
     notebookLabel: "ノートブック: {{name}}",
     itemNotFound: "この{{type}}は見つかりませんでした",
+    contentUnavailable: {
+      notFoundTitle: "このコンテンツは存在しません",
+      notFoundDescription: "削除された可能性があります。過去のメッセージ内の参照は、すでに削除されたコンテンツを指している場合があります。",
+      errorTitle: "コンテンツを読み込めませんでした",
+      errorDescription: "読み込み中に問題が発生しました。もう一度お試しください。",
+    },
     accessibility: {
       transformationViews: "トランスフォーメーション表示",
       searchKB: "ナレッジベースに質問・検索",
@@ -393,7 +399,6 @@ export const jaJP = {
     manageNotebooks: "ノートブックを管理",
     manageNotebooksDesc: "このソースを含むノートブックを管理",
     noNotebooksAvailable: "利用可能なノートブックがありません",
-    loadFailed: "ソース詳細の読み込みに失敗しました",
     removeFromNotebook: "ノートブックから削除",
     retryProcessing: "処理を再試行",
     refreshContent: "コンテンツを更新",
@@ -421,7 +426,6 @@ export const jaJP = {
     embeddingNever: "Embeddingは無効",
     embeddingNeverDesc: "設定でEmbeddingをスキップするよう構成されています。このソースではベクトル検索は利用できません。",
     changeInSettings: "設定で変更できます",
-    notFound: "ソースが見つかりません",
     noContent: "コンテンツがありません",
     insightsDesc: "モデル分析から生成されたインサイト",
     uploadedFile: "アップロードされたファイル",

--- a/frontend/src/lib/locales/pl-PL/index.ts
+++ b/frontend/src/lib/locales/pl-PL/index.ts
@@ -111,6 +111,12 @@ export const plPL = {
     finalAnswer: "Ostateczna odpowiedź",
     notebookLabel: "Notatnik: {{name}}",
     itemNotFound: "Nie udało się odnaleźć elementu ({{type}})",
+    contentUnavailable: {
+      notFoundTitle: "Ta treść już nie istnieje",
+      notFoundDescription: "Mogła zostać usunięta. Odnośniki w starszych wiadomościach mogą wskazywać na treści, które zostały już usunięte.",
+      errorTitle: "Nie udało się wczytać tej treści",
+      errorDescription: "Coś poszło nie tak podczas wczytywania. Spróbuj ponownie.",
+    },
     accessibility: {
       transformationViews: "Widoki transformacji",
       searchKB: "Zadaj pytanie lub przeszukaj swoją bazę wiedzy",
@@ -393,7 +399,6 @@ export const plPL = {
     manageNotebooks: "Zarządzaj notatnikami",
     manageNotebooksDesc: "Zarządzaj notatnikami, które zawierają to źródło",
     noNotebooksAvailable: "Brak dostępnych notatników",
-    loadFailed: "Nie udało się załadować szczegółów źródła",
     removeFromNotebook: "Usuń z notatnika",
     retryProcessing: "Ponów przetwarzanie",
     refreshContent: "Odśwież treść",
@@ -421,7 +426,6 @@ export const plPL = {
     embeddingNever: "Osadzanie wyłączone",
     embeddingNeverDesc: "Twoje ustawienia są skonfigurowane tak, aby pomijać osadzanie. Wyszukiwanie wektorowe nie będzie dostępne dla tego źródła.",
     changeInSettings: "Możesz to zmienić w Ustawieniach",
-    notFound: "Nie znaleziono źródła",
     noContent: "Brak dostępnej treści",
     insightsDesc: "Wglądy wygenerowane na podstawie analizy modelu",
     uploadedFile: "Przesłany plik",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -111,6 +111,12 @@ export const ptBR = {
     finalAnswer: "Resposta Final",
     notebookLabel: "Caderno: {{name}}",
     itemNotFound: "Este {{type}} não foi encontrado",
+    contentUnavailable: {
+      notFoundTitle: "Este conteúdo não existe mais",
+      notFoundDescription: "Ele pode ter sido excluído. Referências em mensagens antigas podem apontar para conteúdo que já foi removido.",
+      errorTitle: "Não foi possível carregar este conteúdo",
+      errorDescription: "Algo deu errado ao carregá-lo. Tente novamente.",
+    },
     accessibility: {
       transformationViews: "Visualizações de transformação",
       searchKB: "Perguntar ou buscar na base de conhecimento",
@@ -393,7 +399,6 @@ export const ptBR = {
     manageNotebooks: "Gerenciar Cadernos",
     manageNotebooksDesc: "Gerencie quais cadernos contêm esta fonte",
     noNotebooksAvailable: "Nenhum caderno disponível",
-    loadFailed: "Falha ao carregar detalhes da fonte",
     removeFromNotebook: "Remover do Caderno",
     retryProcessing: "Tentar Processamento Novamente",
     refreshContent: "Atualizar conteúdo",
@@ -421,7 +426,6 @@ export const ptBR = {
     embeddingNever: "Incorporação desabilitada",
     embeddingNeverDesc: "Suas configurações estão definidas para pular incorporação. Busca vetorial não estará disponível para esta fonte.",
     changeInSettings: "Você pode alterar isso em Configurações",
-    notFound: "Fonte não encontrada",
     noContent: "Nenhum conteúdo disponível",
     insightsDesc: "Insights gerados a partir da análise do modelo",
     uploadedFile: "Arquivo enviado",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -111,6 +111,12 @@ export const ruRU = {
     finalAnswer: "Итоговый ответ",
     notebookLabel: "Блокнот: {{name}}",
     itemNotFound: "Этот {{type}} не найден",
+    contentUnavailable: {
+      notFoundTitle: "Этот контент больше не существует",
+      notFoundDescription: "Возможно, он был удалён. Ссылки в старых сообщениях могут указывать на уже удалённый контент.",
+      errorTitle: "Не удалось загрузить этот контент",
+      errorDescription: "Что-то пошло не так при загрузке. Попробуйте ещё раз.",
+    },
     accessibility: {
       transformationViews: "Представления трансформаций",
       searchKB: "Спросить или найти в базе знаний",
@@ -393,7 +399,6 @@ export const ruRU = {
     manageNotebooks: "Управление блокнотами",
     manageNotebooksDesc: "Управление блокнотами, содержащими этот источник",
     noNotebooksAvailable: "Нет доступных блокнотов",
-    loadFailed: "Не удалось загрузить детали источника",
     removeFromNotebook: "Удалить из блокнота",
     retryProcessing: "Повторить обработку",
     refreshContent: "Обновить содержимое",
@@ -421,7 +426,6 @@ export const ruRU = {
     embeddingNever: "Эмбеддинг отключён",
     embeddingNeverDesc: "В ваших настройках отключено создание эмбеддинга. Векторный поиск будет недоступен для этого источника.",
     changeInSettings: "Вы можете изменить это в Настройках",
-    notFound: "Источник не найден",
     noContent: "Содержимое недоступно",
     insightsDesc: "Инсайты, сгенерированные анализом модели",
     uploadedFile: "Загруженный файл",

--- a/frontend/src/lib/locales/tr-TR/index.ts
+++ b/frontend/src/lib/locales/tr-TR/index.ts
@@ -111,6 +111,12 @@ export const trTR = {
     finalAnswer: "Son Yanıt",
     notebookLabel: "Defter: {{name}}",
     itemNotFound: "Bu {{type}} bulunamadı",
+    contentUnavailable: {
+      notFoundTitle: "Bu içerik artık mevcut değil",
+      notFoundDescription: "Silinmiş olabilir. Eski mesajlardaki bağlantılar, kaldırılmış içeriklere işaret edebilir.",
+      errorTitle: "Bu içerik yüklenemedi",
+      errorDescription: "Yükleme sırasında bir sorun oluştu. Lütfen tekrar deneyin.",
+    },
     accessibility: {
       transformationViews: "Dönüşüm görünümleri",
       searchKB: "Bilgi tabanınızda sor veya ara",
@@ -393,7 +399,6 @@ export const trTR = {
     manageNotebooks: "Defterleri Yönet",
     manageNotebooksDesc: "Bu kaynağı içeren defterleri yönetin",
     noNotebooksAvailable: "Mevcut defter yok",
-    loadFailed: "Kaynak ayrıntıları yüklenemedi",
     removeFromNotebook: "Defterden Kaldır",
     retryProcessing: "İşlemeyi Yeniden Dene",
     refreshContent: "İçeriği yenile",
@@ -421,7 +426,6 @@ export const trTR = {
     embeddingNever: "Gömme devre dışı",
     embeddingNeverDesc: "Ayarlarınız gömmeyi atlamak üzere yapılandırılmış. Bu kaynak için vektör arama kullanılamaz.",
     changeInSettings: "Bunu Ayarlar'dan değiştirebilirsiniz",
-    notFound: "Kaynak bulunamadı",
     noContent: "İçerik mevcut değil",
     insightsDesc: "Model analizinden oluşturulan içgörüler",
     uploadedFile: "Yüklenen dosya",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -111,6 +111,12 @@ export const zhCN = {
     finalAnswer: "最终回答",
     notebookLabel: "笔记本: {{name}}",
     itemNotFound: "未找到该 {{type}}",
+    contentUnavailable: {
+      notFoundTitle: "该内容已不存在",
+      notFoundDescription: "它可能已被删除。旧消息中的引用可能指向已被移除的内容。",
+      errorTitle: "无法加载该内容",
+      errorDescription: "加载时出现问题，请重试。",
+    },
     accessibility: {
       transformationViews: "转换视图",
       searchKB: "向知识库提问或搜索",
@@ -393,7 +399,6 @@ export const zhCN = {
     manageNotebooks: "管理所属笔记本",
     manageNotebooksDesc: "管理包含此来源的笔记本",
     noNotebooksAvailable: "暂无可用笔记本",
-    loadFailed: "加载来源详情失败",
     removeFromNotebook: "从笔记本移除",
     retryProcessing: "重试处理",
     refreshContent: "刷新内容",
@@ -421,7 +426,6 @@ export const zhCN = {
     embeddingNever: "嵌入已禁用",
     embeddingNeverDesc: "您的设置已配置为跳过嵌入。此来源将无法进行向量搜索。",
     changeInSettings: "您可以在此处更改设置：",
-    notFound: "未找到来源",
     noContent: "暂无内容",
     insightsDesc: "根据模型分析生成的见解",
     uploadedFile: "已上传文件",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -111,6 +111,12 @@ export const zhTW = {
     finalAnswer: "最終回答",
     notebookLabel: "筆記本: {{name}}",
     itemNotFound: "未找到該 {{type}}",
+    contentUnavailable: {
+      notFoundTitle: "該內容已不存在",
+      notFoundDescription: "它可能已被刪除。舊訊息中的引用可能指向已被移除的內容。",
+      errorTitle: "無法載入該內容",
+      errorDescription: "載入時發生問題，請重試。",
+    },
     accessibility: {
       transformationViews: "轉換視圖",
       searchKB: "向知識庫提問或搜尋",
@@ -393,7 +399,6 @@ export const zhTW = {
     manageNotebooks: "管理所屬筆記本",
     manageNotebooksDesc: "管理包含此來源的筆記本",
     noNotebooksAvailable: "暫無可用筆記本",
-    loadFailed: "載入來源詳情失敗",
     removeFromNotebook: "從筆記本移除",
     retryProcessing: "重試處理",
     refreshContent: "重新整理內容",
@@ -421,7 +426,6 @@ export const zhTW = {
     embeddingNever: "嵌入已禁用",
     embeddingNeverDesc: "您的設定已設定為跳過嵌入。此來源將無法進行向量搜尋。",
     changeInSettings: "您可以在此處更改設定：",
-    notFound: "未找到來源",
     noContent: "暫無內容",
     insightsDesc: "根據模型分析生成的見解",
     uploadedFile: "已上傳檔案",

--- a/frontend/src/lib/utils/error-handler.ts
+++ b/frontend/src/lib/utils/error-handler.ts
@@ -1,3 +1,13 @@
+import { isAxiosError } from 'axios'
+
+/**
+ * Returns true when the error is an HTTP 404 response, i.e. the requested
+ * item was deleted or never existed (as opposed to a transient failure).
+ */
+export function isNotFoundError(error: unknown): boolean {
+  return isAxiosError(error) && error.response?.status === 404
+}
+
 /**
  * Utility to map backend English error messages to i18n keys.
  */


### PR DESCRIPTION
## Summary

When a chat/Ask citation references a source, insight, or note that has since been deleted, clicking it now opens a single, friendly "this content no longer exists" state in all three dialogs — instead of today's inconsistent behavior (generic red error for sources, silently blank dialog for insights, empty ghost editor inviting edits for notes).

Frontend-only, per the settled design on the issue: backend 404s were already clean for all three GET-by-id endpoints, and dangling refs only exist in persisted message text, discovered at click time.

### Changes

- **Shared state**: new `ContentUnavailable` component (built on the existing `EmptyState`) with two variants — `not-found` (HTTP 404 → "deleted / no longer exists") and `error` (transient failure → "unable to load, try again") — used identically by `SourceDetailContent`, `SourceInsightDialog`, and `NoteEditorDialog`.
- **Insight dialog**: consumes `isError` from `useInsight`; on error all derived fields (content, badge, "View source") go blank through a single gate point instead of falling back to the blank stub.
- **Note editor**: consumes `isError` from `useNote`; the not-found state fully gates the editor and its save path, killing the ghost-edit flow.
- **Source dialog**: distinguishes 404 from other errors (previously both showed a red "failed to load"); `SourceDetailContent` is keyed by `sourceId` so loading/not-found state resets per source. The file-download handler now reuses the new `isNotFoundError` helper.
- **No retry on 404**: the global react-query retry predicate skips 404s (`retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 2`) — retrying cannot resurrect a deleted item; non-404 behavior is unchanged.
- **i18n**: new `common.contentUnavailable.*` strings added to all 14 locales; now-unused `sources.notFound` and `sources.loadFailed` keys removed everywhere (enforced by the locale parity/unused-key tests and `satisfies TranslationShape`).

Out of scope by design: pre-marking orphan refs in message text (would cost N validation requests per rendered message) and the delete-while-editing race (already surfaces a save error).

Closes #455

## Test plan

- New component tests (mocking hooks/API to return axios 404 and network errors):
  - `SourceInsightDialog.test.tsx` — not-found state, error state, close affordance, success render
  - `NoteEditorDialog.test.tsx` — not-found/error states gate the editor and save button, close affordance, success render
  - `SourceDetailContent.test.tsx` — 404 vs non-404 variants, onClose wiring
- `npm run test` — 103 passed (includes locale parity + unused-key tests validating the i18n changes)
- `npx tsc --noEmit`, `npm run lint`, `npm run build` — clean
- `uv run pytest tests/` — 475 passed (backend untouched, hygiene run)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

