### PR TITLE
fix: dynamically resolve document language and RTL layout for ar-SA

### DIFF
--- a/frontend/src/app/(dashboard)/settings/components/SettingsForm.tsx
+++ b/frontend/src/app/(dashboard)/settings/components/SettingsForm.tsx
@@ -94,6 +94,17 @@ export function SettingsForm() {
     await updateSettings.mutateAsync(data)
   }
 
+  const { i18n } = useTranslation()
+  useEffect(() => {
+    if (i18n.language === 'ar-SA') {
+      document.documentElement.dir = 'rtl'
+      document.documentElement.lang = 'ar'
+    } else {
+      document.documentElement.dir = 'ltr'
+      document.documentElement.lang = i18n.language.split('-')[0]
+    }
+  }, [i18n.language])
+  
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">

--- a/frontend/src/app/(dashboard)/settings/components/SettingsForm.tsx
+++ b/frontend/src/app/(dashboard)/settings/components/SettingsForm.tsx
@@ -96,7 +96,13 @@ export function SettingsForm() {
 
   const { i18n } = useTranslation()
   useEffect(() => {
-    if (i18n.language === 'ar-SA') {
+    if (i18n.language.startsWith('ar')) {
+      document.documentElement.dir = 'rtl'
+      document.documentElement.lang = i18n.language
+    } else {
+      document.documentElement.dir = 'ltr'
+      document.documentElement.lang = i18n.language.split('-')[0]
+    }
       document.documentElement.dir = 'rtl'
       document.documentElement.lang = 'ar'
     } else {


### PR DESCRIPTION
Addressed the dynamic language metadata resolution and runtime RTL layout adjustments as requested by the code reviewer bot.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

