### PR TITLE
fix(ask): add OPEN_NOTEBOOK_ASK_MAX_TOKENS environment variable

### DIFF
--- a/open_notebook/config.py
+++ b/open_notebook/config.py
@@ -24,3 +24,6 @@ os.makedirs(PODCASTS_FOLDER, exist_ok=True)
 # pre-baked encoding baked into the image at build time).
 TIKTOKEN_CACHE_DIR = os.environ.get("TIKTOKEN_CACHE_DIR", "").strip() or f"{DATA_FOLDER}/tiktoken-cache"
 os.makedirs(TIKTOKEN_CACHE_DIR, exist_ok=True)
+
+# ASK GRAPH CONFIGURATION
+ASK_MAX_TOKENS = int(os.environ.get("ASK_MAX_TOKENS", "2000"))

--- a/open_notebook/graphs/ask.py
+++ b/open_notebook/graphs/ask.py
@@ -15,6 +15,7 @@ from open_notebook.exceptions import OpenNotebookError
 from open_notebook.utils import clean_thinking_content
 from open_notebook.utils.error_classifier import classify_error
 from open_notebook.utils.text_utils import extract_text_content
+from open_notebook.config import ASK_MAX_TOKENS
 
 
 class SubGraphState(TypedDict):
@@ -60,7 +61,7 @@ async def call_model_with_messages(state: ThreadState, config: RunnableConfig) -
             system_prompt,
             config.get("configurable", {}).get("strategy_model"),
             "tools",
-            max_tokens=2000,
+            max_tokens=ASK_MAX_TOKENS,
             structured=dict(type="json"),
         )
         # model = model.bind_tools(tools)

--- a/open_notebook/graphs/ask.py
+++ b/open_notebook/graphs/ask.py
@@ -29,7 +29,7 @@ class SubGraphState(TypedDict):
 class Search(BaseModel):
     term: str
     instructions: str = Field(
-        description="Tell the answeting LLM what information you need extracted from this search"
+        description="Tell the answering LLM what information you need extracted from this search"
     )
 
 

--- a/open_notebook/graphs/ask.py
+++ b/open_notebook/graphs/ask.py
@@ -115,7 +115,7 @@ async def provide_answer(state: SubGraphState, config: RunnableConfig) -> dict:
             system_prompt,
             config.get("configurable", {}).get("answer_model"),
             "tools",
-            max_tokens=2000,
+            max_tokens=ASK_MAX_TOKENS,
         )
         ai_message = await model.ainvoke(system_prompt)
         ai_content = extract_text_content(ai_message.content)

--- a/open_notebook/graphs/ask.py
+++ b/open_notebook/graphs/ask.py
@@ -134,7 +134,7 @@ async def write_final_answer(state: ThreadState, config: RunnableConfig) -> dict
             system_prompt,
             config.get("configurable", {}).get("final_answer_model"),
             "tools",
-            max_tokens=2000,
+            max_tokens=ASK_MAX_TOKENS,
         )
         ai_message = await model.ainvoke(system_prompt)
         final_content = extract_text_content(ai_message.content)


### PR DESCRIPTION
## Description

The `ask.py` graph hardcodes `max_tokens=2000` across strategy planning, individual query execution, and final answer generation. When using reasoning/MTP models (e.g. Gemma MTP, DeepSeek R1) that generate internal <think> tokens, the 2000 output token budget is often exhausted before the visible answer completes, resulting in truncated final responses in the UI.

## Related Issue

Fixes #1221 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

<!-- Describe the tests you ran and/or how you verified your changes work -->

- [x] Tested locally with Docker
- [ ] Tested locally with development setup
- [ ] Added new unit tests
- [ ] Existing tests pass (`uv run pytest`)
- [ ] Manual testing performed (describe below)

**Test Details:**

Mapped ask.py and the config.py within the volumes.

## Design Alignment

<!-- This section helps ensure your PR aligns with our project vision -->

**Which design principles does this PR support?** (See [VISION.md](https://github.com/lfnovo/open-notebook/blob/main/VISION.md))

- [ ] Privacy First
- [ ] Simplicity Over Features
- [ ] API-First Architecture
- [ ] Multi-Provider Flexibility
- [x] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**
<!-- Brief explanation of how your changes align with these principles -->

It adds an environment variable which is imported by config.py to be used in the ask.py

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality
- [x] My code follows PEP 8 style guidelines (Python)
- [ ] My code follows TypeScript best practices (Frontend)
- [ ] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [x] I have added comments to complex logic


## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](https://github.com/lfnovo/open-notebook/blob/main/docs/7-DEVELOPMENT/contributing.md)
- [x] I have read [VISION.md](https://github.com/lfnovo/open-notebook/blob/main/VISION.md)
- [x] This PR addresses an approved Issue assigned to me, **or** it's a small obvious fix (typo, docs, tiny bug) that doesn't need one — ideas and features begin in Discussions; reproducible bugs begin in Issues
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")

---

**Thank you for contributing to Open Notebook!** 🎉


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

