### PR TITLE
test(i18n): catch interpolation placeholder-format drift in locales

### DIFF
--- a/frontend/src/lib/locales/index.test.ts
+++ b/frontend/src/lib/locales/index.test.ts
@@ -14,6 +14,39 @@ const getKeys = (obj: Record<string, unknown>, prefix = ''): string[] => {
   }, [])
 }
 
+// Flatten to a map of dotted-key -> string leaf value (skips non-string leaves).
+const getLeafStrings = (
+  obj: Record<string, unknown>,
+  prefix = '',
+  acc: Record<string, string> = {},
+): Record<string, string> => {
+  for (const el of Object.keys(obj)) {
+    const val = obj[el]
+    if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+      getLeafStrings(val as Record<string, unknown>, prefix + el + '.', acc)
+    } else if (typeof val === 'string') {
+      acc[prefix + el] = val
+    }
+  }
+  return acc
+}
+
+// Collect the set of i18next `{{name}}` placeholder names in a string.
+const doubleBracePlaceholders = (value: string): Set<string> => {
+  const set = new Set<string>()
+  for (const m of value.matchAll(/\{\{\s*(\w+)\s*\}\}/g)) {
+    set.add(m[1])
+  }
+  return set
+}
+
+// Find stray single-brace `{name}` tokens (the exact #998 drift). We strip the
+// valid `{{...}}` pairs first, so only lone single-brace tokens remain.
+const straySingleBraceTokens = (value: string): string[] => {
+  const withoutDouble = value.replace(/\{\{\s*\w+\s*\}\}/g, '')
+  return [...withoutDouble.matchAll(/\{\s*\w+\s*\}/g)].map(m => m[0])
+}
+
 describe('Locale Parity', () => {
   const enKeys = getKeys(enUS)
 
@@ -29,6 +62,60 @@ describe('Locale Parity', () => {
 
       expect(missing, `Missing keys in ${code}: ${missing.join(', ')}`).toEqual([])
       expect(extra, `Extra keys in ${code}: ${extra.join(', ')}`).toEqual([])
+    },
+  )
+})
+
+describe('Placeholder Parity', () => {
+  const enLeaves = getLeafStrings(enUS)
+
+  const locales = Object.entries(resources).filter(([code]) => code !== 'en-US')
+
+  it.each(locales.map(([code, resource]) => [code, resource] as const))(
+    '%s interpolation placeholders should match en-US',
+    (code, resource) => {
+      const localeLeaves = getLeafStrings(
+        resource.translation as Record<string, unknown>,
+      )
+
+      const mismatches: string[] = []
+      const strays: string[] = []
+
+      for (const [key, enValue] of Object.entries(enLeaves)) {
+        const localeValue = localeLeaves[key]
+        // Missing keys are covered by the parity test; skip here.
+        if (localeValue === undefined) continue
+
+        const enSet = doubleBracePlaceholders(enValue)
+        const localeSet = doubleBracePlaceholders(localeValue)
+
+        const missing = [...enSet].filter(p => !localeSet.has(p))
+        const extra = [...localeSet].filter(p => !enSet.has(p))
+        if (missing.length || extra.length) {
+          mismatches.push(
+            `${key}: missing [${missing.join(', ')}] extra [${extra.join(', ')}]`,
+          )
+        }
+
+        // A stray single-brace token is only drift if en-US expects a
+        // placeholder there (i.e. the token name is a real placeholder).
+        const stray = straySingleBraceTokens(localeValue).filter(tok => {
+          const name = tok.replace(/[{}\s]/g, '')
+          return enSet.has(name)
+        })
+        if (stray.length) {
+          strays.push(`${key}: ${stray.join(', ')}`)
+        }
+      }
+
+      expect(
+        mismatches,
+        `Placeholder mismatches in ${code}:\n${mismatches.join('\n')}`,
+      ).toEqual([])
+      expect(
+        strays,
+        `Single-brace placeholder(s) in ${code} that should be {{...}}:\n${strays.join('\n')}`,
+      ).toEqual([])
     },
   )
 })

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -641,7 +641,7 @@ export const zhCN = {
     speakerDuplicatedDesc: "发言人配置 “{{name}}” 已成功复制。",
     failedToDuplicateSpeaker: "复制发言人配置失败",
     generationStarted: "播客启动生成",
-    generationStartedDesc: "剧集 \"{{name}}\" 正在创建中。",
+    generationStartedDesc: "播客生成已加入队列。",
     failedToStartGeneration: "启动播客生成失败",
     tryAgainMoment: "请稍后再试。",
     deleteProfileTitle: "删除简介？",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -641,7 +641,7 @@ export const zhTW = {
     speakerDuplicatedDesc: "發言人設定 “{{name}}” 已成功複製。",
     failedToDuplicateSpeaker: "複製發言人設定失敗",
     generationStarted: "播客啟動生成",
-    generationStartedDesc: "劇集 \"{{name}}\" 正在建立中。",
+    generationStartedDesc: "播客生成已加入佇列。",
     failedToStartGeneration: "啟動播客生成失敗",
     tryAgainMoment: "請稍後再試。",
     deleteProfileTitle: "刪除簡介？",


### PR DESCRIPTION
## Problem

The locale parity test (`frontend/src/lib/locales/index.test.ts`) and the `satisfies TranslationShape` type check only validate that translation **keys** match `en-US`. They do NOT validate the interpolation **placeholders** inside the values. This let a real regression (single-brace `{count}` vs i18next's double-brace `{{count}}`) get within one step of merging in #998.

## Change

Adds a `Placeholder Parity` describe block that, for every leaf string key present in both a locale and `en-US`:

- extracts the set of `{{...}}` placeholder names on both sides and fails on any missing or extra placeholder;
- flags any stray single-brace `{x}` token that maps to a real `en-US` placeholder (the exact #998 drift), while ignoring literal braces where `en-US` has no placeholder to avoid false positives.

Missing/extra keys remain the responsibility of the existing key-parity test.

## Drift fixed

The new test surfaced existing drift: `podcasts.generationStartedDesc` in `zh-CN` and `zh-TW` referenced a `{{name}}` placeholder that the `en-US` reference does not use. Both were realigned to the `en-US` string ("Podcast generation has been queued.").

## Verification

- `npm run test` — 140 passed
- `npm run lint` — 0 errors
- `npm run build` — succeeds
- Sanity-checked that injecting a single-brace `{name}` into a locale makes the new test fail, then reverted.

Closes #1159

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

