### PR TITLE
fix(transformations): make insight max_tokens configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,6 @@ SURREAL_DATABASE=open_notebook
 
 # For more configuration options, see:
 # https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/environment-reference.md
+
+# Max output tokens for source insights / transformations (default: 8192)
+# OPEN_NOTEBOOK_TRANSFORM_MAX_TOKENS=8192

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -330,3 +330,9 @@ If you have these variables configured from a previous installation, click the *
 | `AZURE_OPENAI_API_KEY_EMBEDDING` | Azure OpenAI | Configure per-service in credential |
 | `AZURE_OPENAI_ENDPOINT_EMBEDDING` | Azure OpenAI | Configure per-service in credential |
 | `AZURE_OPENAI_API_VERSION_EMBEDDING` | Azure OpenAI | Configure per-service in credential |
+
+### `OPEN_NOTEBOOK_TRANSFORM_MAX_TOKENS`
+
+Maximum output tokens for source insights / transformations. Default: `8192`.
+Invalid or non-positive values fall back to `8192`.
+

--- a/open_notebook/graphs/transformation.py
+++ b/open_notebook/graphs/transformation.py
@@ -1,7 +1,11 @@
+import os
+from functools import cache
+
 from ai_prompter import Prompter
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
+from loguru import logger
 from typing_extensions import TypedDict
 
 from open_notebook.ai.provision import provision_langchain_model
@@ -11,6 +15,36 @@ from open_notebook.exceptions import OpenNotebookError
 from open_notebook.utils import clean_thinking_content
 from open_notebook.utils.error_classifier import classify_error
 from open_notebook.utils.text_utils import extract_text_content
+
+DEFAULT_TRANSFORM_MAX_TOKENS = 8192
+TRANSFORM_MAX_TOKENS_ENV_VAR = "OPEN_NOTEBOOK_TRANSFORM_MAX_TOKENS"
+
+
+@cache
+def get_transform_max_tokens() -> int:
+    """Read the configured output budget for transformation / insight generation."""
+    raw = os.environ.get(TRANSFORM_MAX_TOKENS_ENV_VAR)
+    if raw is None:
+        return DEFAULT_TRANSFORM_MAX_TOKENS
+
+    raw = raw.strip()
+    try:
+        max_tokens = int(raw)
+    except ValueError:
+        logger.warning(
+            f"{TRANSFORM_MAX_TOKENS_ENV_VAR}={raw!r} is not a valid integer; "
+            f"using the default of {DEFAULT_TRANSFORM_MAX_TOKENS}"
+        )
+        return DEFAULT_TRANSFORM_MAX_TOKENS
+
+    if max_tokens <= 0:
+        logger.warning(
+            f"{TRANSFORM_MAX_TOKENS_ENV_VAR}={raw!r} is not positive; "
+            f"using the default of {DEFAULT_TRANSFORM_MAX_TOKENS}"
+        )
+        return DEFAULT_TRANSFORM_MAX_TOKENS
+
+    return max_tokens
 
 
 class TransformationState(TypedDict):
@@ -48,7 +82,7 @@ async def run_transformation(state: dict, config: RunnableConfig) -> dict:
             str(payload),
             config.get("configurable", {}).get("model_id"),
             "transformation",
-            max_tokens=8192,
+            max_tokens=get_transform_max_tokens(),
         )
 
         response = await chain.ainvoke(payload)

--- a/tests/test_transform_token_budget.py
+++ b/tests/test_transform_token_budget.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import open_notebook.graphs.transformation as transformation
+
+
+@pytest.fixture(autouse=True)
+def clear_transform_max_tokens_cache():
+    transformation.get_transform_max_tokens.cache_clear()
+    yield
+    transformation.get_transform_max_tokens.cache_clear()
+
+
+def test_transform_max_tokens_defaults_when_env_is_unset(monkeypatch):
+    monkeypatch.delenv(transformation.TRANSFORM_MAX_TOKENS_ENV_VAR, raising=False)
+
+    assert transformation.get_transform_max_tokens() == 8192
+
+
+def test_transform_max_tokens_reads_positive_override(monkeypatch):
+    monkeypatch.setenv(transformation.TRANSFORM_MAX_TOKENS_ENV_VAR, "12000")
+
+    assert transformation.get_transform_max_tokens() == 12000
+
+
+def test_transform_max_tokens_caches_process_value(monkeypatch):
+    monkeypatch.setenv(transformation.TRANSFORM_MAX_TOKENS_ENV_VAR, "12000")
+
+    assert transformation.get_transform_max_tokens() == 12000
+
+    monkeypatch.setenv(transformation.TRANSFORM_MAX_TOKENS_ENV_VAR, "16000")
+    assert transformation.get_transform_max_tokens() == 12000
+
+    transformation.get_transform_max_tokens.cache_clear()
+    assert transformation.get_transform_max_tokens() == 16000
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "0", "-5", "  "])
+def test_transform_max_tokens_invalid_values_fall_back_to_default(monkeypatch, value):
+    monkeypatch.setenv(transformation.TRANSFORM_MAX_TOKENS_ENV_VAR, value)
+
+    assert transformation.get_transform_max_tokens() == 8192
+
+
+@pytest.mark.asyncio
+async def test_run_transformation_passes_configured_max_tokens(monkeypatch):
+    monkeypatch.setenv(transformation.TRANSFORM_MAX_TOKENS_ENV_VAR, "15000")
+    transformation.get_transform_max_tokens.cache_clear()
+
+    fake_chain = MagicMock()
+    fake_chain.ainvoke = AsyncMock(
+        return_value=MagicMock(content="complete insight text")
+    )
+    provision = AsyncMock(return_value=fake_chain)
+
+    with patch.object(transformation, "provision_langchain_model", provision):
+        result = await transformation.run_transformation(
+            {
+                "input_text": "source transcript",
+                "transformation": MagicMock(
+                    prompt="Summarize",
+                    title="Summary",
+                    model_id=None,
+                ),
+            },
+            {"configurable": {}},
+        )
+
+    assert result["output"] == "complete insight text"
+    assert provision.await_args.kwargs["max_tokens"] == 15000


### PR DESCRIPTION
## Summary
- Adds `OPEN_NOTEBOOK_TRANSFORM_MAX_TOKENS` (default `8192`) so source insights / transformations are not stuck on Esperanto’s silent 850-token default for non-reasoning `openai_compatible` models.
- Invalid or non-positive values fall back to `8192` with a warning.
- Documents the env var and covers it with focused regressions.

Fixes #1273

## Test plan
- [x] `pytest tests/test_transform_token_budget.py` (8 passed)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

