### PR TITLE
docs(readme): add link to follow @lfnovo on X

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
     <br />
     <a href="https://www.open-notebook.ai"><strong>Checkout our website »</strong></a>
     <br />
+    Follow <a href="https://x.com/lfnovo">@lfnovo on X</a> for updates
+    <br />
     <br />
     <a href="docs/0-START-HERE/index.md">📚 Get Started</a>
     ·
@@ -328,6 +330,7 @@ See the [open issues](https://github.com/lfnovo/open-notebook/issues) for a full
 
 ### Join the Community
 - 💬 **[Discord Server](https://discord.gg/37XJPXfz2w)** - Get help, share ideas, and connect with other users
+- 𝕏 **[Follow @lfnovo on X](https://x.com/lfnovo)** - Project updates and news from the maintainer
 - 🐛 **[GitHub Issues](https://github.com/lfnovo/open-notebook/issues)** - Report bugs and request features
 - ⭐ **Star this repo** - Show your support and help others discover Open Notebook
 
@@ -353,6 +356,7 @@ Open Notebook is MIT licensed. See the [LICENSE](LICENSE) file for details.
 
 **Community Support**:
 - 💬 [Discord Server](https://discord.gg/37XJPXfz2w) - Get help, share ideas, and connect with users
+- 𝕏 [Follow @lfnovo on X](https://x.com/lfnovo) - Project updates and news from the maintainer
 - 🐛 [GitHub Issues](https://github.com/lfnovo/open-notebook/issues) - Report bugs and request features
 - 🌐 [Website](https://www.open-notebook.ai) - Learn more about the project
 


### PR DESCRIPTION
## Summary

Adds a link to follow [@lfnovo on X](https://x.com/lfnovo) in the README, in three places:

- Header block, under the website link
- "Join the Community" list
- "Community Support" list at the bottom

## Notes

README-only change; no CHANGELOG entry.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

