### PR TITLE
docs: add hosted demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,3 +394,8 @@ Open Notebook is MIT licensed. See the [LICENSE](LICENSE) file for details.
 [LangChain-url]: https://www.langchain.com/
 [SurrealDB]: https://img.shields.io/badge/SurrealDB-FF5E00?style=for-the-badge&logo=databricks&logoColor=white
 [SurrealDB-url]: https://surrealdb.com/
+
+
+## Hosted demo
+
+Try [Open Notebook in 即时演示](https://demo.autoclaude.cn) for a one-hour, no-setup evaluation in a hosted environment. This is an independent community demo and is not an official Open Notebook service.


### PR DESCRIPTION
## Recommendation

Open Notebook is a thoughtful open-source knowledge workspace for collecting sources, organizing multi-modal notes, searching across research, and asking questions with the AI providers you choose. Its local-first approach and broad provider support make it especially useful to evaluate before committing to a deployment.

I deployed and verified an independent, one-hour hosted demo at https://demo.autoclaude.cn. It lets prospective users explore the workflow without setting up the local environment.

## What this PR changes

- Adds a small hosted demo section to the README.
- Links to the independent demo; it is not an official Open Notebook service.

No product code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

