### PR TITLE
fix: surface missing model and 422 errors in transformation playground

### DIFF
--- a/frontend/src/app/(dashboard)/transformations/components/TransformationPlayground.tsx
+++ b/frontend/src/app/(dashboard)/transformations/components/TransformationPlayground.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Play, Loader2 } from 'lucide-react'
 import { Transformation } from '@/lib/types/transformations'
 import { useExecuteTransformation } from '@/lib/hooks/use-transformations'
+import { useToast } from '@/lib/hooks/use-toast'
 import { ModelSelector } from '@/components/common/ModelSelector'
 import { useTranslation } from '@/lib/hooks/use-translation'
 import ReactMarkdown from 'react-markdown'
@@ -30,22 +31,48 @@ export function TransformationPlayground({ transformations, selectedTransformati
   const [output, setOutput] = useState('')
   
   const executeTransformation = useExecuteTransformation()
+  const { toast } = useToast()
 
   const handleExecute = async () => {
-    if (!selectedId || !modelId || !inputText.trim()) {
+    if (!selectedId) {
+      toast({
+        title: t('common.error'),
+        description: t('transformations.selectToStart'),
+        variant: 'destructive',
+      })
+      return
+    }
+    if (!modelId) {
+      toast({
+        title: t('common.error'),
+        description: t('transformations.selectModel'),
+        variant: 'destructive',
+      })
+      return
+    }
+    if (!inputText.trim()) {
+      toast({
+        title: t('common.error'),
+        description: t('transformations.inputPlaceholder'),
+        variant: 'destructive',
+      })
       return
     }
 
-    const result = await executeTransformation.mutateAsync({
-      transformation_id: selectedId,
-      input_text: inputText,
-      model_id: modelId
-    })
-
-    setOutput(result.output)
+    try {
+      const result = await executeTransformation.mutateAsync({
+        transformation_id: selectedId,
+        input_text: inputText,
+        model_id: modelId
+      })
+      setOutput(result.output)
+    } catch {
+      // useExecuteTransformation.onError already surfaces a toast for API failures
+      // (including HTTP 422 validation errors). Avoid an unhandled rejection.
+    }
   }
 
-  const canExecute = selectedId && modelId && inputText.trim() && !executeTransformation.isPending
+  const canExecute = Boolean(selectedId && modelId && inputText.trim()) && !executeTransformation.isPending
 
   return (
     <div className="space-y-6">

--- a/frontend/src/lib/utils/error-handler.test.ts
+++ b/frontend/src/lib/utils/error-handler.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { formatApiError, getApiErrorMessage } from './error-handler'
+
+describe('formatApiError', () => {
+  it('returns FastAPI validation array messages instead of a blank generic string', () => {
+    const error = {
+      response: {
+        data: {
+          detail: [
+            {
+              type: 'missing',
+              loc: ['body', 'model_id'],
+              msg: 'Field required',
+              input: {},
+            },
+          ],
+        },
+      },
+      message: 'Request failed with status code 422',
+    }
+
+    expect(formatApiError(error)).toBe('Field required')
+    expect(getApiErrorMessage(error, (key) => key)).toBe('Field required')
+  })
+
+  it('still returns plain string detail messages', () => {
+    expect(
+      formatApiError({
+        response: { data: { detail: 'Transformation not found' } },
+      })
+    ).toBe('Transformation not found')
+  })
+})

--- a/frontend/src/lib/utils/error-handler.ts
+++ b/frontend/src/lib/utils/error-handler.ts
@@ -92,11 +92,24 @@ export function getApiErrorMessage(
 export function formatApiError(error: unknown): string {
   if (typeof error === 'string') return error;
   
-  const err = error as { response?: { data?: { detail?: string } }, detail?: string, message?: string };
-  const detail = err?.response?.data?.detail || err?.detail || err?.message;
+  const err = error as {
+    response?: { data?: { detail?: unknown } }
+    detail?: unknown
+    message?: string
+  };
+  const detail = err?.response?.data?.detail ?? err?.detail ?? err?.message;
   
   if (typeof detail === 'string') {
-    return detail; // We'll handle the actual translation using the key in the hook/component
+    return detail;
+  }
+
+  // FastAPI / Pydantic validation errors return detail as an array of
+  // {loc, msg, type} objects. Surface the first message so UI toasts are not blank.
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0] as { msg?: unknown }
+    if (typeof first?.msg === 'string' && first.msg.trim()) {
+      return first.msg
+    }
   }
   
   return "An unexpected error occurred";


### PR DESCRIPTION
## Summary
- Fixes #1253: the Transformations playground could fail silently when required fields were missing or when the API returned HTTP 422.
- Show destructive toasts for missing transformation/model/input, catch `mutateAsync` rejections so API errors stay handled by the existing mutation `onError` toast, and map FastAPI validation `detail` arrays to readable toast text.

## Test plan
- [x] `npx vitest run src/lib/utils/error-handler.test.ts` — 2 passed (validation array + string detail)
- [ ] Manual: leave Model empty / trigger 422 and confirm a toast appears
- [ ] CI

AI assistance was used to draft this fix; I reviewed and verified the change.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

