### PR TITLE
refactor(ai): remove redundant anthropic to_langchain shim

### DIFF
--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -258,14 +258,11 @@ class ModelManager:
 
         # Create model based on type (Esperanto will cache the instance)
         if model.type == "language":
-            language_model = AIFactory.create_language(
+            return AIFactory.create_language(
                 model_name=model.name,
                 provider=provider,
                 config=config,
             )
-            if model.provider == "anthropic_compatible":
-                setattr(language_model, "_open_notebook_provider", model.provider)
-            return language_model
         elif model.type == "embedding":
             return AIFactory.create_embedding(
                 model_name=model.name,

--- a/open_notebook/ai/provision.py
+++ b/open_notebook/ai/provision.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from esperanto import LanguageModel
 from langchain_core.language_models.chat_models import BaseChatModel
 from loguru import logger
@@ -7,34 +5,6 @@ from loguru import logger
 from open_notebook.ai.models import model_manager
 from open_notebook.exceptions import ConfigurationError
 from open_notebook.utils import token_count
-
-
-def _to_langchain(model: LanguageModel) -> BaseChatModel:
-    """Convert a model while preserving Anthropic-compatible base URLs.
-
-    Esperanto's to_langchain() maps anthropic_compatible to the Anthropic
-    implementation but drops the custom base_url; re-inject it via ChatAnthropic.
-    """
-    if getattr(model, "_open_notebook_provider", None) != "anthropic_compatible":
-        return model.to_langchain()
-
-    from langchain_anthropic import ChatAnthropic
-
-    base_url = model.base_url.rstrip("/") if model.base_url else None
-    if base_url and base_url.endswith("/v1"):
-        base_url = base_url.removesuffix("/v1")
-
-    config: dict[str, Any] = {
-        "model": model.get_model_name(),
-        "max_tokens": model.max_tokens,
-        "api_key": model.api_key,
-        "base_url": base_url,
-    }
-    if model.temperature is not None:
-        config["temperature"] = model.temperature
-    elif model.top_p is not None:
-        config["top_p"] = model.top_p
-    return ChatAnthropic(**config)
 
 
 async def provision_langchain_model(
@@ -88,4 +58,4 @@ async def provision_langchain_model(
             f"Please check that the model configured for '{default_type}' is a language model, not an embedding or speech model."
         )
 
-    return _to_langchain(model)
+    return model.to_langchain()

--- a/tests/test_anthropic_compatible_provider.py
+++ b/tests/test_anthropic_compatible_provider.py
@@ -1,7 +1,7 @@
 """Wiring tests for Anthropic-compatible credentials."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -165,7 +165,6 @@ async def test_model_manager_maps_normalized_url_to_anthropic_factory(
         provider="anthropic",
         config={"api_key": "sk-test", "base_url": expected_base_url},
     )
-    assert getattr(result, "_open_notebook_provider") == "anthropic_compatible"
 
 
 @pytest.mark.asyncio
@@ -276,24 +275,25 @@ async def test_model_manager_rejects_missing_compatible_endpoint():
 
 
 def test_langchain_bridge_forwards_base_url():
-    from open_notebook.ai.provision import _to_langchain
+    """An anthropic-compatible model must reach its custom base URL via the
+    native esperanto ``to_langchain()`` path (no Open Notebook shim), NOT the
+    official ``api.anthropic.com`` endpoint.
+    """
+    from esperanto import AIFactory
 
-    esperanto_model = MagicMock()
-    esperanto_model._open_notebook_provider = "anthropic_compatible"
-    esperanto_model.base_url = "https://api.example.com/v1"
-    esperanto_model.api_key = "sk-test"
-    esperanto_model.max_tokens = 850
-    esperanto_model.temperature = 0.5
-    esperanto_model.top_p = 0.9
-    esperanto_model.get_model_name.return_value = "compatible-model"
-
-    with patch("langchain_anthropic.ChatAnthropic") as chat_anthropic:
-        _to_langchain(esperanto_model)
-
-    chat_anthropic.assert_called_once_with(
-        model="compatible-model",
-        max_tokens=850,
-        api_key="sk-test",
-        base_url="https://api.example.com",
-        temperature=0.5,
+    esperanto_model = AIFactory.create_language(
+        model_name="compatible-model",
+        provider="anthropic",
+        config={
+            "api_key": "sk-test",
+            "base_url": "https://api.example.com/v1",
+            "max_tokens": 850,
+            "temperature": 0.5,
+        },
     )
+
+    langchain_model = esperanto_model.to_langchain()
+
+    # ChatAnthropic exposes the endpoint as ``anthropic_api_url`` (alias base_url).
+    assert langchain_model.anthropic_api_url == "https://api.example.com"
+    assert "api.anthropic.com" not in (langchain_model.anthropic_api_url or "")


### PR DESCRIPTION
## Summary

esperanto `2.25.1` (esperanto#229) now forwards a custom `base_url` for `anthropic_compatible` models natively inside `to_langchain()`. The `ChatAnthropic` re-injection shim introduced by #1043 to work around the old base_url-dropping behavior is therefore redundant and is removed here.

## Changes

- `open_notebook/ai/provision.py`: delete the `_to_langchain()` helper and call `model.to_langchain()` directly. The LangChain bridge is now identical for all providers. Removed the now-unused `typing.Any` import.
- `open_notebook/ai/models.py`: remove the `_open_notebook_provider` marker `setattr` — its only consumer was the shim.
- `tests/test_anthropic_compatible_provider.py`: `test_langchain_bridge_forwards_base_url` now exercises the native esperanto path — it builds a real anthropic model with a custom `base_url` and asserts the resulting `ChatAnthropic` reaches the custom endpoint (`anthropic_api_url`), NOT `api.anthropic.com`. The base_url-forwarding regression coverage is preserved.

## Verification

- `uv run pytest tests/` — 596 passed
- `ruff check` and `mypy` clean
- `grep -rn "_open_notebook_provider\|_to_langchain\|ChatAnthropic" open_notebook/` returns nothing

Closes #1055

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

