### PR TITLE
feat(models): offer newer ElevenLabs models in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Newer ElevenLabs models are now offered in model discovery: `eleven_v3`, `eleven_flash_v2_5` and `eleven_flash_v2` for text-to-speech, and `scribe_v2` for speech-to-text — alongside the existing models. Esperanto passes the `model_id` straight through to ElevenLabs, so no provider changes were needed (#PRNUM)
+
 ## [1.13.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Newer ElevenLabs models are now offered in model discovery: `eleven_v3`, `eleven_flash_v2_5` and `eleven_flash_v2` for text-to-speech, and `scribe_v2` for speech-to-text — alongside the existing models. Esperanto passes the `model_id` straight through to ElevenLabs, so no provider changes were needed (#PRNUM)
+- Newer ElevenLabs models are now offered in model discovery: `eleven_v3`, `eleven_flash_v2_5` and `eleven_flash_v2` for text-to-speech, and `scribe_v2` for speech-to-text — alongside the existing models. Esperanto passes the `model_id` straight through to ElevenLabs, so no provider changes were needed (#1167)
 
 ## [1.13.0] - 2026-07-13
 

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -489,8 +489,11 @@ async def discover_elevenlabs_models() -> List[DiscoveredModel]:
     if not api_key:
         return []
 
-    # ElevenLabs TTS models + the Scribe STT model
+    # ElevenLabs TTS models + the Scribe STT models
     elevenlabs_models = [
+        "eleven_v3",
+        "eleven_flash_v2_5",
+        "eleven_flash_v2",
         "eleven_multilingual_v2",
         "eleven_turbo_v2_5",
         "eleven_turbo_v2",
@@ -502,10 +505,9 @@ async def discover_elevenlabs_models() -> List[DiscoveredModel]:
         DiscoveredModel(name=m, provider="elevenlabs", model_type="text_to_speech")
         for m in elevenlabs_models
     ]
-    discovered.append(
-        DiscoveredModel(
-            name="scribe_v1", provider="elevenlabs", model_type="speech_to_text"
-        )
+    discovered.extend(
+        DiscoveredModel(name=m, provider="elevenlabs", model_type="speech_to_text")
+        for m in ("scribe_v2", "scribe_v1")
     )
     return discovered
 


### PR DESCRIPTION
## Summary

Adds newer ElevenLabs models to model discovery (`discover_elevenlabs_models()`):

- **TTS:** `eleven_v3`, `eleven_flash_v2_5`, `eleven_flash_v2`
- **STT:** `scribe_v2`

Existing models are kept. Esperanto passes `model_id` straight through to the ElevenLabs API (its ElevenLabs provider `_get_models()` returns `[]` and forwards `model_id`), so no provider/registry changes are needed — our static discovery list is the only source of truth for what's offered.

`classify_model_type` already handles the new ids correctly via its substring patterns (`eleven` → text_to_speech, `scribe` → speech_to_text, STT checked first).

## Test plan

- `ruff check` and `mypy` clean on the changed file
- `uv run pytest tests/test_model_discovery.py tests/test_credentials_api.py` — 32 passed (covers discovery + `classify_model_type` for elevenlabs/scribe)
- Confirmed the new models work natively through Esperanto

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

