### PR TITLE
feat(providers): OpenRouter text-to-speech and speech-to-text support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **OpenRouter now supports text-to-speech and speech-to-text**, not just LLMs and embeddings (esperanto 2.25.0). The provider's modalities were extended so the Settings UI offers TTS/STT when registering OpenRouter models. Because OpenRouter's `/models` listing does not reliably tag audio models, discovery seeds the working defaults esperanto ships — `microsoft/mai-voice-2` (TTS) and `openai/whisper-1` + `openai/whisper-large-v3` (STT) — alongside the API-discovered language models; any other `vendor/model` id can be added manually. Note that `microsoft/mai-voice-2` uses Microsoft neural voice names (e.g. `en-US-AvaNeural`), not OpenAI's `alloy`/`nova` set (#987)
 - Newer ElevenLabs models are now offered in model discovery: `eleven_v3`, `eleven_flash_v2_5` and `eleven_flash_v2` for text-to-speech, and `scribe_v2` for speech-to-text — alongside the existing models. Esperanto passes the `model_id` straight through to ElevenLabs, so no provider changes were needed (#1167)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Thanks to the [Esperanto](https://github.com/lfnovo/esperanto) library, we suppo
 | DeepSeek     | ✅          | ❌               | ❌             | ❌             |
 | Voyage       | ❌          | ✅               | ❌             | ❌             |
 | xAI          | ✅          | ❌               | ❌             | ✅             |
-| OpenRouter   | ✅          | ✅               | ❌             | ❌             |
+| OpenRouter   | ✅          | ✅               | ✅             | ✅             |
 | DashScope (Qwen) | ✅          | ❌               | ❌             | ❌             |
 | MiniMax      | ✅          | ❌               | ❌             | ❌             |
 | OpenAI Compatible* | ✅          | ✅               | ✅             | ✅             |

--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -17,6 +17,7 @@ from pydantic import SecretStr
 from api.models import CredentialResponse
 from open_notebook.ai.model_discovery import (
     ANTHROPIC_FALLBACK_MODELS,
+    OPENROUTER_AUDIO_MODELS,
     classify_model_type,
     fetch_anthropic_model_ids,
 )
@@ -553,7 +554,7 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
             response.raise_for_status()
             data = response.json()
 
-            return [
+            discovered = [
                 {
                     "name": m.get("id", ""),
                     "provider": provider,
@@ -562,6 +563,16 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
                 for m in data.get("data", [])
                 if m.get("id")
             ]
+            # OpenRouter's /models listing does not reliably surface its TTS/STT
+            # catalog, so seed the audio model ids esperanto ships as defaults.
+            if provider == "openrouter":
+                seen = {m["name"] for m in discovered}
+                for names in OPENROUTER_AUDIO_MODELS.values():
+                    for name in names:
+                        if name not in seen:
+                            discovered.append({"name": name, "provider": provider})
+                            seen.add(name)
+            return discovered
     except Exception as e:
         logger.warning(f"Failed to discover {provider} models: {e}")
         return []

--- a/docs/4-AI-PROVIDERS/index.md
+++ b/docs/4-AI-PROVIDERS/index.md
@@ -50,7 +50,8 @@ Open Notebook supports 17+ AI providers. This guide helps you **choose the right
 - Speed: Varies by model
 - Quality: Varies by model
 - Best for: Model comparison, testing, unified billing
-- Advantage: One API key for 100+ models from different providers
+- Advantage: One API key for 100+ models from different providers, plus
+  text-to-speech and speech-to-text models
 
 → [Setup Guide](../5-CONFIGURATION/ai-providers.md#openrouter)
 

--- a/docs/5-CONFIGURATION/ai-providers.md
+++ b/docs/5-CONFIGURATION/ai-providers.md
@@ -225,6 +225,13 @@ Opus: $10-50+/month
 - DeepSeek: `deepseek/deepseek-chat`
 - And many more...
 
+**Speech Models (Text-to-Speech & Speech-to-Text):**
+OpenRouter also exposes audio models. Discovery seeds working defaults; add any
+other `vendor/model` id manually via the custom-model input.
+- Text-to-Speech: `microsoft/mai-voice-2` (uses Microsoft neural voice names such
+  as `en-US-AvaNeural`, not OpenAI's `alloy`/`nova` set)
+- Speech-to-Text: `openai/whisper-1`, `openai/whisper-large-v3`
+
 **Recommended:**
 - For quality: `anthropic/claude-sonnet-4.5` (best overall)
 - For speed/cost: `google/gemini-2.5-flash` (very fast, cheap)

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -234,7 +234,11 @@ async def _test_openai_compatible_connection(base_url: str, api_key: Optional[st
         return False, f"Connection error: {str(e)[:100]}"
 
 # Default voices for TTS testing per provider
-# ElevenLabs and Mistral excluded: voices looked up dynamically via available_voices
+# ElevenLabs, Mistral and OpenRouter excluded: voices looked up dynamically via
+# available_voices. OpenRouter's voices are model-specific (its default model,
+# microsoft/mai-voice-2, uses Microsoft neural voice names like en-US-AvaNeural,
+# not OpenAI's alloy/nova set), so a single hard-coded voice can't fit every
+# OpenRouter TTS model — available_voices supplies a valid one for the default.
 DEFAULT_TEST_VOICES = {
     "openai": "alloy",
     "azure": "alloy",

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -161,6 +161,16 @@ MINIMAX_MODEL_TYPES = {
     "language": ["minimax", "abab"],
 }
 
+# OpenRouter added OpenAI-compatible TTS/STT endpoints (esperanto 2.25.0), but
+# its /models listing is dominated by language models and does not reliably tag
+# audio models — so audio discovery is a small static seed of the model ids
+# esperanto ships as working defaults. Users can add any other vendor/model id
+# manually via the custom-model input. Keys are esperanto's default models.
+OPENROUTER_AUDIO_MODELS: Dict[str, List[str]] = {
+    "text_to_speech": ["microsoft/mai-voice-2"],
+    "speech_to_text": ["openai/whisper-1", "openai/whisper-large-v3"],
+}
+
 
 def classify_model_type(model_name: str, provider: str) -> str:
     """
@@ -311,7 +321,6 @@ discover_groq_models = _make_openai_compat_discoverer("groq")
 discover_mistral_models = _make_openai_compat_discoverer("mistral")
 discover_deepseek_models = _make_openai_compat_discoverer("deepseek")
 discover_xai_models = _make_openai_compat_discoverer("xai")
-discover_openrouter_models = _make_openai_compat_discoverer("openrouter")
 discover_dashscope_models = _make_openai_compat_discoverer("dashscope")
 discover_minimax_models = _make_openai_compat_discoverer("minimax")
 
@@ -458,6 +467,39 @@ async def discover_ollama_models() -> List[DiscoveredModel]:
     except Exception as e:
         logger.warning(f"Failed to discover Ollama models: {e}")
 
+    return models
+
+
+async def discover_openrouter_models() -> List[DiscoveredModel]:
+    """Discover OpenRouter models (language/embedding + a static audio seed).
+
+    OpenRouter's OpenAI-compatible /models endpoint lists language (and some
+    embedding) models but does not reliably surface its TTS/STT catalog, so we
+    combine live API discovery with a small static seed of the audio model ids
+    esperanto ships as defaults (see OPENROUTER_AUDIO_MODELS). Returns [] when
+    live discovery yields nothing (missing key, HTTP/network error), so the
+    audio seed is never registered on top of a failed discovery.
+    """
+    models = await discover_openai_compatible_provider("openrouter")
+
+    # Only seed the static audio models when live discovery actually returned
+    # something. An empty result means the /models call failed (invalid key,
+    # HTTP error, network) — seeding on top of a failed discovery would make it
+    # look successful and auto-register unusable audio models during sync.
+    if not models:
+        return models
+
+    seen = {(m.name, m.model_type) for m in models}
+    for model_type, names in OPENROUTER_AUDIO_MODELS.items():
+        for name in names:
+            if (name, model_type) not in seen:
+                models.append(
+                    DiscoveredModel(
+                        name=name,
+                        provider="openrouter",
+                        model_type=model_type,
+                    )
+                )
     return models
 
 

--- a/open_notebook/ai/provider_registry.py
+++ b/open_notebook/ai/provider_registry.py
@@ -134,7 +134,7 @@ _PROVIDER_SPECS: Tuple[ProviderSpec, ...] = (
         ProviderSpec(
             name="openrouter",
             display_name="OpenRouter",
-            modalities=("language", "embedding"),
+            modalities=_ALL_MODALITIES,
             required_env=("OPENROUTER_API_KEY",),
             test_model="openai/gpt-3.5-turbo",
             docs_url="https://openrouter.ai/keys",

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -312,6 +312,9 @@ class TestAudioProviderWiring:
         assert "text_to_speech" in PROVIDER_MODALITIES["mistral"]
         assert "text_to_speech" in PROVIDER_MODALITIES["xai"]
         assert PROVIDER_MODALITIES["deepgram"] == ["text_to_speech"]
+        # OpenRouter added TTS/STT in esperanto 2.25.0 (issue #987).
+        assert "speech_to_text" in PROVIDER_MODALITIES["openrouter"]
+        assert "text_to_speech" in PROVIDER_MODALITIES["openrouter"]
 
     def test_deepgram_has_env_and_test_model(self):
         from api.credentials_service import PROVIDER_ENV_CONFIG

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -13,9 +13,11 @@ from open_notebook.ai import model_discovery
 from open_notebook.ai.model_discovery import (
     ANTHROPIC_FALLBACK_MODELS,
     OPENAI_COMPAT_PROVIDERS,
+    OPENROUTER_AUDIO_MODELS,
     PROVIDER_DISCOVERY_FUNCTIONS,
     discover_anthropic_models,
     discover_openai_compatible_provider,
+    discover_openrouter_models,
 )
 
 
@@ -178,6 +180,39 @@ class TestGenericOpenAICompatDiscovery:
         # OpenRouter models are always registered as language models
         assert models[0].model_type == "language"
         assert models[0].description == "Acme Embedding X"
+
+
+class TestOpenRouterDiscovery:
+    """discover_openrouter_models combines API discovery with an audio seed."""
+
+    @pytest.mark.asyncio
+    async def test_missing_key_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        assert await discover_openrouter_models() == []
+
+    @pytest.mark.asyncio
+    async def test_seeds_audio_models_alongside_api_models(self, monkeypatch):
+        def handler(url, headers, params, timeout):
+            return json_response(
+                url,
+                {"data": [{"id": "openai/gpt-4o", "name": "GPT-4o"}]},
+            )
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
+        monkeypatch.setattr(
+            model_discovery.httpx, "AsyncClient", make_fake_client(handler)
+        )
+
+        models = await discover_openrouter_models()
+        by_type = {(m.name, m.model_type) for m in models}
+
+        # Language model from the /models endpoint is preserved.
+        assert ("openai/gpt-4o", "language") in by_type
+        # The esperanto default audio models are seeded.
+        for model_type, names in OPENROUTER_AUDIO_MODELS.items():
+            for name in names:
+                assert (name, model_type) in by_type
+        assert all(m.provider == "openrouter" for m in models)
 
 
 class TestAnthropicDiscovery:


### PR DESCRIPTION
## Summary

esperanto 2.25.0 added OpenRouter support for text-to-speech (TTS) and speech-to-text (STT) — previously it was LLM/embedding only. This exposes those modalities in Open Notebook via the single-source-of-truth provider registry.

## Changes

- **`provider_registry.py`**: OpenRouter modalities extended to all four (`language`, `embedding`, `speech_to_text`, `text_to_speech`). Everything downstream (`PROVIDER_MODALITIES`, `TEST_MODELS`, `GET /api/providers`, the Settings UI) derives from this.
- **`model_discovery.py`**: new bespoke `discover_openrouter_models()` combines the live OpenAI-compatible `/models` listing with a small static seed of the audio model ids esperanto ships as working defaults — `microsoft/mai-voice-2` (TTS) and `openai/whisper-1` / `openai/whisper-large-v3` (STT). OpenRouter's `/models` listing does not reliably tag audio models, so they must be seeded. The seed is only added when live discovery actually returns models, so a failed discovery (bad key / network) never auto-registers unusable audio models during sync.
- **`credentials_service.py`**: the credential-based discovery flow seeds the same audio ids for OpenRouter, only after a successful `/models` response.
- **`connection_tester.py`**: OpenRouter is excluded from `DEFAULT_TEST_VOICES` (like ElevenLabs/Mistral) so TTS connection tests use esperanto's model-specific `available_voices`. OpenRouter voices are model-specific — its default model uses Microsoft neural voice names (e.g. `en-US-AvaNeural`), not OpenAI's `alloy`/`nova` set.
- **Tests**: new coverage for `discover_openrouter_models` (missing key -> empty; audio seed alongside API models) and an assertion that OpenRouter modalities include audio.
- **Docs**: README provider matrix, `docs/4-AI-PROVIDERS/index.md`, `docs/5-CONFIGURATION/ai-providers.md`, and `CHANGELOG.md`.

## Verification

- `uv run pytest tests/` -> 561 passed
- `ruff check .` clean; `mypy` clean on changed modules
- `GET /api/providers` reports `['language', 'embedding', 'speech_to_text', 'text_to_speech']` for openrouter
- Confirmed against esperanto 2.25.1: `AIFactory.create_speech_to_text("openrouter", ...)` and `create_text_to_speech("openrouter", ...)` are registered; default models `openai/whisper-1` (STT) and `microsoft/mai-voice-2` / `en-US-AvaNeural` (TTS)

Real end-to-end API calls to OpenRouter need a live `OPENROUTER_API_KEY` and were not exercised; registry/discovery wiring is covered by the test suite and in-process checks.

Closes #987