### PR TITLE
docs: content processing engines + extraction config (#1105, #602)

### DIFF
--- a/docs/3-USER-GUIDE/adding-sources.md
+++ b/docs/3-USER-GUIDE/adding-sources.md
@@ -50,10 +50,13 @@ Sources are the raw materials of your research. This guide covers how to add dif
 - **EPUB** (.epub) — eBook files
 - **Markdown** (.md, .txt) — Plain text formats
 - **HTML** (.html, .htm) — Web page files
+- **Images** (.png, .jpg, .jpeg, .tiff, .bmp) — Text read via OCR
 
 **File size limits:** Up to ~100MB (varies by system)
 
 **Processing time:** 10 seconds - 2 minutes (depending on length and file type)
+
+**OCR (scanned PDFs & images):** Text is read off scanned PDFs and image files using OCR, which is **on by default**. You can turn it off (or force a more accurate extraction engine) in **Settings → Content Processing** — see [Content Processing Engines](content-processing-engines.md).
 
 ### Audio & Video
 - **Audio**: MP3, WAV, M4A, OGG, FLAC (~30 seconds - 3 minutes per hour)
@@ -65,16 +68,19 @@ Sources are the raw materials of your research. This guide covers how to add dif
 
 ### Web Content
 - **Articles**: Blog posts, news articles, Medium
-- **YouTube**: Full videos or playlists
+- **YouTube**: Full videos, playlists, plus `/live/` and `/shorts/` URLs
+- **Reddit**: Public post URLs (fetched via Reddit's public JSON)
 - **PDFs online**: Direct PDF links
 - **News**: News site articles
 
 **Just paste the URL** in "Web Link" section.
 
+**JavaScript-heavy sites:** How well a URL extracts depends on the URL processing engine. The default (`auto`) tries several engines and can render JavaScript pages; if a link comes back empty, see [Content Processing Engines](content-processing-engines.md).
+
 ### What Doesn't Work
 - Paywalled content (WSJ, FT, etc.) — Can't extract
 - Password-protected PDFs — Can't open
-- Pure image files (.jpg, .png) — Except scanned PDFs which have OCR
+- Unsupported formats — Rejected immediately with a clear "unsupported file type" message (no long wait)
 - Very large files (>100MB) — Timeout
 
 ---
@@ -188,6 +194,7 @@ Two ways to add:
 
 Method 1: Direct URL
   1. Copy YouTube URL: https://www.youtube.com/watch?v=...
+     (regular watch, /live/, and /shorts/ URLs all work)
   2. Paste in "Web Link"
   3. Click Add
   4. System extracts captions (if available) + transcript
@@ -357,7 +364,8 @@ Example: "Keep this in notebook but don't use in this conversation"
 
 **"Unsupported file type"**
 - You tried to upload a format not in the list (e.g., `.webp` image)
-- Solution: Convert to supported format (PDF for documents, MP3 for audio)
+- The upload is rejected **immediately** with a message naming the detected type — no long wait or stuck "Processing" state
+- Solution: Convert to a supported format (PDF for documents, MP3 for audio)
 
 **"Processing timeout"**
 - Very large file (>100MB) or very long audio
@@ -369,7 +377,7 @@ Example: "Keep this in notebook but don't use in this conversation"
 
 **"Web link won't extract"**
 - Website blocks automated access or uses JavaScript for content
-- Solution: Copy the article text and paste as "Text" instead
+- Solution: Try a different URL processing engine (see [Content Processing Engines](content-processing-engines.md)), or copy the article text and paste as "Text" instead
 
 ---
 

--- a/docs/3-USER-GUIDE/content-processing-engines.md
+++ b/docs/3-USER-GUIDE/content-processing-engines.md
@@ -1,0 +1,114 @@
+# Content Processing Engines - Choosing How Content Is Extracted
+
+When you add a source, Open Notebook extracts its text before chunking, embedding, and indexing it. How that extraction happens depends on the **processing engine**. You usually don't need to touch this — the defaults handle most content — but knowing your options helps when a document extracts poorly or a URL comes back empty.
+
+Configure everything here in **Settings → Content Processing**.
+
+---
+
+## Where to Configure
+
+```
+Settings → Content Processing:
+  - Document Processing Engine   (for uploaded files)
+  - URL Processing Engine        (for web links)
+  - Enable OCR                   (scanned PDFs and images)
+```
+
+Changes apply to sources you add **after** saving. Re-add a source if you want it re-extracted with a different engine.
+
+---
+
+## Document Processing Engines
+
+Controls how uploaded files (PDF, Word, PowerPoint, EPUB, etc.) are turned into text.
+
+| Engine | What it does | Trade-off |
+|--------|--------------|-----------|
+| **auto** (default) | Picks the best engine for the file type. Uses Docling for complex documents, simple extraction for the rest. | Balanced. Good default for almost everyone. |
+| **docling** | Layout-aware extraction: understands columns, tables, headings, and reading order. Runs OCR on scanned pages when OCR is enabled. | Most accurate, but slower and heavier. |
+| **simple** | Fast, lightweight text extraction. Skips Docling entirely. | Fastest, but loses table structure and layout; no OCR. |
+
+**When to pick each:**
+
+- **auto** — leave it here unless you have a reason not to.
+- **docling** — force it when tables, multi-column layouts, or scanned PDFs matter and `auto` isn't giving you clean results.
+- **simple** — choose it for large batches of clean, text-native documents where speed matters more than layout fidelity.
+
+---
+
+## URL Processing Engines
+
+Controls how web links are fetched and converted to text. Sites differ wildly — some are static HTML, others render everything with JavaScript, others sit behind anti-bot protection — so Open Notebook offers several engines with different capabilities.
+
+| Engine | What it does | Needs |
+|--------|--------------|-------|
+| **auto** (default) | Tries each engine in order until one succeeds (see chain below). | Nothing; uses whatever is configured. |
+| **firecrawl** | Managed scraping service. Handles JavaScript, anti-bot, and proxies well. | `FIRECRAWL_API_KEY` (or a self-hosted instance). |
+| **jina** | Jina AI Reader. Good at turning articles into clean text. | `JINA_API_KEY`. |
+| **crawl4ai** | Renders JavaScript pages locally in a bundled Chromium browser. No API key needed. | Bundled in the Docker image; or point at a remote server with `CRAWL4AI_API_URL`. |
+| **simple** | Basic HTTP fetch parsed with BeautifulSoup. | Nothing. |
+
+### How the `auto` fallback chain works
+
+In `auto` mode, Open Notebook tries engines in order and stops at the first that returns usable content:
+
+```
+Firecrawl  →  Jina  →  Crawl4AI  →  simple (bs4)
+```
+
+- Engines that aren't configured (e.g. no Firecrawl key) are skipped.
+- Firecrawl and Jina are tried first because they handle difficult sites best.
+- Crawl4AI catches JavaScript-heavy pages the API services miss, using local Chromium.
+- `simple` is the last resort — a plain HTTP request. It's fast and needs nothing, but **misses anything rendered by JavaScript**, so single-page apps and dynamic sites often come back empty or partial.
+
+**When to force a specific engine:**
+
+- **firecrawl** / **jina** — you have a key and want consistent, high-quality extraction without paying the local-rendering cost.
+- **crawl4ai** — a site needs a real browser (JavaScript-rendered content) but you'd rather not use a paid API.
+- **simple** — the site is plain HTML and you want the fastest, dependency-free path.
+
+See the [Environment Reference](../5-CONFIGURATION/environment-reference.md#content-extraction) for the API keys and tuning variables (`FIRECRAWL_API_URL`, `CCORE_FIRECRAWL_PROXY`, `CCORE_FIRECRAWL_WAIT_FOR`, `CRAWL4AI_API_URL`).
+
+---
+
+## OCR Toggle
+
+**Settings → Content Processing → Enable OCR** (on by default).
+
+OCR reads text off images. It applies when the Docling engine handles:
+
+- **Scanned PDFs** — pages that are images of text rather than real text.
+- **Image sources** — PNG, JPEG, TIFF, BMP.
+
+**Leave it on** if you work with scanned documents or images. **Turn it off** to speed up processing when all your documents are text-native — OCR adds overhead you don't need there.
+
+OCR only runs through Docling. If you set the Document Processing Engine to `simple`, OCR is skipped regardless of this toggle.
+
+---
+
+## Quick Reference
+
+```
+Document extracts poorly (tables, columns garbled)
+  → Set Document Engine to "docling"
+
+Scanned PDF or image comes out blank
+  → Enable OCR (and make sure the engine is auto or docling)
+
+Web link comes back empty or half-extracted
+  → The site is likely JavaScript-heavy
+  → In auto mode, add a Firecrawl or Jina key, or rely on bundled Crawl4AI
+  → Or force "crawl4ai" / "firecrawl"
+
+Processing feels slow on clean documents
+  → Set Document Engine to "simple" and/or disable OCR
+```
+
+---
+
+## Related
+
+- [Adding Sources](adding-sources.md) — supported file types and step-by-step upload guide
+- [Environment Reference](../5-CONFIGURATION/environment-reference.md) — extraction API keys and tuning variables
+- [Advanced Configuration](../5-CONFIGURATION/advanced.md) — web scraping and content extraction setup

--- a/docs/3-USER-GUIDE/index.md
+++ b/docs/3-USER-GUIDE/index.md
@@ -25,6 +25,8 @@ How to bring content into your notebook. Supports PDFs, web links, audio, video,
 - Paste text directly
 - Common mistakes + fixes
 
+**Related:** [Content Processing Engines](content-processing-engines.md) — choose how documents and URLs are extracted (Docling, Firecrawl, Jina, Crawl4AI) and control OCR.
+
 ---
 
 ### 2. [Working with Notes](working-with-notes.md)

--- a/docs/5-CONFIGURATION/advanced.md
+++ b/docs/5-CONFIGURATION/advanced.md
@@ -250,7 +250,7 @@ Restrict access to your Open Notebook:
 
 ## Web Scraping & Content Extraction
 
-Open Notebook uses multiple services for content extraction:
+Open Notebook uses multiple engines for content extraction. Which one runs is chosen in **Settings → Content Processing** (see the user-guide page on [Content Processing Engines](../3-USER-GUIDE/content-processing-engines.md)); the variables below configure them.
 
 ### Firecrawl
 
@@ -258,6 +258,15 @@ For advanced web scraping:
 
 ```env
 FIRECRAWL_API_KEY=your-key
+
+# Optional: self-hosted Firecrawl instance
+FIRECRAWL_API_URL=https://firecrawl.internal.example.com
+
+# Optional: bypass anti-bot protection (basic | stealth | auto)
+CCORE_FIRECRAWL_PROXY=auto
+
+# Optional: ms to wait for JavaScript to render (default 3000)
+CCORE_FIRECRAWL_WAIT_FOR=3000
 ```
 
 Get key from: https://firecrawl.dev/
@@ -271,6 +280,14 @@ JINA_API_KEY=your-key
 ```
 
 Get key from: https://jina.ai/
+
+### Crawl4AI
+
+Renders JavaScript pages in a local Chromium browser — no API key required. The Docker image bundles the Crawl4AI runtime and Chromium, so it works out of the box. To offload rendering to a remote Crawl4AI server instead:
+
+```env
+CRAWL4AI_API_URL=http://crawl4ai.example.com:11235
+```
 
 ---
 

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -105,11 +105,18 @@ CORS_ORIGINS=https://notebook.example.com
 | Variable | Required? | Default | Description |
 |----------|-----------|---------|-------------|
 | `FIRECRAWL_API_KEY` | No | None | Firecrawl API key for advanced web scraping |
+| `FIRECRAWL_API_URL` | No | None | Base URL of a self-hosted Firecrawl instance (use instead of the hosted service) |
+| `CCORE_FIRECRAWL_PROXY` | No | `auto` | Firecrawl proxy mode to bypass anti-bot protection: `basic`, `stealth`, or `auto` |
+| `CCORE_FIRECRAWL_WAIT_FOR` | No | `3000` | Milliseconds Firecrawl waits for JavaScript to render before capturing the page |
 | `JINA_API_KEY` | No | None | Jina AI API key for web extraction |
+| `CRAWL4AI_API_URL` | No | None | Base URL of a remote Crawl4AI server. Leave unset to use the Chromium runtime bundled in the Docker image |
 
 **Setup:**
 - Firecrawl: https://firecrawl.dev/
 - Jina: https://jina.ai/
+- Crawl4AI: https://github.com/unclecode/crawl4ai
+
+The `CCORE_FIRECRAWL_*` variables are passed straight through to the content-core library (its settings are prefixed with `CCORE_`); Open Notebook itself doesn't read them. See [Content Processing Engines](../3-USER-GUIDE/content-processing-engines.md) for how these engines are selected in the UI.
 
 ---
 

--- a/docs/7-DEVELOPMENT/decisions/ADR-002-external-libraries.md
+++ b/docs/7-DEVELOPMENT/decisions/ADR-002-external-libraries.md
@@ -30,3 +30,7 @@ Applied today:
 - The libraries are independently versioned, testable and swappable; the boundary keeps this repo's scope honest.
 - Debugging sometimes spans two repos; issues whose root cause is upstream get the `upstream` + library labels (`esperanto`, `content-core`, `podcast-creator`).
 - Provider-specific *capabilities* (not just plumbing) remain constrained by [PDR-002](PDR-002-provider-agnostic-core.md).
+
+## Addendum (2026-07): Content Core 2.x
+
+The upgrade to Content Core 2.x (2.0.4) validated the "swappable external library" thesis in practice. New capabilities came straight from upstream — new formats (EPUB, Reddit posts, YouTube `/live/` and `/shorts/`), selectable URL/document engines (`auto`, `firecrawl`, `jina`, `crawl4ai`, `simple` / `docling`), and better licensing — while the only Open Notebook-side work was adapting our single `extract_content()` call site to 2.x's new keyword-only API. Upstream swapped PDF extraction from PyMuPDF (AGPL) to pdfplumber (MIT) and dropped moviepy in favour of direct ffmpeg, so Open Notebook inherited a cleaner license posture and fixed audio bugs for free. Concentrating all extraction behind that one boundary is what kept the blast radius so small.


### PR DESCRIPTION
Part of #939 — the final child. Documents everything the content-core 2.x upgrade exposed, and closes **#602** (Firecrawl proxy/wait_for — env-only, so it was always a docs task).

## What's here

- **New page** `docs/3-USER-GUIDE/content-processing-engines.md` — explains the document engines (`auto`/`docling`/`simple`) and URL engines (`auto`/`firecrawl`/`jina`/`crawl4ai`/`simple`), how the `auto` fallback chain works (Firecrawl → Jina → Crawl4AI → simple), the OCR toggle, and a troubleshooting quick-reference. Linked from the User Guide index.
- **`adding-sources.md`** — image/OCR support, Reddit URLs, YouTube `/live/` + `/shorts/`, JavaScript-heavy-site guidance, and the new **immediate 415 rejection** for unsupported types (no more long "Processing" hang, per #975).
- **`environment-reference.md`** + **`advanced.md`** — `FIRECRAWL_API_URL`, `CCORE_FIRECRAWL_PROXY`, `CCORE_FIRECRAWL_WAIT_FOR`, `CRAWL4AI_API_URL`, with a note that `CCORE_*` vars pass straight through to content-core. **This is the resolution of #602** (no code needed — content-core reads them natively).
- **`ADR-002`** — addendum on the 2.x upgrade and the AGPL→MIT licensing improvement (PyMuPDF → pdfplumber, moviepy → ffmpeg).

## Notes

- Docs are English-only (no i18n). There's no MkDocs/Docusaurus nav file — navigation is via per-section `index.md`, so the new page is registered as a "Related" link under Adding Sources in `docs/3-USER-GUIDE/index.md`.
- Verified with the repo's own `scripts/check_md_links.py` — all relative links resolve.

With this merged, the #939 umbrella (content-core 2.x) is complete.

Closes #1105
Closes #602

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

