### PR TITLE
test(runtime): characterize Notebook Chat, Source Chat, and ASK

### DIFF
--- a/docs/7-DEVELOPMENT/index.md
+++ b/docs/7-DEVELOPMENT/index.md
@@ -36,6 +36,7 @@ Start with **[Contributing Guide](contributing.md)** for the workflow, then chec
 For deeper dives into specific subsystems:
 - **[Credentials](credentials.md)** - Provider credential storage, encryption, provisioning
 - **[Content Processing](content-processing.md)** - Chunking, embedding, context building, encryption
+- **[Research Runtime Baseline](research-runtime-baseline.md)** - Notebook Chat, Source Chat, and ASK topology and contracts
 - **[Podcasts](podcasts.md)** - Profile system, model registry, job lifecycle
 - **[Prompts](prompts.md)** - Prompt engineering patterns
 - **[Frontend](frontend.md)** - Next.js layers and data flows
@@ -72,6 +73,7 @@ repo root, `open_notebook/`, and `frontend/`.
 | [Architecture](architecture.md) | Understanding system | System design, tech stack, workflows |
 | [Credentials](credentials.md) | Understanding system | Provider credential subsystem |
 | [Content Processing](content-processing.md) | Understanding system | Chunking, embedding, context building |
+| [Research Runtime Baseline](research-runtime-baseline.md) | Understanding system | Notebook Chat, Source Chat, and ASK behavior |
 | [Podcasts](podcasts.md) | Understanding system | Podcast profiles and job lifecycle |
 | [Prompts](prompts.md) | Understanding system | Prompt engineering patterns |
 | [Frontend](frontend.md) | Understanding system | Next.js architecture and data flows |

