### PR TITLE
docs: use OLLAMA_API_BASE in quick-start and compose examples

### DIFF
--- a/docs/0-START-HERE/quick-start-local.md
+++ b/docs/0-START-HERE/quick-start-local.md
@@ -60,7 +60,7 @@ services:
       - SURREAL_DATABASE=open_notebook
 
       # Ollama (required when running Ollama via Docker, as in this compose file)
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - OLLAMA_API_BASE=http://ollama:11434
     volumes:
       - ./notebook_data:/app/data
     depends_on:

--- a/examples/docker-compose-full-local.yml
+++ b/examples/docker-compose-full-local.yml
@@ -86,7 +86,7 @@ services:
       - SURREAL_DATABASE=open_notebook
 
       # Ollama connection (optional, can also configure via UI)
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - OLLAMA_API_BASE=http://ollama:11434
     volumes:
       - ./notebook_data:/app/data
     depends_on:

--- a/examples/docker-compose-ollama.yml
+++ b/examples/docker-compose-ollama.yml
@@ -52,7 +52,7 @@ services:
       - SURREAL_DATABASE=open_notebook
 
       # Ollama connection
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - OLLAMA_API_BASE=http://ollama:11434
     volumes:
       - ./notebook_data:/app/data
     depends_on:


### PR DESCRIPTION
## Problem

The quick-start guide and the Ollama Docker Compose examples set `OLLAMA_BASE_URL`, but no code path reads that variable. The authoritative env var is `OLLAMA_API_BASE`, declared as `required_env=("OLLAMA_API_BASE",)` in `open_notebook/ai/provider_registry.py`.

As a result, following the quick-start verbatim leaves Ollama permanently `unavailable` with no error surfaced to the user. This is the remainder of #127, which fixed only one file.

## Change

Renames `OLLAMA_BASE_URL` to `OLLAMA_API_BASE` in the three remaining shipped files, keeping the value (`http://ollama:11434`) unchanged:

- `docs/0-START-HERE/quick-start-local.md`
- `examples/docker-compose-ollama.yml`
- `examples/docker-compose-full-local.yml`

## Verification

- `grep -rn "OLLAMA_BASE_URL" docs/ examples/` returns nothing.
- The three files now use `OLLAMA_API_BASE`, matching `open_notebook/ai/provider_registry.py`.

Docs-only change; no code paths touched.

Closes #1148

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

