### PR TITLE
docs: bind SurrealDB's docker port to localhost in setup snippets

### DIFF
--- a/docs/0-START-HERE/quick-start-cloud.md
+++ b/docs/0-START-HERE/quick-start-cloud.md
@@ -28,7 +28,10 @@ services:
     image: surrealdb/surrealdb:v2
     command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     ports:
-      - "8000:8000"
+      # Localhost only: this starts with root:root, and 0.0.0.0 would
+      # expose that to the network. open_notebook reaches it over the
+      # internal compose network regardless.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
     # Removed the healthcheck because the v2 image is too minimal to run wget/curl

--- a/docs/0-START-HERE/quick-start-external-ollama.md
+++ b/docs/0-START-HERE/quick-start-external-ollama.md
@@ -49,7 +49,10 @@ services:
     command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     user: root
     ports:
-      - "8000:8000"
+      # Localhost only: this starts with root:root, and 0.0.0.0 would
+      # expose that to the network. open_notebook reaches it over the
+      # internal compose network regardless.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
 

--- a/docs/0-START-HERE/quick-start-local.md
+++ b/docs/0-START-HERE/quick-start-local.md
@@ -36,7 +36,10 @@ services:
     command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     user: root
     ports:
-      - "8000:8000"
+      # Localhost only: this starts with root:root, and 0.0.0.0 would
+      # expose that to the network. open_notebook reaches it over the
+      # internal compose network regardless.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
 

--- a/docs/0-START-HERE/quick-start-openai.md
+++ b/docs/0-START-HERE/quick-start-openai.md
@@ -25,7 +25,10 @@ services:
     image: surrealdb/surrealdb:v2
     command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     ports:
-      - "8000:8000"
+      # Localhost only: this starts with root:root, and 0.0.0.0 would
+      # expose that to the network. open_notebook reaches it over the
+      # internal compose network regardless.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
 

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -34,7 +34,10 @@ services:
     command: start --log info --user root --pass root rocksdb:/mydata/mydatabase.db
     user: root  # Required for bind mounts on Linux
     ports:
-      - "8000:8000"
+      # Localhost only: this starts with root:root, and 0.0.0.0 would
+      # expose that to the network. open_notebook reaches it over the
+      # internal compose network regardless.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
     environment:

--- a/docs/5-CONFIGURATION/reverse-proxy.md
+++ b/docs/5-CONFIGURATION/reverse-proxy.md
@@ -424,7 +424,10 @@ services:
     image: surrealdb/surrealdb:latest
     command: start --log trace --user root --pass root file:/mydata/database.db
     ports:
-      - "8000:8000"
+      # Localhost only: this starts with root:root, and 0.0.0.0 would
+      # expose that to the network. open_notebook reaches it over the
+      # internal compose network regardless.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./surreal_data:/mydata
 ```

--- a/docs/7-DEVELOPMENT/development-setup.md
+++ b/docs/7-DEVELOPMENT/development-setup.md
@@ -89,13 +89,15 @@ For local development, you can also use:
 
 ```bash
 # Start SurrealDB in memory
-docker run -d --name surrealdb -p 8000:8000 \
+# -p 127.0.0.1:8000:8000, not -p 8000:8000: this starts with root:root,
+# and publishing on 0.0.0.0 would expose that to the network.
+docker run -d --name surrealdb -p 127.0.0.1:8000:8000 \
   surrealdb/surrealdb:v2 start \
   --user root --pass password \
   --bind 0.0.0.0:8000 memory
 
 # Or with persistent storage
-docker run -d --name surrealdb -p 8000:8000 \
+docker run -d --name surrealdb -p 127.0.0.1:8000:8000 \
   -v surrealdb_data:/data \
   surrealdb/surrealdb:v2 start \
   --user root --pass password \
@@ -333,7 +335,7 @@ git push origin feature/my-feature -f
 1. Check if SurrealDB is running: `docker ps | grep surrealdb`
 2. Verify URL in `.env`: Should be `ws://localhost:8000/rpc`
 3. Restart SurrealDB: `docker stop surrealdb && docker rm surrealdb`
-4. Then restart with: `docker run -d --name surrealdb -p 8000:8000 surrealdb/surrealdb:v2 start --user root --pass password --bind 0.0.0.0:8000 memory`
+4. Then restart with: `docker run -d --name surrealdb -p 127.0.0.1:8000:8000 surrealdb/surrealdb:v2 start --user root --pass password --bind 0.0.0.0:8000 memory`
 
 ### "Address already in use"
 

--- a/docs/7-DEVELOPMENT/quick-start.md
+++ b/docs/7-DEVELOPMENT/quick-start.md
@@ -37,7 +37,7 @@ In separate terminal windows:
 ```bash
 # Terminal 1: Start SurrealDB (database)
 make database
-# or: docker run -d --name surrealdb -p 8000:8000 surrealdb/surrealdb:v2 start --user root --pass password --bind 0.0.0.0:8000 memory
+# or: docker run -d --name surrealdb -p 127.0.0.1:8000:8000 surrealdb/surrealdb:v2 start --user root --pass password --bind 0.0.0.0:8000 memory
 
 # Terminal 2: Start API (backend on port 5055)
 make api


### PR DESCRIPTION
Fixes #1034

#1025 fixed the shipped `docker-compose.yml` to bind SurrealDB's port to 127.0.0.1 (it starts with root:root, so 0.0.0.0 exposure means anyone who can reach the host connects as root) — but ~9 docs pages still showed copy-pasteable snippets publishing it on 0.0.0.0. Users copy those snippets, not the repo's compose file.

**Fixed 10 spots across 7 files:** the four quick-start guides, the Docker Compose and reverse-proxy install docs, and the standalone `docker run` examples in development-setup.md and quick-start.md — all now use `127.0.0.1:8000:8000` port-publish syntax.

**Deliberately left `--bind 0.0.0.0:8000` untouched inside containers** — that's correct and necessary (SurrealDB must listen on all interfaces *inside* the container for the `open_notebook` service to reach it over the compose network; binding that to 127.0.0.1 would break inter-container connectivity). Host-level exposure is controlled entirely by the port-publish syntax — confirmed against #1025's merged diff, which only ever touched that line.

Docs-only change; per the contributing guide's issue-first workflow this references the existing issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

