### PR TITLE
fix(credentials): emit vertex_project/vertex_location for Vertex credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Newer ElevenLabs models are now offered in model discovery: `eleven_v3`, `eleven_flash_v2_5` and `eleven_flash_v2` for text-to-speech, and `scribe_v2` for speech-to-text — alongside the existing models. Esperanto passes the `model_id` straight through to ElevenLabs, so no provider changes were needed (#1167)
 
 ### Fixed
+- Vertex credentials now configure text-to-speech (and other Vertex providers) correctly when used through a stored credential rather than environment variables. `Credential.to_esperanto_config()` emitted the generic `project`/`location` keys, but esperanto's Vertex providers expect `vertex_project`/`vertex_location` — so credential-linked Vertex TTS crashed with `__init__() got an unexpected keyword argument 'project'`. The config now maps to the Vertex-specific key names for the `vertex` provider only; the `Credential` schema/API fields stay `project`/`location`, and non-Vertex providers are unaffected (#1151)
 - Deleting a notebook now also deletes its chat sessions instead of leaving orphaned `chat_session` records behind. The notebook `delete()` cascade enumerates the notebook's chat sessions (via the existing `refers_to` relation) and deletes each one alongside the notes and exclusive sources it already handled (#1124)
 
 ## [1.13.0] - 2026-07-13

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -125,10 +125,15 @@ class Credential(ObjectModel):
             config["endpoint_stt"] = self.endpoint_stt
         if self.endpoint_tts:
             config["endpoint_tts"] = self.endpoint_tts
+        # Vertex esperanto providers accept `vertex_project`/`vertex_location`,
+        # not the generic `project`/`location` keys (#1151). Emit the Vertex-
+        # specific names so credential-linked (non-env) config actually
+        # configures the provider instead of crashing on unexpected kwargs.
+        is_vertex = bool(self.provider) and self.provider.lower() == "vertex"
         if self.project:
-            config["project"] = self.project
+            config["vertex_project" if is_vertex else "project"] = self.project
         if self.location:
-            config["location"] = self.location
+            config["vertex_location" if is_vertex else "location"] = self.location
         if self.credentials_path:
             config["credentials_path"] = self.credentials_path
         if self.num_ctx is not None:

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -289,6 +289,46 @@ class TestCredentialNumCtx:
         assert "num_ctx" not in cred.to_esperanto_config()
 
 
+class TestCredentialVertexConfig:
+    """Tests for #1151 - Vertex credentials must emit vertex_project/vertex_location."""
+
+    def test_vertex_emits_vertex_prefixed_keys(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(
+            name="Vertex",
+            provider="vertex",
+            modalities=["text_to_speech"],
+            project="my-gcp-project",
+            location="us-central1",
+            credentials_path="/secrets/sa.json",
+        )
+        config = cred.to_esperanto_config()
+        # esperanto's Vertex providers accept vertex_project/vertex_location
+        assert config["vertex_project"] == "my-gcp-project"
+        assert config["vertex_location"] == "us-central1"
+        # The generic keys must NOT be emitted for vertex
+        assert "project" not in config
+        assert "location" not in config
+        # credentials_path is passed through unchanged
+        assert config["credentials_path"] == "/secrets/sa.json"
+
+    def test_non_vertex_provider_keeps_generic_keys(self):
+        from open_notebook.domain.credential import Credential
+
+        cred = Credential(
+            name="Other",
+            provider="openai",
+            project="my-project",
+            location="us-central1",
+        )
+        config = cred.to_esperanto_config()
+        assert config["project"] == "my-project"
+        assert config["location"] == "us-central1"
+        assert "vertex_project" not in config
+        assert "vertex_location" not in config
+
+
 class TestAudioProviderWiring:
     """Tests for the new audio providers (Mistral STT/TTS, Deepgram TTS, xAI TTS)."""
 


### PR DESCRIPTION
Fixes Bug 1 of #1151: `Credential.to_esperanto_config()` emitted the generic `project`/`location` keys for all providers, but esperanto's Vertex providers (`VertexTextToSpeechModel` and the LLM/embedding Vertex providers) accept `vertex_project`/`vertex_location`. As a result, credential-linked (non-env) Vertex TTS generation crashed with:

```
TextToSpeechModel.__init__() got an unexpected keyword argument 'project'
```

## Change

In `to_esperanto_config()`, when `self.provider == "vertex"`, emit `vertex_project`/`vertex_location` instead of `project`/`location` (`credentials_path` unchanged). The `Credential` schema/API field names stay `project`/`location` — only the emitted esperanto config keys change. Non-Vertex providers are unaffected.

Confirmed against the esperanto Vertex constructor signatures (`vertex_project`/`vertex_location`) in `providers/tts/vertex.py`, `providers/llm/vertex.py`, and `providers/embedding/vertex.py`.

Bug 2 (auth ignoring `credentials_path`) is already fixed upstream in esperanto 2.25.1 (VertexAuthMixin) and is out of scope here.

## Tests

- New `TestCredentialVertexConfig` asserting a `vertex` credential emits `vertex_project`/`vertex_location` (and not the generic keys), and that a non-vertex provider keeps `project`/`location`.
- Full suite green: `uv run pytest tests/` → 561 passed. Ruff + mypy clean.

Closes #1151

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

