### PR TITLE
ci: gate the dev Docker build on image-affecting paths

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -72,12 +72,50 @@ jobs:
             echo "This is a PR or manual run - test build only"
           fi
 
+  # Detect whether this PR touches anything that ends up in the Docker image.
+  # build-regular is a required status check, so it must always REPORT — the
+  # expensive build steps below are gated on this output instead of filtering
+  # the workflow trigger (a path-filtered required check never reports and
+  # deadlocks merge, even for admins). On push to main the build always runs.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      image: ${{ steps.filter.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect image-affecting changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            image:
+              - 'Dockerfile*'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'open_notebook/**'
+              - 'api/**'
+              - 'commands/**'
+              - 'frontend/**'
+              - '.github/workflows/build-dev.yml'
+
+  # The job always runs (so the required `build-regular` check always reports),
+  # but every build step is gated on: push to main OR the PR touched an
+  # image-affecting path (needs.changes.outputs.image). Uses needs.* directly in
+  # each step `if:` (fully supported) rather than a job-level env indirection.
   build-regular:
-    needs: extract-version
+    needs: [extract-version, changes]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Skip notice
+        if: needs.extract-version.outputs.is_push_to_main != 'true' && needs.changes.outputs.image != 'true'
+        run: echo "No image-affecting paths changed — skipping the Docker build. Reporting success."
 
       - name: Free up disk space
         if: needs.extract-version.outputs.is_push_to_main == 'true'
@@ -90,6 +128,7 @@ jobs:
           df -h
 
       - name: Set up Docker Buildx
+        if: needs.extract-version.outputs.is_push_to_main == 'true' || needs.changes.outputs.image == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
@@ -108,6 +147,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Cache Docker layers
+        if: needs.extract-version.outputs.is_push_to_main == 'true' || needs.changes.outputs.image == 'true'
         uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache-dev
@@ -117,6 +157,7 @@ jobs:
 
       - name: Prepare Docker tags
         id: tags
+        if: needs.extract-version.outputs.is_push_to_main == 'true' || needs.changes.outputs.image == 'true'
         run: |
           if [[ "${{ needs.extract-version.outputs.is_push_to_main }}" == "true" ]]; then
             # Push to main: build and push v1-dev tags
@@ -135,6 +176,7 @@ jobs:
           fi
 
       - name: Build and push regular image
+        if: needs.extract-version.outputs.is_push_to_main == 'true' || needs.changes.outputs.image == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -147,6 +189,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-dev-new,mode=max
 
       - name: Move cache
+        if: needs.extract-version.outputs.is_push_to_main == 'true' || needs.changes.outputs.image == 'true'
         run: |
           rm -rf /tmp/.buildx-cache-dev
           mv /tmp/.buildx-cache-dev-new /tmp/.buildx-cache-dev


### PR DESCRIPTION
## Summary

Closes #1134. `build-regular` (the dev Docker image build) is a required status check that ran a full, several-minute build on **every** PR — including docs/config-only PRs where the built image is byte-for-byte identical to `main` (surfaced while merging #1129, where the build was the only thing between a trivially-safe change and merge). The build is worth keeping (it catches broken `Dockerfile` / unresolvable deps that unit tests miss), so the goal is to run it only when it can actually tell us something.

## Approach

This uses a **single-workflow, always-reports** gate rather than the skip-companion job the issue sketched — it's simpler and removes the two-workflows-sharing-a-check-name fragility:

- New `changes` job runs `dorny/paths-filter` and outputs `image` (did the PR touch anything that ends up in the image).
- `build-regular` still **always runs** (so the required check always reports), but every build step is gated on `push to main OR needs.changes.outputs.image == 'true'`. When nothing image-affecting changed, the job succeeds in seconds after a "Skip notice" step.

**Why not a `paths:` filter on the trigger:** a required status check whose workflow is filtered out by `paths` never reports, and GitHub treats it as `expected` — blocking merge forever, even for admins. Gating *steps* inside an always-running job avoids that entirely.

The condition is written inline in each step's `if:` using `needs.*` (fully supported) rather than a job-level `env` indirection, to avoid any ambiguity about context availability in a check that gates merges.

Image-affecting paths: `Dockerfile*`, `pyproject.toml`, `uv.lock`, `open_notebook/**`, `api/**`, `commands/**`, `frontend/**`, and the build workflow itself.

## Behavior

- **Docs/config-only PR** → `changes.image = false` → `build-regular` reports green in seconds, no Docker build.
- **PR touching image paths** → real build as before (this very PR touches `build-dev.yml`, so `build-regular` runs the real build here — validating the workflow still builds).
- **Push to main** → always builds (`is_push_to_main` short-circuits the gate); the existing `paths-ignore` on the push trigger still excludes docs.
- **Release build** (`build-and-release.yml`) — untouched.

## Verification

- YAML parses; jobs resolve to `extract-version, changes, build-regular, build-single, summary`.
- `build-single` (push-only) and the `summary` job are unchanged; `summary` still reads `build-regular.result`, which is now always reported.

**Caveat:** the skip path (docs-only PR reporting green without building) can only be confirmed by GitHub on the first docs-only PR after this merges — the always-runs-job pattern is the established safe shape for exactly this reason.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

