### PR TITLE
fix(sources): cap error text surfaced to clients

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -71,6 +71,19 @@ async def _assert_file_supported(file_path: str) -> None:
             detail = f"{detail} (detected type: {support.identified_type})"
         raise UnsupportedTypeException(detail)
 
+
+def _truncate_error(msg: Optional[str], limit: int = 200) -> Optional[str]:
+    """Cap error text surfaced to clients.
+
+    Command/processing failures can carry arbitrary internal exception text;
+    return at most ``limit`` characters so a raw traceback message can't leak
+    to the API response. ``None`` passes through unchanged.
+    """
+    if not msg:
+        return msg
+    return msg if len(msg) <= limit else msg[:limit] + "…"
+
+
 SOURCE_SORT_FIELDS = {
     "created": "created",
     "updated": "updated",
@@ -326,7 +339,7 @@ async def get_sources(
                 processing_info = {
                     "started_at": execution_metadata.get("started_at"),
                     "completed_at": execution_metadata.get("completed_at"),
-                    "error": command.get("error_message"),
+                    "error": _truncate_error(command.get("error_message")),
                 }
             elif command:
                 # Command exists but FETCH failed to resolve it (broken reference)
@@ -603,7 +616,7 @@ async def _create_source_sync_path(
                 pass
             raise HTTPException(
                 status_code=500,
-                detail=f"Processing failed: {result.error_message}",
+                detail=f"Processing failed: {_truncate_error(result.error_message)}",
             )
 
         # Get the processed source

--- a/tests/test_error_message_sanitization.py
+++ b/tests/test_error_message_sanitization.py
@@ -211,6 +211,7 @@ class TestTruncateErrorHelper:
         from api.routers.sources import _truncate_error
 
         result = _truncate_error(SECRET + "x" * 500)
+        assert result is not None
         # capped at limit + the single-character ellipsis
         assert len(result) == 201
         assert result.endswith("…")

--- a/tests/test_error_message_sanitization.py
+++ b/tests/test_error_message_sanitization.py
@@ -180,3 +180,43 @@ class TestPodcastServiceDoesNotLeakExceptionText:
         assert exc_info.value.status_code == 500
         assert SECRET not in exc_info.value.detail
         assert exc_info.value.detail == "Failed to submit podcast generation job"
+
+
+class TestTruncateErrorHelper:
+    """`_truncate_error` caps client-facing error text surfaced by the source
+    status and sync-processing paths (#1136)."""
+
+    def test_none_passes_through(self):
+        from api.routers.sources import _truncate_error
+
+        assert _truncate_error(None) is None
+
+    def test_empty_string_passes_through(self):
+        from api.routers.sources import _truncate_error
+
+        assert _truncate_error("") == ""
+
+    def test_short_message_unchanged(self):
+        from api.routers.sources import _truncate_error
+
+        assert _truncate_error("boom") == "boom"
+
+    def test_message_at_limit_unchanged(self):
+        from api.routers.sources import _truncate_error
+
+        msg = "x" * 200
+        assert _truncate_error(msg) == msg
+
+    def test_long_message_truncated_with_ellipsis(self):
+        from api.routers.sources import _truncate_error
+
+        result = _truncate_error(SECRET + "x" * 500)
+        # capped at limit + the single-character ellipsis
+        assert len(result) == 201
+        assert result.endswith("…")
+        assert result.startswith(SECRET[:50])
+
+    def test_custom_limit(self):
+        from api.routers.sources import _truncate_error
+
+        assert _truncate_error("abcdefghij", limit=4) == "abcd…"


### PR DESCRIPTION
## Summary

Source processing status and sync-processing failures returned the raw internal exception text to clients, unbounded — which could expose arbitrary internal exception detail and didn't match the error-capping applied elsewhere in the API (`api/routers/models.py:303` uses `str(e)[:200]`).

Two spots in `api/routers/sources.py`:
- `get_source_status` returned `command.get("error_message")` verbatim in the `error` field.
- The sync-processing path raised `detail=f"Processing failed: {result.error_message}"` unbounded.

## Changes

- Add a None-safe `_truncate_error(msg, limit=200)` helper: passes `None`/empty through unchanged, returns the message as-is when within the limit, otherwise caps at `limit` and appends a single-character ellipsis (`…`).
- Apply it on both surfacing paths.
- Add focused unit tests in `tests/test_error_message_sanitization.py` (None passthrough, short/at-limit unchanged, long truncated to `limit + 1` with ellipsis, custom limit).

No migration, i18n, or frontend impact.

## Verification

- `uv run pytest tests/test_error_message_sanitization.py` — 15 passed
- `uv run ruff check` — clean
- `uv run python -m mypy api/routers/sources.py` — clean

Closes #1136


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

