### PR TITLE
chore(release): automate container probes + document post-tag re-cut

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -148,6 +148,20 @@ accepted improvements immediately — update this document, the scripts under
 
 ## Known Gotchas
 
+- **Never leave the version bump uncommitted on a branch.** Editing
+  `pyproject.toml` / `CHANGELOG.md` for the cut and then switching branches
+  carries those unstaged changes along, and the next `git add -A` sweeps the
+  bump into an unrelated fix PR — the version silently ships inside a `fix(...)`
+  commit. The cut is always the **last** step, on its own branch, committed
+  immediately; if you must build an image early (which needs the bumped
+  version), do it on a throwaway branch and `git stash`/discard before moving
+  on (v1.14.0 lesson).
+- **A fix that lands after the cut requires a full re-cut, not a tag nudge.**
+  If the release was tagged but not yet published (no GitHub release, no
+  `v1-latest`) and a blocker is found in bucket C, the tag must move to the new
+  commit AND the version images must be rebuilt — a stale tag or stale registry
+  image will otherwise be what publication promotes to `v1-latest`. The exact
+  sequence is in `runbook.md` → "Re-cut after a post-tag fix" (v1.14.0 lesson).
 - **RC stack on non-default ports needs `API_URL`** or the browser talks to
   `host:5055` — on a dev machine that is the development API (data crossover).
   `rc-stack.sh` sets it; remember this for any custom setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Release image gate gained a `probe` scenario (`make release-test` runs it as part of `all`): container-level checks that a Python test suite can't cover because they depend on the shipped image's process supervision — `OPEN_NOTEBOOK_WORKER_MAX_TASKS` reaching the in-image worker (the supervisord `sh -c` expansion), and the worker surviving startup with `HTTP_PROXY` set while a user's `NO_PROXY` value is preserved (the internal SurrealDB websocket not being tunneled). Both were manual probes during the v1.14.0 release; they now run automatically. Release-process docs gained the post-tag re-cut sequence and a note on never leaving the version bump uncommitted (v1.14.0 retro)
+
 ## [1.14.0] - 2026-07-20
 
 ### Added

--- a/scripts/release-test/release-image-test.sh
+++ b/scripts/release-test/release-image-test.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 # Release image gate: fresh-install and upgrade tests against built Docker images.
 #
-# Usage: release-image-test.sh <fresh|upgrade|all> <new-image> [old-image]
+# Usage: release-image-test.sh <fresh|upgrade|probe|all> <new-image> [old-image]
 #   e.g. release-image-test.sh all lfnovo/open_notebook:1.12.0 lfnovo/open_notebook:1.11.0
+#
+# Scenarios:
+#   fresh   - empty DB -> migrations on boot -> worker processes a source
+#   upgrade - boot old image, seed, swap to new image on the same volume
+#   probe   - container-level checks for image-specific behavior (worker
+#             concurrency env expansion, HTTP proxy / no_proxy handling)
+#   all     - all of the above
 #
 # IMPORTANT: `make docker-build-local` tags the build with the CURRENT pyproject
 # version. If that version matches a published release, `docker pull` the
@@ -140,10 +147,85 @@ print('yes' if any(n.get('name')=='release-probe' for n in nbs) else 'no')" 2>/d
   echo
 }
 
