### PR TITLE
feat(worker): expose OPEN_NOTEBOOK_WORKER_MAX_TASKS for worker concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@ SURREAL_DATABASE=open_notebook
 # CHUNK_SIZE=1500
 # CHUNK_OVERLAP=150
 
+# Max background tasks the worker runs concurrently (default 5). Set to 1 for
+# sequential processing on single-GPU / local-LLM setups to avoid rate limits.
+# NOTE: consumed at worker launch, not by the app — for `make`/dev-init export
+# it in your shell; for Docker set it under `environment:` in docker-compose.yml.
+# OPEN_NOTEBOOK_WORKER_MAX_TASKS=1
+
 # Maximum upload/request body size in MB (default: 100). Raise this if you
 # need to upload larger audio/video files. A fronting reverse proxy's own
 # limit (e.g. nginx client_max_body_size) still applies and should be raised

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ worker: worker-start
 
 worker-start:
 	@echo "Starting surreal-commands worker..."
-	uv run --env-file .env surreal-commands-worker --import-modules commands
+	uv run --env-file .env surreal-commands-worker --import-modules commands --max-tasks "$${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}"
 
 worker-stop:
 	@echo "Stopping surreal-commands worker..."
@@ -182,7 +182,7 @@ start-all:
 	@uv run run_api.py &
 	@sleep 3
 	@echo "⚙️ Starting background worker..."
-	@uv run --env-file .env surreal-commands-worker --import-modules commands &
+	@uv run --env-file .env surreal-commands-worker --import-modules commands --max-tasks "$${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}" &
 	@sleep 2
 	@echo "🌐 Starting Next.js frontend..."
 	@echo "✅ All services started!"

--- a/dev-init.sh
+++ b/dev-init.sh
@@ -29,7 +29,7 @@ sleep 3
 
 # Start background worker in background
 echo "Starting background worker..."
-uv run --env-file .env surreal-commands-worker --import-modules commands &
+uv run --env-file .env surreal-commands-worker --import-modules commands --max-tasks "${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}" &
 sleep 2
 
 # Start frontend (foreground)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,11 @@ services:
       # - OPEN_NOTEBOOK_ENABLE_DOCLING=true    # Docling engine + OCR + image sources (large ML stack)
       # - OPEN_NOTEBOOK_ENABLE_CRAWL4AI=true   # local Crawl4AI (bundles a Chromium browser)
       # - CRAWL4AI_API_URL=http://crawl4ai:11235  # use a remote Crawl4AI server instead (no local install)
+
+      # OPTIONAL: max concurrent background tasks the worker processes at once
+      # (default 5). Set to 1 for sequential processing on single-GPU / local
+      # LLM setups to avoid overloading the model with parallel requests.
+      # - OPEN_NOTEBOOK_WORKER_MAX_TASKS=1
     volumes:
       - ./notebook_data:/app/data
     depends_on:

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -45,11 +45,13 @@ Comprehensive list of all environment variables available in Open Notebook.
 
 ---
 
-## Database: Concurrency
+## Worker: Concurrency
 
 | Variable | Required? | Default | Description |
 |----------|-----------|---------|-------------|
-| `SURREAL_COMMANDS_MAX_TASKS` | No | 5 | Maximum concurrent database tasks |
+| `OPEN_NOTEBOOK_WORKER_MAX_TASKS` | No | 5 | Maximum number of background tasks (source processing, embeddings, podcasts) the worker runs concurrently. Passed to the worker as `--max-tasks` at launch. Set to `1` for **sequential processing** on single-GPU or local-LLM setups, where parallel requests overload the model and trigger rate limits. |
+
+> **Read at worker launch, from the process environment.** In Docker this comes from the container environment — set it under `environment:` in `docker-compose.yml` (or your orchestrator). For local `make worker-start` / `dev-init.sh`, export it in your shell (e.g. `export OPEN_NOTEBOOK_WORKER_MAX_TASKS=1`) — it is consumed by the shell before the app loads `.env`, so a value placed only in `.env` will not apply to these local launch paths.
 
 ---
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -20,7 +20,9 @@ autostart=true
 startsecs=3
 
 [program:worker]
-command=uv run --no-sync surreal-commands-worker --import-modules commands
+; sh -c so the shell expands ${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5} (supervisord's
+; own command= does not run through a shell). Falls back to 5 when unset.
+command=sh -c "uv run --no-sync surreal-commands-worker --import-modules commands --max-tasks ${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Summary

Closes #893. The background worker runs a fixed 5 concurrent tasks, which overloads single-GPU / local-LLM setups — all sources process in parallel and hammer the model into rate limits. This exposes an `OPEN_NOTEBOOK_WORKER_MAX_TASKS` env var (default 5) so operators can set `1` for sequential processing.

The `surreal-commands-worker` already accepts `--max-tasks`; this just wires it to the env var at every launch point. **No changes to the retry architecture or the graphs** — this is deliberately scoped to only the concurrency knob (unlike the earlier #933, which bundled the rejected #894 changes).

## Changes

- **`Makefile`** (`worker-start`, `start-all`) — `--max-tasks "$${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}"` (Make-escaped `$$` → shell `$`).
- **`dev-init.sh`** — `--max-tasks "${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}"`.
- **`supervisord.conf`** — wrapped the worker command in `sh -c` so the shell performs the `${VAR:-5}` expansion (`command=` does not run through a shell). This avoids the two bugs that sank #933: no bash-only `[[ =~ ]]` (POSIX default expansion instead), and no `$$MAX`→PID mistake.
- **`docker-compose.yml`** — commented `# - OPEN_NOTEBOOK_WORKER_MAX_TASKS=1` example alongside the other optional toggles.
- **`.env.example` + `docs/5-CONFIGURATION/environment-reference.md`** — document the var and the launch-time sourcing behavior (Docker: container `environment:`; local `make`/dev-init: export in shell, since it's consumed before the app loads `.env`).

### Drive-by doc fix

`environment-reference.md` documented `SURREAL_COMMANDS_MAX_TASKS` (default 5) as the concurrency knob, but that env var **is not read anywhere** — the worker's `--max-tasks` Typer option has no `envvar=`, and nothing in `surreal_commands` reads `SURREAL_COMMANDS_MAX_TASKS`. Replaced that phantom entry with the real `OPEN_NOTEBOOK_WORKER_MAX_TASKS`.

## Verification

Shell expansion validated (the part that regressed in #933):
- `${VAR:-5}` under `sh`/dash → `5` unset, the value when set.
- `make -n worker-start` shows the recipe resolving to a single `${OPEN_NOTEBOOK_WORKER_MAX_TASKS:-5}` (no `$$`/PID artifact).
- The supervisord `sh -c` inner command expands correctly (`OPEN_NOTEBOOK_WORKER_MAX_TASKS=2` → `--max-tasks 2`).
- `sh -n dev-init.sh` — syntax OK.

No Python/frontend changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

