### PR TITLE
fix: filter OpenRouter discover list by selected model type

### DIFF
--- a/frontend/src/components/settings/DiscoverModelsDialog.tsx
+++ b/frontend/src/components/settings/DiscoverModelsDialog.tsx
@@ -90,12 +90,30 @@ export function DiscoverModelsDialog({
     setCustomModelSelected(false)
   }, [searchQuery])
 
-  // Filter discovered models by search query
+  // Filter discovered models by selected modality first, then search query.
+  // Without the type filter, switching Model Type left the full chat catalog
+  // visible (#1274) even though registration would stamp a different type.
   const filteredModels = useMemo(() => {
-    if (!searchQuery.trim()) return discoveredModels
+    const byType = discoveredModels.filter(
+      (m) => !m.model_type || m.model_type === selectedType
+    )
+    if (!searchQuery.trim()) return byType
     const q = searchQuery.toLowerCase()
-    return discoveredModels.filter(m => m.name.toLowerCase().includes(q))
-  }, [discoveredModels, searchQuery])
+    return byType.filter((m) => m.name.toLowerCase().includes(q))
+  }, [discoveredModels, searchQuery, selectedType])
+
+  // Drop selections that no longer belong to the active model type.
+  useEffect(() => {
+    setSelectedModels((prev) => {
+      const allowed = new Set(
+        discoveredModels
+          .filter((m) => !m.model_type || m.model_type === selectedType)
+          .map((m) => m.name)
+      )
+      const next = new Set([...prev].filter((name) => allowed.has(name)))
+      return next.size === prev.size ? prev : next
+    })
+  }, [discoveredModels, selectedType])
 
   // Show custom model option when search doesn't exactly match any discovered model
   const showCustomOption = useMemo(() => {

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -250,11 +250,39 @@ class ProviderDiscoverySpec:
     description: Optional[Callable[[dict], Optional[str]]] = None
 
 
+def _classify_openrouter(model: dict) -> str:
+    """Classify OpenRouter catalog entries using architecture metadata + name.
+
+    OpenRouter's /models payload is dominated by chat models, but embedding
+    (and some audio) ids are present. Blindly tagging everything as ``language``
+    made the discover UI show the same chat list after switching Model Type
+    (see #1274). Prefer ``architecture.output_modalities`` when present, then
+    fall back to id substrings, then language.
+    """
+    architecture = model.get("architecture") or {}
+    outputs = architecture.get("output_modalities") or []
+    if isinstance(outputs, (list, tuple, set)):
+        outs = {str(item).lower() for item in outputs}
+        if "embeddings" in outs or "embedding" in outs:
+            return "embedding"
+        if outs == {"audio"} or (outs & {"audio", "speech"} and "text" not in outs):
+            return "text_to_speech"
+
+    model_id = str(model.get("id") or "")
+    name_lower = model_id.lower()
+    if "embed" in name_lower:
+        return "embedding"
+    if "whisper" in name_lower:
+        return "speech_to_text"
+    if "tts" in name_lower or "/mai-voice" in name_lower or name_lower.endswith("-voice"):
+        return "text_to_speech"
+    return "language"
+
+
 # Per-provider quirk hooks that can't live in the (pure data) registry.
 _COMPAT_CLASSIFY: Dict[str, Callable[[dict], str]] = {
     "mistral": _classify_mistral,
-    # OpenRouter models are typically language models
-    "openrouter": lambda model: "language",
+    "openrouter": _classify_openrouter,
 }
 _COMPAT_DESCRIPTION: Dict[str, Callable[[dict], Optional[str]]] = {
     "openrouter": lambda model: model.get("name"),

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -174,7 +174,17 @@ class TestGenericOpenAICompatDiscovery:
         def handler(url, headers, params, timeout):
             return json_response(
                 url,
-                {"data": [{"id": "acme/embedding-x", "name": "Acme Embedding X"}]},
+                {
+                    "data": [
+                        {"id": "openai/gpt-4o", "name": "GPT-4o"},
+                        {
+                            "id": "openai/text-embedding-3-small",
+                            "name": "Text Embedding 3 Small",
+                            "architecture": {"output_modalities": ["embeddings"]},
+                        },
+                        {"id": "acme/chat-x", "name": "Acme Chat X"},
+                    ]
+                },
             )
 
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
@@ -183,10 +193,13 @@ class TestGenericOpenAICompatDiscovery:
         )
 
         models = await discover_openai_compatible_provider("openrouter")
-        assert len(models) == 1
-        # OpenRouter models are always registered as language models
-        assert models[0].model_type == "language"
-        assert models[0].description == "Acme Embedding X"
+        by_name = {m.name: m for m in models}
+        assert by_name["openai/gpt-4o"].model_type == "language"
+        assert by_name["openai/text-embedding-3-small"].model_type == "embedding"
+        assert by_name["acme/chat-x"].model_type == "language"
+        assert by_name["acme/chat-x"].description == "Acme Chat X"
+        # Name substring still classifies embeddings without architecture metadata.
+        assert by_name["openai/text-embedding-3-small"].description == "Text Embedding 3 Small"
 
 
 class TestOpenRouterDiscovery:


### PR DESCRIPTION
## Summary
- Fixes #1274: switching Model Type in Discover Models still showed the full chat catalog because OpenRouter discovery forced every id to `language` and the UI did not filter by `model_type`.
- Classify OpenRouter models from `architecture.output_modalities` / id substrings, and filter (plus prune) the dialog list by the selected modality.

## Test plan
- [x] Standalone `_classify_openrouter` checks for language / embedding / whisper / voice
- [x] Updated `test_openrouter_quirk_language_and_description` expectations
- [ ] CI / frontend manual: Discover Models → switch to Embedding → list shows embedding-classified ids only

AI assistance was used to draft this fix; I reviewed and verified the change.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