+# Container-level probes for release changes that a repo test suite cannot cover
+# because they depend on the shipped image's process supervision and env
+# handling (supervisord, entrypoint), not on Python. Each is self-contained
+# (standalone `docker run`, own cleanup) so a failure here can never leak state
+# into the fresh/upgrade scenarios.
+probe_test() {
+  echo "═══ CONTAINER PROBES — $NEW_IMAGE"
+
+  # #1141: OPEN_NOTEBOOK_WORKER_MAX_TASKS must reach the worker. supervisord's
+  # command= does not run through a shell, so the value is only honored if the
+  # command is wrapped in `sh -c`. Boot with the var set and a dead DB (the
+  # worker logs its configured concurrency before it ever connects), then read
+  # the value back from its startup log.
+  local CID
+  CID=$(docker run -d --rm \
+    -e OPEN_NOTEBOOK_WORKER_MAX_TASKS=2 \
+    -e SURREAL_URL=ws://127.0.0.1:9/rpc \
+    -e OPEN_NOTEBOOK_ENCRYPTION_KEY=probe \
+    "$NEW_IMAGE" 2>/dev/null)
+  if [ -z "$CID" ]; then
+    bad "worker-concurrency probe: container did not start"
+  else
+    local CONC=""
+    for i in $(seq 1 20); do
+      CONC=$(docker logs "$CID" 2>&1 | grep -oiE "up to [0-9]+ concurrent tasks" | grep -oE "[0-9]+" | head -1)
+      [ -n "$CONC" ] && break
+      sleep 3
+    done
+    check "OPEN_NOTEBOOK_WORKER_MAX_TASKS honored by the in-image worker" "2" "$CONC"
+    docker rm -f "$CID" >/dev/null 2>&1
+  fi
+
+  # #1160: with HTTP_PROXY set, the internal SurrealDB websocket must NOT be
+  # tunneled through the proxy (websockets 15 auto-detects proxy env even for
+  # ws://). The app injects the internal hosts into NO_PROXY at startup. Boot
+  # with a dead proxy set plus a user NO_PROXY value, against a real DB, and
+  # assert the worker reaches RUNNING and the user's NO_PROXY value survives.
+  local NET=onrelprobe-net
+  docker network create "$NET" >/dev/null 2>&1
+  docker run -d --rm --network "$NET" --name onrelprobe-surreal \
+    surrealdb/surrealdb:v2 start --user root --pass root --bind 0.0.0.0:8000 memory >/dev/null 2>&1
+  sleep 6
+  local APP
+  APP=$(docker run -d --rm --network "$NET" --name onrelprobe-app \
+    -e SURREAL_URL=ws://onrelprobe-surreal:8000/rpc -e SURREAL_USER=root -e SURREAL_PASS=root \
+    -e SURREAL_NAMESPACE=open_notebook -e SURREAL_DATABASE=probe \
+    -e OPEN_NOTEBOOK_ENCRYPTION_KEY=probe \
+    -e HTTP_PROXY=http://127.0.0.1:9 -e HTTPS_PROXY=http://127.0.0.1:9 \
+    -e NO_PROXY=my-corp.example \
+    "$NEW_IMAGE" 2>/dev/null)
+  if [ -z "$APP" ]; then
+    bad "no_proxy probe: container did not start"
+  else
+    local RUNNING="" MERGED=""
+    for i in $(seq 1 20); do
+      RUNNING=$(docker logs "$APP" 2>&1 | grep -c "worker entered RUNNING state")
+      [ "$RUNNING" != "0" ] && break
+      sleep 3
+    done
+    if [ "$RUNNING" != "0" ]; then ok "worker starts with HTTP_PROXY set (internal ws not tunneled)"; else
+      bad "worker did not reach RUNNING with HTTP_PROXY set"; docker logs "$APP" 2>&1 | tail -8 | sed 's/^/    /'
+    fi
+    local REJECT
+    REJECT=$(docker logs "$APP" 2>&1 | grep -ciE "403|proxy.*reject")
+    check "no proxy-rejection (403) in worker/API startup" "0" "$REJECT"
+    MERGED=$(docker exec "$APP" sh -c 'python -c "import os;print(\"my-corp.example\" in (os.environ.get(\"NO_PROXY\") or \"\"))"' 2>/dev/null)
+    check "user NO_PROXY value preserved (not clobbered)" "True" "$MERGED"
+    docker rm -f "$APP" >/dev/null 2>&1
+  fi
+  docker rm -f onrelprobe-surreal >/dev/null 2>&1
+  docker network rm "$NET" >/dev/null 2>&1
+  echo
+}
+
 case "${1:-all}" in
   fresh)   fresh_test ;;
   upgrade) upgrade_test ;;
-  all)     fresh_test; upgrade_test ;;
+  probe)   probe_test ;;
+  all)     fresh_test; upgrade_test; probe_test ;;
 esac
 
 echo "═══ RESULT: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Retro improvements captured immediately after the v1.14.0 release, while the context is fresh (Phase 9 of the release process).

## What

**1. Container probes are now automated** (`scripts/release-test/release-image-test.sh`)

A new `probe` scenario, run as part of `make release-test ... all`, covers two release checks that a Python test suite structurally can't — they depend on the shipped image's process supervision (supervisord, entrypoint), not on app code:

- **`OPEN_NOTEBOOK_WORKER_MAX_TASKS` reaches the in-image worker** (#1141). supervisord's `command=` doesn't run through a shell, so the value is only honored via the `sh -c` wrapper — the probe boots with the var set and reads the concurrency back from the worker's startup log.
- **The worker survives startup with `HTTP_PROXY` set** (#1160), the internal SurrealDB websocket isn't tunneled (no 403), and a user's `NO_PROXY` value is preserved. Boots against a real SurrealDB with a dead proxy configured and asserts the worker reaches `RUNNING`.

Both were run by hand during the v1.14.0 release. Each probe is a self-contained standalone container with its own cleanup, so a failure can't leak state into the fresh/upgrade scenarios.

**2. Two gotchas documented** (`.github/RELEASE_PROCESS.md`)

- Never leave the version bump uncommitted on a branch — during v1.14.0 the bump was carried across a branch switch and swept into an unrelated fix PR by `git add -A`, shipping the version inside a `fix(...)` commit.
- A fix found after the tag exists but before publication requires a full re-cut (move the tag to the new commit **and** rebuild/re-push the version images), not just a tag nudge — otherwise publication promotes the un-fixed artifact to `v1-latest`.

The exact re-cut command sequence was also added to the release runbook (maintainer-local, gitignored).

## Verification

```
$ bash scripts/release-test/release-image-test.sh probe lfnovo/open_notebook:1.14.0
  ✅ OPEN_NOTEBOOK_WORKER_MAX_TASKS honored by the in-image worker
  ✅ worker starts with HTTP_PROXY set (internal ws not tunneled)
  ✅ no proxy-rejection (403) in worker/API startup
  ✅ user NO_PROXY value preserved (not clobbered)
═══ RESULT: 4 passed, 0 failed
```

`bash -n` clean on the script.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

