### PR TITLE
Fix single-source chat missing full document content

### DIFF
--- a/open_notebook/utils/context_builder.py
+++ b/open_notebook/utils/context_builder.py
@@ -185,10 +185,18 @@ async def build_source_context(
         # Truncate to the token budget: drop insights from the end. The
         # source is never dropped, even if it alone exceeds the budget —
         # an empty context is worse than a source whose full_text gets
-        # capped later by the prompt formatter (see docstring).
+        # capped later by the prompt formatter (see docstring). If the
+        # source alone already exceeds the budget, trimming insights can't
+        # bring the total under it anyway, so keep them all instead of
+        # discarding useful context for nothing.
         total_tokens = sum(item_tokens)
-        if max_tokens:
-            while total_tokens > max_tokens and insights:
+        source_tokens = item_tokens[0] if sources else 0
+        if max_tokens is not None:
+            while (
+                total_tokens > max_tokens
+                and insights
+                and source_tokens <= max_tokens
+            ):
                 total_tokens -= item_tokens.pop()
                 insights.pop()
 

--- a/open_notebook/utils/context_builder.py
+++ b/open_notebook/utils/context_builder.py
@@ -166,7 +166,13 @@ async def build_source_context(
             source = None
 
         if source:
-            source_context = await source.get_context(context_size="long")
+            # Pass insights=[] so get_context() doesn't fetch and embed them
+            # itself — this function fetches and represents insights
+            # separately below. Fetching them here too would hit the DB
+            # twice and double-count their tokens toward the budget.
+            source_context = await source.get_context(
+                context_size="long", insights=[]
+            )
             sources.append(source_context)
             item_tokens.append(token_count(str(source_context)))
 

--- a/open_notebook/utils/context_builder.py
+++ b/open_notebook/utils/context_builder.py
@@ -140,11 +140,16 @@ async def build_notebook_context(
 async def build_source_context(
     source_id: str, max_tokens: Optional[int] = None
 ) -> Dict[str, Any]:
-    """Assemble a single source's short context plus its insights.
+    """Assemble a single source's full content plus its insights.
 
-    Used by the source-chat graph. If `max_tokens` is given, insights are
-    dropped (last-fetched first) until the total fits — the source itself is
-    always kept.
+    Used by the source-chat graph. Uses the "long" context so the source's
+    full text is always included — a source with no insights/transformations
+    would otherwise leave the LLM with only the title. If `max_tokens` is
+    given, insights are dropped (last-fetched first) until the total fits.
+    The source itself is never dropped — a large full_text can alone exceed
+    the budget, and dropping it would leave an empty context; the caller
+    (source-chat's prompt formatter) already caps full_text at a fixed size
+    before it reaches the LLM.
 
     Returns a dict with "sources", "notes" (always empty), "insights",
     "total_tokens", "total_items" and per-type counts in "metadata".
@@ -161,7 +166,7 @@ async def build_source_context(
             source = None
 
         if source:
-            source_context = await source.get_context(context_size="short")
+            source_context = await source.get_context(context_size="long")
             sources.append(source_context)
             item_tokens.append(token_count(str(source_context)))
 
@@ -177,16 +182,15 @@ async def build_source_context(
         else:
             logger.warning(f"Source {source_id} not found")
 
-        # Truncate to the token budget: drop insights from the end (the
-        # source, added first, is dropped only if it alone exceeds the budget).
+        # Truncate to the token budget: drop insights from the end. The
+        # source is never dropped, even if it alone exceeds the budget —
+        # an empty context is worse than a source whose full_text gets
+        # capped later by the prompt formatter (see docstring).
         total_tokens = sum(item_tokens)
         if max_tokens:
-            while total_tokens > max_tokens and item_tokens:
+            while total_tokens > max_tokens and insights:
                 total_tokens -= item_tokens.pop()
-                if insights:
-                    insights.pop()
-                else:
-                    sources.pop()
+                insights.pop()
 
         total_items = len(sources) + len(insights)
         logger.info(f"Built context with {total_items} items, {total_tokens} tokens")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,7 +273,7 @@ class TestBuildSourceContext:
 
     @pytest.mark.asyncio
     async def test_source_and_insights_shape(self):
-        """The response carries the source's short context and its insights."""
+        """The response carries the source's full-text context and its insights."""
         source = _mock_source([_insight("source_insight:1")])
 
         with patch(
@@ -283,7 +283,9 @@ class TestBuildSourceContext:
             result = await build_source_context("123")
 
         mock_get.assert_awaited_once_with("source:123")  # bare id gets prefixed
-        source.get_context.assert_awaited_once_with(context_size="short")
+        # Long context is used so full_text is always included — a source
+        # with no insights would otherwise leave the LLM with only the title.
+        source.get_context.assert_awaited_once_with(context_size="long")
         assert result["sources"] == [
             {"id": "source:123", "title": "T", "full_text": "body"}
         ]
@@ -322,6 +324,28 @@ class TestBuildSourceContext:
         assert len(result["sources"]) == 1
         assert [i["id"] for i in result["insights"]] == ["source_insight:1"]
         assert result["total_tokens"] <= 600
+
+    @pytest.mark.asyncio
+    async def test_keeps_source_when_it_alone_exceeds_budget(self):
+        """A source whose full_text alone exceeds max_tokens is still
+        returned (not dropped) — an empty context is worse than one over
+        budget, and the prompt formatter caps full_text length downstream."""
+        source = SimpleNamespace(id="source:123")
+        big_text = "word " * 20000  # far bigger than the token budget below
+        source.get_context = AsyncMock(
+            return_value={"id": "source:123", "title": "T", "full_text": big_text}
+        )
+        source.get_insights = AsyncMock(return_value=[])
+
+        with patch(
+            "open_notebook.utils.context_builder.Source.get",
+            new=AsyncMock(return_value=source),
+        ):
+            result = await build_source_context("source:123", max_tokens=600)
+
+        assert len(result["sources"]) == 1
+        assert result["sources"][0]["full_text"] == big_text
+        assert result["total_tokens"] > 600
 
     @pytest.mark.asyncio
     async def test_missing_source_yields_empty_context(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -329,13 +329,18 @@ class TestBuildSourceContext:
     async def test_keeps_source_when_it_alone_exceeds_budget(self):
         """A source whose full_text alone exceeds max_tokens is still
         returned (not dropped) — an empty context is worse than one over
-        budget, and the prompt formatter caps full_text length downstream."""
+        budget, and the prompt formatter caps full_text length downstream.
+        Its insights are kept too: trimming them can't bring the total
+        under budget anyway (the source alone already exceeds it), so
+        dropping them would lose context for no benefit."""
         source = SimpleNamespace(id="source:123")
         big_text = "word " * 20000  # far bigger than the token budget below
         source.get_context = AsyncMock(
             return_value={"id": "source:123", "title": "T", "full_text": big_text}
         )
-        source.get_insights = AsyncMock(return_value=[])
+        source.get_insights = AsyncMock(
+            return_value=[_insight("source_insight:1"), _insight("source_insight:2")]
+        )
 
         with patch(
             "open_notebook.utils.context_builder.Source.get",
@@ -345,6 +350,10 @@ class TestBuildSourceContext:
 
         assert len(result["sources"]) == 1
         assert result["sources"][0]["full_text"] == big_text
+        assert [i["id"] for i in result["insights"]] == [
+            "source_insight:1",
+            "source_insight:2",
+        ]
         assert result["total_tokens"] > 600
 
     @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -284,8 +284,12 @@ class TestBuildSourceContext:
 
         mock_get.assert_awaited_once_with("source:123")  # bare id gets prefixed
         # Long context is used so full_text is always included — a source
-        # with no insights would otherwise leave the LLM with only the title.
-        source.get_context.assert_awaited_once_with(context_size="long")
+        # with no insights would otherwise leave the LLM with only the
+        # title. insights=[] avoids get_context() double-fetching/counting
+        # insights that this function already fetches separately below.
+        source.get_context.assert_awaited_once_with(
+            context_size="long", insights=[]
+        )
         assert result["sources"] == [
             {"id": "source:123", "title": "T", "full_text": "body"}
         ]


### PR DESCRIPTION
## Problem

Chatting/asking questions about an individual source (not a notebook) silently failed to use the document's actual content when no transformation/insight had been generated for it — the LLM only ever saw the source's title, with no error or warning. Users would get generic "I have no document to analyze" style answers without understanding why.

## Root cause

`build_source_context()` (in `open_notebook/utils/context_builder.py`, used by the source-chat graph) requested `context_size="short"` from `Source.get_context()`. That mode never includes `full_text` — only `id`, `title`, `insights`. Without insights (i.e. no transformation run on the source), the context was reduced to just the title.

Switching to `context_size="long"` alone was not enough: it exposed a second, previously latent bug. The function's token-budget truncation loop dropped the **entire source** whenever its `full_text` alone exceeded `max_tokens` (very common for real documents, since the budget is 50k tokens) — leaving an empty context for exactly the documents most likely to have real content.

## Fix

- Use `context_size="long"` in `build_source_context` so `full_text` is always included, regardless of whether the source has insights.
- Fix the truncation loop to only drop insights (last-fetched first) for budget — the source itself is never dropped. The prompt formatter (`_format_source_context` in `open_notebook/graphs/source_chat.py`) already caps `full_text` at a fixed size before it reaches the LLM, so this doesn't risk oversized prompts.

## Tests

Added/updated tests in `tests/test_utils.py`:
- `test_source_and_insights_shape` now asserts `context_size="long"` is requested.
- New `test_keeps_source_when_it_alone_exceeds_budget`: a source whose `full_text` alone exceeds `max_tokens` is still returned instead of being dropped.
- Existing `test_truncates_insights_to_token_budget` and `test_missing_source_yields_empty_context` still pass unchanged in behavior.

```
tests/test_utils.py::TestBuildSourceContext::test_source_and_insights_shape PASSED
tests/test_utils.py::TestBuildSourceContext::test_truncates_insights_to_token_budget PASSED
tests/test_utils.py::TestBuildSourceContext::test_keeps_source_when_it_alone_exceeds_budget PASSED
tests/test_utils.py::TestBuildSourceContext::test_missing_source_yields_empty_context PASSED
4 passed
```

Also manually verified end-to-end locally: uploaded a document with no transformation, opened its chat, and confirmed the LLM's response now reflects the document's actual content instead of the "no document" fallback.

This is a small, self-contained bug fix (per [CONTRIBUTING.md](../blob/main/docs/7-DEVELOPMENT/contributing.md) — "small, obvious bug fixes" are exempt from requiring a prior Discussion/Issue).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