--- a/docs/7-DEVELOPMENT/research-runtime-baseline.md
+++ b/docs/7-DEVELOPMENT/research-runtime-baseline.md
@@ -1,0 +1,309 @@
+# Research runtime baseline
+
+This document characterizes the interactive research runtimes in Open
+Notebook as they exist on `main` at commit `62b071b` (July 26, 2026):
+Notebook Chat, Source Chat, and ASK. It is an observation baseline, not a
+redesign proposal.
+
+Source Chat has one deliberate exception: the corrected behavior specified by
+[issue #1224](https://github.com/lfnovo/open-notebook/issues/1224) is the
+**future baseline**. The current behavior and that target are recorded
+separately so later work does not accidentally preserve the known context
+loss.
+
+## At a glance
+
+| Concern | Notebook Chat | Source Chat | ASK |
+|---|---|---|---|
+| API entry | `POST /api/chat/execute` | `POST /api/sources/{source_id}/chat/sessions/{session_id}/messages` | `POST /api/search/ask`; non-streaming variant at `/api/search/ask/simple` |
+| Topology | `START → agent → END` | `START → source_chat_agent → END` | `START → agent → Send(provide_answer)* → write_final_answer → END` |
+| Invocation | Synchronous graph `invoke` moved to a worker thread | Synchronous graph `invoke` moved to a worker thread | Async graph `astream(..., stream_mode="updates")` |
+| Context source | Context payload assembled by `/api/chat/context` and sent back by the client | Source and insights rebuilt from the database on every turn | Vector search per planned query across sources and notes |
+| Durable session row | SurrealDB `chat_session` related to a notebook by `refers_to` | SurrealDB `chat_session` related to a source by `refers_to` | None |
+| Conversation checkpoint | SQLite `SqliteSaver`, keyed by the normalized `chat_session:*` thread ID | SQLite `SqliteSaver`, keyed by the normalized `chat_session:*` thread ID | None |
+| Models | One chat model | One chat model | Strategy, per-search answer, and final-answer models |
+| Transport output | One JSON response containing the complete message list | SSE events | SSE events, or one `AskResponse` from the simple endpoint |
+
+The two chat graphs open separate SQLite connections to the same
+`LANGGRAPH_CHECKPOINT_FILE`, currently
+`./data/sqlite-db/checkpoints.sqlite`. ASK compiles without a checkpointer.
+
+## Notebook Chat
+
+### Topology and request path
+
+```text
+client
+  ├─ POST /api/chat/context
+  │    └─ build_notebook_context(notebook, context_config)
+  └─ POST /api/chat/execute
+       ├─ load chat_session and its refers_to notebook
+       ├─ load LangGraph checkpoint by thread_id
+       ├─ append HumanMessage
+       ├─ START → agent → END
+       ├─ save chat_session (updates its timestamp)
+       └─ return all checkpointed messages as JSON
+```
+
+Context selection and response execution are separate calls. The context
+endpoint returns the structured `{"sources": [...], "notes": [...]}` payload
+plus estimated token and character counts. The execute endpoint trusts the
+context payload sent by the caller; the graph itself performs no database
+search or context construction.
+
+### Inputs, state, and context
+
+The API input is:
+
+```python
+{
+    "session_id": str,
+    "message": str,
+    "context": dict,
+    "model_override": str | None,
+}
+```
+
+The graph state is:
+
+```python
+{
+    "messages": list,                 # add_messages reducer
+    "notebook": Notebook | None,
+    "context": str | None,            # receives the API's dict at runtime
+    "context_config": dict | None,    # declared but not populated by execute
+    "model_override": str | None,
+}
+```
+
+`build_notebook_context` has two policies:
+
+- With an explicit config, status strings select no context, source insights
+  (`Source.get_context("short")`), or full source content
+  (`Source.get_context("long")`). Notes are included only for `full content`.
+- Without a config, every notebook source and note is included with short
+  context. Source insights are batch-fetched before formatting.
+
+Per-item context failures are logged and skipped. The token count returned by
+the context endpoint is informational; it does not truncate the payload.
+
+The `chat/system.jinja` prompt receives notebook name/description, the supplied
+context, and the complete checkpointed message history. A `SystemMessage` is
+prepended for the model call.
+
+### Models, outputs, persistence, and events
+
+The router resolves model precedence as request override, then session
+override. The graph gives `config.configurable.model_id` precedence over the
+state override and provisions purpose `chat` with `max_tokens=8192`.
+Provisioning can still select the configured large-context model when the
+serialized payload exceeds 105,000 tokens.
+
+The model is invoked synchronously. Extended-thinking markup is removed from
+the returned `AIMessage`, and LangGraph checkpoints the updated state. The API
+returns:
+
+```python
+{"session_id": str, "messages": list[ChatMessage]}
+```
+
+Notebook Chat has no SSE event contract. Its observable completion is the
+single JSON response. SurrealDB persists session metadata and the notebook
+relationship; SQLite persists graph messages and the other state values.
+Deleting the session row does not explicitly delete its SQLite checkpoints.
+
+## Source Chat
+
+### Topology and request path
+
+```text
+client POST .../messages
+  ├─ verify source, chat_session, and refers_to relation in SurrealDB
+  ├─ save chat_session (updates its timestamp)
+  └─ SSE generator
+       ├─ load LangGraph checkpoint by thread_id
+       ├─ append HumanMessage and emit user_message
+       ├─ START → source_chat_agent → END
+       │    ├─ build_source_context(source_id, max_tokens=50_000)
+       │    ├─ format source + insights
+       │    └─ invoke one chat model
+       ├─ emit ai_message event(s)
+       ├─ emit context_indicators
+       └─ emit complete
+```
+
+### Inputs, state, and current context behavior
+
+The message API accepts `message` and an optional model override; source and
+session IDs are path parameters. The graph state is:
+
+```python
+{
+    "messages": list,                         # add_messages reducer
+    "source_id": str,
+    "source": Source | None,
+    "insights": list[SourceInsight] | None,
+    "context": str | None,
+    "model_override": str | None,
+    "context_indicators": {
+        "sources": list[str],
+        "insights": list[str],
+        "notes": list[str],
+    } | None,
+}
+```
+
+The context is rebuilt on every turn rather than reused from the checkpoint.
+The current builder:
+
+1. loads the source from SurrealDB;
+2. calls `Source.get_context(context_size="short")`, which normally returns ID,
+   title, and embedded insights but **not `full_text`**;
+3. separately loads source insights;
+4. counts the string representation of each item;
+5. when over 50,000 tokens, removes insights from the end and can ultimately
+   remove the source itself;
+6. formats the retained values for `source_chat/system.jinja`.
+
+The formatter has a second policy: if a source dict happens to contain
+`full_text`, it cuts that text at 5,000 characters and appends
+`[Content truncated]`. Consequently the token budget and character budget can
+compound. In normal domain behavior, the earlier `short` context call means
+the formatter usually has no source text to include at all.
+
+Context indicators contain IDs for the retained source and separately loaded
+insights. They indicate item inclusion, not proof that substantive source text
+reached the model.
+
+### Models, outputs, persistence, and events
+
+The request override uses truthy precedence over the session override. The
+graph provisions purpose `chat` with `max_tokens=8192`; the configurable model
+ID wins over the state override. The model is invoked synchronously and
+extended-thinking content is removed.
+
+SurrealDB persists the session row and its source relationship. SQLite
+checkpoints messages, source/context snapshots, and context indicators. As in
+Notebook Chat, deleting the SurrealDB session does not explicitly clear the
+checkpoint.
+
+The SSE contract is:
+
+1. `user_message`
+2. zero or more `ai_message`
+3. optional `context_indicators`
+4. `complete`
+
+On failure it emits `error` and no `complete`. The adapter iterates every AI
+message in the graph result, which is the accumulated message state; on later
+turns it can therefore re-emit earlier AI messages before the new one.
+
+### Future baseline: issue #1224
+
+The future Source Chat baseline is the corrected contract, not the lossy
+behavior above:
+
+- a source that fits within the context budget reaches the prompt in full;
+- an oversized source is truncated deterministically and explicitly;
+- there is one context budget, preferably token-based, with no second silent
+  formatter cut;
+- insights are preserved within the remaining budget;
+- missing text produces an honest state instead of implying content is
+  available;
+- context indicators describe what the model actually received.
+
+This baseline does not add single-source RAG, mentions, or structured
+citations. The characterization suite includes a strict expected failure for
+this future contract. It should be converted to a normal passing regression
+test when #1224 lands; current-behavior assertions that encode the 5,000
+character cut should be updated in the same change.
+
+## ASK
+
+### Topology and request path
+
+```text
+question
+  └─ agent: plan up to five searches
+       └─ Send(provide_answer) for each search
+            ├─ vector_search(term, 10, source=True, note=True)
+            └─ answer model for non-empty results
+                 └─ write_final_answer after fan-in
+                      └─ final-answer model
+```
+
+ASK is a request-scoped research graph. It has no session row, conversation
+history, durable state, or checkpoint. The graph state is:
+
+```python
+{
+    "question": str,
+    "strategy": Strategy,
+    "answers": list[str],       # operator.add reducer across fan-out branches
+    "final_answer": str,
+}
+```
+
+Each `Search` contains a term and extraction instructions. The strategy prompt
+allows up to five searches, but this limit is prompt guidance rather than a
+Pydantic length constraint.
+
+### Models and search
+
+The API requires explicit IDs for three model roles and verifies all three
+`Model` records in SurrealDB before streaming. It also requires a configured
+embedding model.
+
+| Stage | Model purpose | Limit | Input/output |
+|---|---|---:|---|
+| Strategy | `tools` | 2,000 tokens | Question → structured JSON `Strategy` |
+| Per-query answer | `tools` | 2,000 tokens | Question + instructions + vector results → cited partial answer |
+| Final answer | `tools` | 2,000 tokens | Question + strategy + accumulated partial answers → synthesis |
+
+Every planned search uses `vector_search(term, 10, True, True)`, including
+source chunks and notes with the vector-search default minimum score of `0.2`.
+The vector path generates a query embedding and calls SurrealDB's
+`fn::vector_search`. A query with no results contributes an empty answer list
+and does not invoke the per-query answer model.
+
+All model calls are async and thinking markup is removed. Retrieved result IDs
+are included in the per-query prompt; citation correctness remains a prompt
+contract rather than structured output validation.
+
+### Outputs and events
+
+The streaming endpoint emits graph updates as:
+
+1. `strategy` with reasoning and searches;
+2. one `answer` per partial answer;
+3. `final_answer`;
+4. `complete`, repeating the final answer.
+
+On failure it emits `error` and no `complete`. The simple endpoint consumes the
+same update stream internally and returns only:
+
+```python
+{"answer": str, "question": str}
+```
+
+No ASK question, strategy, retrieval result, partial answer, or final answer is
+persisted by this runtime.
+
+## Characterization test seams
+
+`tests/test_research_runtime_characterization.py` avoids provider and live
+database dependencies:
+
+- model provisioning returns mocked LangChain models;
+- SurrealDB record reads and vector search are mocked at their runtime
+  boundaries;
+- checkpoint state is represented by a mocked graph state where API behavior
+  is under test;
+- the compiled graphs are still inspected or invoked to freeze node topology,
+  reducers, fan-out, prompts, model-role selection, and outputs;
+- SSE adapters are consumed as async generators to freeze event order and
+  terminal behavior.
+
+The tests intentionally record surprising current behavior (Source Chat's
+secondary truncation and replay of accumulated AI messages). They should
+change only alongside an intentional runtime change.

--- a/tests/test_research_runtime_characterization.py
+++ b/tests/test_research_runtime_characterization.py
@@ -1,0 +1,480 @@
+"""Characterization coverage for the three interactive research runtimes.
+
+These tests deliberately exercise runtime boundaries with database access and
+language models mocked. They document behavior; they are not a redesign suite.
+The one strict xfail records the future Source Chat contract from issue #1224.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from api.routers.chat import ExecuteChatRequest, execute_chat
+from api.routers.search import stream_ask_response
+from api.routers.source_chat import stream_source_chat_response
+from open_notebook.graphs.ask import graph as ask_graph
+from open_notebook.graphs.chat import call_model_with_messages
+from open_notebook.graphs.chat import graph as notebook_chat_graph
+from open_notebook.graphs.source_chat import (
+    _call_model_with_source_context_inner,
+    _format_source_context,
+    source_chat_graph,
+)
+from open_notebook.utils.context_builder import build_source_context
+
+
+def _topology(graph):
+    drawable = graph.get_graph()
+    nodes = set(drawable.nodes)
+    edges = {(edge.source, edge.target, edge.conditional) for edge in drawable.edges}
+    return nodes, edges
+
+
+def _sse_payloads(events):
+    return [json.loads(event.removeprefix("data: ").strip()) for event in events]
+
+
+def test_runtime_topologies_and_checkpoints():
+    """Freeze graph nodes, edges, and checkpoint ownership."""
+    notebook_nodes, notebook_edges = _topology(notebook_chat_graph)
+    assert notebook_nodes == {"__start__", "agent", "__end__"}
+    assert notebook_edges == {
+        ("__start__", "agent", False),
+        ("agent", "__end__", False),
+    }
+    assert type(notebook_chat_graph.checkpointer).__name__ == "SqliteSaver"
+
+    source_nodes, source_edges = _topology(source_chat_graph)
+    assert source_nodes == {"__start__", "source_chat_agent", "__end__"}
+    assert source_edges == {
+        ("__start__", "source_chat_agent", False),
+        ("source_chat_agent", "__end__", False),
+    }
+    assert type(source_chat_graph.checkpointer).__name__ == "SqliteSaver"
+
+    ask_nodes, ask_edges = _topology(ask_graph)
+    assert ask_nodes == {
+        "__start__",
+        "agent",
+        "provide_answer",
+        "write_final_answer",
+        "__end__",
+    }
+    assert ask_edges == {
+        ("__start__", "agent", False),
+        ("agent", "provide_answer", True),
+        ("provide_answer", "write_final_answer", False),
+        ("write_final_answer", "__end__", False),
+    }
+    assert ask_graph.checkpointer is None
+
+
+def test_notebook_chat_prompt_model_selection_and_cleaned_output():
+    """Notebook Chat renders supplied context and invokes one synchronous model."""
+    model = MagicMock()
+    model.invoke.return_value = AIMessage(
+        content="<think>not user-visible</think>Notebook answer"
+    )
+    provision = AsyncMock(return_value=model)
+    state = {
+        "messages": [HumanMessage(content="What changed?")],
+        "notebook": SimpleNamespace(
+            name="Runtime Research", description="Current behavior"
+        ),
+        "context": "source:alpha says the baseline is observable",
+        "context_config": {"sources": {"alpha": "full content"}},
+        "model_override": "model:session",
+    }
+
+    with patch("open_notebook.graphs.chat.provision_langchain_model", new=provision):
+        result = call_model_with_messages(
+            state, {"configurable": {"model_id": "model:request"}}
+        )
+
+    provision.assert_awaited_once()
+    provision_args = provision.await_args
+    assert provision_args.args[1:] == ("model:request", "chat")
+    assert provision_args.kwargs == {"max_tokens": 8192}
+
+    payload = model.invoke.call_args.args[0]
+    assert [message.type for message in payload] == ["system", "human"]
+    assert "Runtime Research" in payload[0].content
+    assert "source:alpha says the baseline is observable" in payload[0].content
+    assert result["messages"].content == "Notebook answer"
+
+
+@pytest.mark.asyncio
+async def test_notebook_chat_api_uses_mocked_db_checkpoint_and_session_model():
+    """The API hydrates notebook/checkpoint state and persists the session touch."""
+    old_message = HumanMessage(content="Earlier", id="message:old")
+    ai_message = AIMessage(content="Current answer", id="message:new")
+    session = SimpleNamespace(
+        id="chat_session:session",
+        title="Session",
+        model_override="model:session",
+        save=AsyncMock(),
+    )
+    graph = MagicMock()
+    graph.get_state.return_value = SimpleNamespace(values={"messages": [old_message]})
+    graph.invoke.return_value = {
+        "messages": [
+            old_message,
+            HumanMessage(content="Now", id="message:user"),
+            ai_message,
+        ]
+    }
+    notebook = SimpleNamespace(id="notebook:research")
+
+    with (
+        patch(
+            "api.routers._chat_shared.ChatSession.get",
+            new=AsyncMock(return_value=session),
+        ) as get_session,
+        patch(
+            "api.routers.chat.repo_query",
+            new=AsyncMock(return_value=[{"out": "notebook:research"}]),
+        ) as repo_query,
+        patch(
+            "api.routers.chat.Notebook.get",
+            new=AsyncMock(return_value=notebook),
+        ) as get_notebook,
+        patch("api.routers.chat.chat_graph", new=graph),
+    ):
+        response = await execute_chat(
+            ExecuteChatRequest(
+                session_id="session",
+                message="Now",
+                context={"sources": [{"id": "source:alpha"}], "notes": []},
+            )
+        )
+
+    get_session.assert_awaited_once_with("chat_session:session")
+    repo_query.assert_awaited_once()
+    get_notebook.assert_awaited_once_with("notebook:research")
+    session.save.assert_awaited_once()
+
+    invocation = graph.invoke.call_args.kwargs
+    assert invocation["input"]["notebook"] is notebook
+    assert invocation["input"]["context"]["sources"][0]["id"] == "source:alpha"
+    assert invocation["input"]["messages"][-1].content == "Now"
+    assert invocation["config"]["configurable"] == {
+        "thread_id": "chat_session:session",
+        "model_id": "model:session",
+    }
+    assert response.session_id == "session"
+    assert [message.content for message in response.messages] == [
+        "Earlier",
+        "Now",
+        "Current answer",
+    ]
+
+
+def test_source_chat_current_prompt_has_secondary_character_truncation():
+    """Capture the pre-#1224 formatter behavior without endorsing it."""
+    full_text = ("A" * 5_000) + "TAIL_NOT_IN_CURRENT_PROMPT"
+    context_data = {
+        "sources": [
+            {
+                "id": "source:alpha",
+                "title": "Long source",
+                "full_text": full_text,
+            }
+        ],
+        "notes": [],
+        "insights": [
+            {
+                "id": "source_insight:one",
+                "source_id": "source:alpha",
+                "insight_type": "summary",
+                "content": "An insight",
+            }
+        ],
+        "total_tokens": 1_300,
+        "metadata": {"source_count": 1, "note_count": 0, "insight_count": 1},
+    }
+    model = MagicMock()
+    model.invoke.return_value = AIMessage(content="Source answer")
+
+    with (
+        patch(
+            "open_notebook.graphs.source_chat.build_source_context",
+            new=AsyncMock(return_value=context_data),
+        ) as build_context,
+        patch(
+            "open_notebook.graphs.source_chat.provision_langchain_model",
+            new=AsyncMock(return_value=model),
+        ) as provision,
+    ):
+        result = _call_model_with_source_context_inner(
+            {
+                "messages": [HumanMessage(content="Summarize")],
+                "source_id": "source:alpha",
+                "source": None,
+                "insights": None,
+                "context": None,
+                "model_override": "model:source",
+                "context_indicators": None,
+            },
+            {"configurable": {}},
+        )
+
+    build_context.assert_awaited_once_with(source_id="source:alpha", max_tokens=50_000)
+    provision_args = provision.await_args
+    assert provision_args.args[1:] == ("model:source", "chat")
+    assert provision_args.kwargs == {"max_tokens": 8192}
+
+    system_prompt = model.invoke.call_args.args[0][0].content
+    assert "A" * 5_000 in system_prompt
+    assert "TAIL_NOT_IN_CURRENT_PROMPT" not in system_prompt
+    assert "[Content truncated]" in system_prompt
+    assert result["context_indicators"] == {
+        "sources": ["source:alpha"],
+        "insights": ["source_insight:one"],
+        "notes": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_source_chat_current_builder_requests_short_context_without_full_text():
+    """Capture the database-backed context gap described by issue #1224."""
+    source = SimpleNamespace(id="source:alpha")
+
+    async def get_context(*, context_size):
+        if context_size == "long":
+            return {
+                "id": "source:alpha",
+                "title": "Current baseline",
+                "full_text": "Substantive source text",
+            }
+        return {"id": "source:alpha", "title": "Current baseline"}
+
+    source.get_context = AsyncMock(side_effect=get_context)
+    source.get_insights = AsyncMock(return_value=[])
+
+    with patch(
+        "open_notebook.utils.context_builder.Source.get",
+        new=AsyncMock(return_value=source),
+    ) as get_source:
+        context_data = await build_source_context("alpha", max_tokens=50_000)
+
+    get_source.assert_awaited_once_with("source:alpha")
+    source.get_context.assert_awaited_once_with(context_size="short")
+    assert context_data["sources"] == [
+        {"id": "source:alpha", "title": "Current baseline"}
+    ]
+    assert "full_text" not in context_data["sources"][0]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Future Source Chat baseline from issue #1224: use full source text "
+        "and one token budget, with no second formatter truncation"
+    ),
+)
+@pytest.mark.asyncio
+async def test_source_chat_issue_1224_future_baseline_includes_fitting_text_once():
+    """Executable future contract; expected to xfail until #1224 is implemented."""
+    full_text = ("B" * 6_000) + "END_OF_SOURCE"
+    source = SimpleNamespace(id="source:alpha")
+
+    async def get_context(*, context_size):
+        if context_size == "long":
+            return {
+                "id": "source:alpha",
+                "title": "Future baseline",
+                "full_text": full_text,
+            }
+        return {"id": "source:alpha", "title": "Future baseline"}
+
+    source.get_context = AsyncMock(side_effect=get_context)
+    source.get_insights = AsyncMock(return_value=[])
+
+    with patch(
+        "open_notebook.utils.context_builder.Source.get",
+        new=AsyncMock(return_value=source),
+    ):
+        context_data = await build_source_context("source:alpha", max_tokens=50_000)
+
+    source.get_context.assert_awaited_once_with(context_size="long")
+    assert context_data["sources"][0]["full_text"] == full_text
+    formatted = _format_source_context(context_data)
+    assert "END_OF_SOURCE" in formatted
+    assert "[Content truncated]" not in formatted
+
+
+@pytest.mark.asyncio
+async def test_source_chat_sse_event_order_and_accumulated_ai_replay():
+    """Source Chat emits the user event, all AI messages, indicators, then complete."""
+    graph = MagicMock()
+    graph.get_state.return_value = SimpleNamespace(
+        values={"messages": [AIMessage(content="Earlier answer")]}
+    )
+    graph.invoke.return_value = {
+        "messages": [
+            AIMessage(content="Earlier answer"),
+            HumanMessage(content="Next question"),
+            AIMessage(content="New answer"),
+        ],
+        "context_indicators": {
+            "sources": ["source:alpha"],
+            "insights": [],
+            "notes": [],
+        },
+    }
+
+    with patch("api.routers.source_chat.source_chat_graph", new=graph):
+        events = [
+            event
+            async for event in stream_source_chat_response(
+                "chat_session:session",
+                "source:alpha",
+                "Next question",
+                "model:source",
+            )
+        ]
+
+    payloads = _sse_payloads(events)
+    assert [payload["type"] for payload in payloads] == [
+        "user_message",
+        "ai_message",
+        "ai_message",
+        "context_indicators",
+        "complete",
+    ]
+    assert [payloads[1]["content"], payloads[2]["content"]] == [
+        "Earlier answer",
+        "New answer",
+    ]
+    assert graph.invoke.call_args.kwargs["config"]["configurable"] == {
+        "thread_id": "chat_session:session",
+        "model_id": "model:source",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ask_graph_fanout_search_and_three_mocked_models():
+    """ASK plans, searches the mocked database, answers, and synthesizes."""
+    strategy_model = MagicMock()
+    strategy_model.ainvoke = AsyncMock(
+        return_value=AIMessage(
+            content=(
+                '{"reasoning":"Find the runtime baseline",'
+                '"searches":[{"term":"runtime baseline",'
+                '"instructions":"Extract the persisted state"}]}'
+            )
+        )
+    )
+    answer_model = MagicMock()
+    answer_model.ainvoke = AsyncMock(
+        return_value=AIMessage(content="The state is checkpointed [note:one].")
+    )
+    final_model = MagicMock()
+    final_model.ainvoke = AsyncMock(
+        return_value=AIMessage(content="Final synthesis [note:one].")
+    )
+    provision = AsyncMock(side_effect=[strategy_model, answer_model, final_model])
+    vector_search = AsyncMock(
+        return_value=[
+            {
+                "id": "note:one",
+                "title": "Runtime note",
+                "content": "Checkpoint details",
+                "score": 0.9,
+            }
+        ]
+    )
+
+    with (
+        patch("open_notebook.graphs.ask.provision_langchain_model", new=provision),
+        patch("open_notebook.graphs.ask.vector_search", new=vector_search),
+    ):
+        result = await ask_graph.ainvoke(
+            {"question": "How is runtime state stored?"},
+            config={
+                "configurable": {
+                    "strategy_model": "model:strategy",
+                    "answer_model": "model:answer",
+                    "final_answer_model": "model:final",
+                }
+            },
+        )
+
+    vector_search.assert_awaited_once_with("runtime baseline", 10, True, True)
+    assert [item.args[1:3] for item in provision.await_args_list] == [
+        ("model:strategy", "tools"),
+        ("model:answer", "tools"),
+        ("model:final", "tools"),
+    ]
+    assert provision.await_args_list[0].kwargs == {
+        "max_tokens": 2000,
+        "structured": {"type": "json"},
+    }
+    assert provision.await_args_list[1].kwargs == {"max_tokens": 2000}
+    assert provision.await_args_list[2].kwargs == {"max_tokens": 2000}
+    assert result["strategy"].reasoning == "Find the runtime baseline"
+    assert result["answers"] == ["The state is checkpointed [note:one]."]
+    assert result["final_answer"] == "Final synthesis [note:one]."
+
+
+@pytest.mark.asyncio
+async def test_ask_sse_event_contract():
+    """The streaming adapter exposes graph updates and a terminal summary."""
+
+    class FakeAskGraph:
+        def astream(self, **kwargs):
+            self.kwargs = kwargs
+
+            async def chunks():
+                yield {
+                    "agent": {
+                        "strategy": SimpleNamespace(
+                            reasoning="Search once",
+                            searches=[
+                                SimpleNamespace(
+                                    term="checkpoint", instructions="Explain it"
+                                )
+                            ],
+                        )
+                    }
+                }
+                yield {"provide_answer": {"answers": ["Partial [note:one]."]}}
+                yield {"write_final_answer": {"final_answer": "Complete [note:one]."}}
+
+            return chunks()
+
+    graph = FakeAskGraph()
+    models = [
+        SimpleNamespace(id="model:strategy"),
+        SimpleNamespace(id="model:answer"),
+        SimpleNamespace(id="model:final"),
+    ]
+
+    with patch("api.routers.search.ask_graph", new=graph):
+        events = [
+            event
+            async for event in stream_ask_response("What is checkpointing?", *models)
+        ]
+
+    payloads = _sse_payloads(events)
+    assert [payload["type"] for payload in payloads] == [
+        "strategy",
+        "answer",
+        "final_answer",
+        "complete",
+    ]
+    assert payloads[-1]["final_answer"] == "Complete [note:one]."
+    assert graph.kwargs == {
+        "input": {"question": "What is checkpointing?"},
+        "config": {
+            "configurable": {
+                "strategy_model": "model:strategy",
+                "answer_model": "model:answer",
+                "final_answer_model": "model:final",
+            }
+        },
+        "stream_mode": "updates",
+    }


### PR DESCRIPTION
## Why

Open Notebook has three interactive research paths with materially different context, persistence, model, search, and event contracts. Those differences were spread across routers, LangGraph nodes, prompts, domain methods, and checkpoint code, which made future runtime work vulnerable to preserving accidental behavior.

This establishes an evidence-backed baseline before further research-runtime evolution. It also records the corrected Source Chat contract from #1224 as the future baseline without changing current runtime behavior in this PR.

## What

- adds `docs/7-DEVELOPMENT/research-runtime-baseline.md` covering Notebook Chat, Source Chat, and ASK:
  - topology and invocation mode
  - API and graph inputs/outputs
  - graph state and context construction
  - SurrealDB persistence and SQLite checkpoints
  - model selection and token limits
  - search behavior
  - SSE/JSON event contracts
- distinguishes observed Source Chat behavior from the future #1224 baseline
- adds isolated characterization tests with SurrealDB/model/checkpoint seams mocked
- freezes compiled graph topology, prompt/model selection, state hydration, ASK fan-out, and SSE ordering
- links the baseline from the development documentation index

No production runtime or public API code is changed.

## Key Decisions

- **Observed behavior remains explicit.** Current Source Chat short-context loss, the secondary 5,000-character formatter truncation, and accumulated AI-message replay are characterized rather than silently normalized.
- **#1224 is executable future intent.** A strict `xfail` captures the corrected one-budget/full-text contract. It should become a normal regression test when #1224 lands, while current-loss assertions are updated in the same change.
- **Tests stop at owned boundaries.** Model provisioning, SurrealDB reads/vector search, and checkpoint snapshots are mocked, while compiled LangGraph topology and ASK execution remain real. This avoids provider dependencies without reducing the suite to static source assertions.
- **Unrelated formatting is excluded.** The new test is Ruff-formatted; the repository-wide format check currently reports 65 pre-existing files that would be reformatted, so this PR avoids that unrelated mechanical diff.

## Validation

- `uv run pytest tests/ -q` — 645 passed, 1 expected xfail
- `uv run ruff check .` — passed
- `uv run ruff format tests/test_research_runtime_characterization.py` — passed
- `git diff --cached --check` — passed before commit

Related to #1224.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

