### PR TITLE
docs: standardize Models navigation path

### DIFF
--- a/docs/0-START-HERE/quick-start-cloud.md
+++ b/docs/0-START-HERE/quick-start-cloud.md
@@ -114,7 +114,7 @@ Your provider's models are now available!
 | **Groq** | `llama-3.3-70b-versatile` | Ultra-fast |
 | **Mistral** | `mistral-large-latest` | Strong European option |
 
-4. Click **Save**
+3. Click **Save**
 
 ---
 

--- a/docs/0-START-HERE/quick-start-cloud.md
+++ b/docs/0-START-HERE/quick-start-cloud.md
@@ -87,7 +87,7 @@ You should see the Open Notebook interface!
 
 ## Step 4: Configure Your AI Provider (1 min)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select your provider (e.g., Anthropic, Google, Groq, OpenRouter)
 4. Give it a name, paste your API key
@@ -167,7 +167,7 @@ Your provider's models are now available!
 
 ### "Model not found" Error
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Test Connection** on your credential
 3. If valid, click **Discover Models** → **Register Models**
 4. Check you have credits/access for the model

--- a/docs/0-START-HERE/quick-start-cloud.md
+++ b/docs/0-START-HERE/quick-start-cloud.md
@@ -103,9 +103,8 @@ Your provider's models are now available!
 
 ## Step 5: Configure Your Model (1 min)
 
-1. Go to **Settings** (gear icon)
-2. Navigate to **Models**
-3. Select your provider's model:
+1. In the sidebar, open **Manage** → **Models**
+2. Select your provider's model:
 
 | Provider | Recommended Model | Notes |
 |----------|-------------------|-------|

--- a/docs/0-START-HERE/quick-start-external-ollama.md
+++ b/docs/0-START-HERE/quick-start-external-ollama.md
@@ -109,7 +109,7 @@ Wait 10-15 seconds for services to start.
 
 ## Step 5: Configure Ollama Provider (1 min)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Ollama**
 4. Give it a name (e.g., "Local Ollama")
@@ -124,7 +124,7 @@ Wait 10-15 seconds for services to start.
 
 ## Step 6: Configure Models (1 min)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Set:
    - **Language Model**: `ollama/mistral` (or whichever model you downloaded)
    - **Embedding Model**: `ollama/nomic-embed-text`

--- a/docs/0-START-HERE/quick-start-openai.md
+++ b/docs/0-START-HERE/quick-start-openai.md
@@ -85,7 +85,7 @@ You should see the Open Notebook interface!
 
 ## Step 4: Configure Your OpenAI Provider (1 min)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **OpenAI**
 4. Give it a name (e.g., "My OpenAI Key")
@@ -140,7 +140,7 @@ Your OpenAI models are now available!
 
 ## Using Different Models
 
-In your notebook, go to **Settings** → **Models** to choose:
+In your notebook, go to **Manage** → **Models** to choose:
 - `gpt-4o` - Best quality (recommended)
 - `gpt-4o-mini` - Fast and cheap (good for testing)
 
@@ -160,7 +160,7 @@ Then access at `http://localhost:8503`
 
 ### "API key not working"
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Test Connection** on your OpenAI credential
 3. If it fails, verify your key at https://platform.openai.com
 4. Delete the credential and create a new one with the correct key

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -126,7 +126,7 @@ You should see the Open Notebook interface!
 
 ## Step 4: Configure AI Provider (2 min)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select your provider (e.g., OpenAI, Anthropic, Google)
 4. Give it a name, paste your API key
@@ -193,7 +193,7 @@ docker exec open-notebook-local-ollama-1 ollama pull mistral
 ```
 
 Configure Ollama in the Settings UI:
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **Ollama**
 3. Enter base URL: `http://ollama:11434`
 4. Click **Save**, then **Test Connection**
@@ -292,7 +292,7 @@ Then access at `http://localhost:8503`
 
 ### Credential Issues
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Test Connection** on the credential
 3. If it fails, verify key at provider's website
 4. Check you have credits in your account
@@ -353,7 +353,7 @@ Each example includes detailed comments and usage instructions.
 ## Next Steps
 
 1. **Add Content**: Sources, notebooks, documents
-2. **Configure Models**: Settings → Models (choose your preferences)
+2. **Configure Models**: Manage → Models (choose your preferences)
 3. **Explore Features**: Chat, search, transformations
 4. **Read Guide**: [User Guide](../3-USER-GUIDE/index.md)
 

--- a/docs/1-INSTALLATION/index.md
+++ b/docs/1-INSTALLATION/index.md
@@ -124,7 +124,7 @@ Before installing, you'll need:
 
 Once you're up and running:
 
-1. **Configure Models** - Choose your AI provider in Settings
+1. **Configure Models** - Choose your AI provider in Manage → Models
 2. **Create First Notebook** - Start organizing research
 3. **Add Sources** - PDFs, web links, documents
 4. **Explore Features** - Chat, search, transformations

--- a/docs/1-INSTALLATION/single-container.md
+++ b/docs/1-INSTALLATION/single-container.md
@@ -47,7 +47,7 @@ docker compose up -d
 Access: `http://localhost:8502`
 
 Then configure your AI provider:
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select your provider → Paste API key
 3. Click **Save**, then **Test Connection**
 4. Click **Discover Models** → **Register Models**
@@ -59,14 +59,14 @@ Then configure your AI provider:
 2. Search "Open Notebook"
 3. Set environment variables (at minimum: `OPEN_NOTEBOOK_ENCRYPTION_KEY`)
 4. Click "Deploy"
-5. Open the app → Go to **Settings → Models** to configure your AI provider
+5. Open the app → Go to **Manage → Models** to configure your AI provider
 
 **Railway:**
 1. Create new project
 2. Add `lfnovo/open_notebook:v1-latest-single`
 3. Set environment variables (at minimum: `OPEN_NOTEBOOK_ENCRYPTION_KEY`)
 4. Deploy
-5. Open the app → Go to **Settings → Models** to configure your AI provider
+5. Open the app → Go to **Manage → Models** to configure your AI provider
 
 **Render:**
 1. Create new Web Service
@@ -104,7 +104,7 @@ Open Notebook ships an EasyPanel template at [`examples/easypanel/`](https://git
 - **One-click (recommended):** once the template is published to the official [EasyPanel template gallery](https://github.com/easypanel-io/templates), create a new service from "Open Notebook", set an app password (or leave it blank to auto-generate one), and deploy.
 - **Manual:** copy `examples/easypanel/` into `templates/open-notebook` in a checkout of [`easypanel-io/templates`](https://github.com/easypanel-io/templates), run the templates playground (`npm run dev`), and create the template from the generated JSON in your EasyPanel instance.
 
-After deployment, open the EasyPanel domain and configure your AI provider in **Settings → Models**. See [`examples/easypanel/README.md`](https://github.com/lfnovo/open-notebook/blob/main/examples/easypanel/README.md) for details.
+After deployment, open the EasyPanel domain and configure your AI provider in **Manage → Models**. See [`examples/easypanel/README.md`](https://github.com/lfnovo/open-notebook/blob/main/examples/easypanel/README.md) for details.
 
 ---
 
@@ -120,7 +120,7 @@ After deployment, open the EasyPanel domain and configure your AI provider in **
 | `SURREAL_DATABASE` | DB name | `open_notebook` |
 | `API_URL` | External URL (for remote access) | `https://myapp.example.com` |
 
-AI provider API keys are configured via the **Settings → Models** UI after deployment.
+AI provider API keys are configured via the **Manage → Models** UI after deployment.
 
 ---
 
@@ -140,7 +140,7 @@ AI provider API keys are configured via the **Settings → Models** UI after dep
 
 Same as Docker Compose setup - just access via `http://localhost:8502` (local) or your platform's URL (cloud).
 
-1. Go to **Settings → Models** to add your AI provider credential
+1. Go to **Manage → Models** to add your AI provider credential
 2. **Test Connection** and **Discover Models**
 
 See [Docker Compose](docker-compose.md) for full post-install guide.

--- a/docs/1-INSTALLATION/windows-native.md
+++ b/docs/1-INSTALLATION/windows-native.md
@@ -228,7 +228,7 @@ GOOGLE_API_KEY=your-key-here
 
 ## Available AI Models
 
-Once running, add models in Settings. Common model names:
+Once running, add models in Manage → Models. Common model names:
 
 | Provider  | Models                                                       |
 | --------- | ------------------------------------------------------------ |

--- a/docs/3-USER-GUIDE/api-configuration.md
+++ b/docs/3-USER-GUIDE/api-configuration.md
@@ -75,7 +75,7 @@ API keys stored in the database are encrypted using Fernet (AES-128-CBC + HMAC-S
 3. You'll see existing credentials and an **Add Credential** button
 
 ```
-Navigation: Settings → Models
+Navigation: Manage → Models
 ```
 
 ---
@@ -118,7 +118,7 @@ Navigation: Settings → Models
 
 ### Step 1: Add Credential
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select your provider
 4. Give it a descriptive name (e.g., "My OpenAI Key", "Work Anthropic")
@@ -257,7 +257,7 @@ Google Cloud's enterprise AI platform:
 
 If you have existing API keys in environment variables (from a previous version):
 
-1. Open **Settings → Models**
+1. Open **Manage → Models**
 2. A banner appears: "Environment variables detected"
 3. Click **Migrate to Database**
 4. Keys are copied to the database (encrypted)
@@ -292,7 +292,7 @@ If you're upgrading from an older version that used the ProviderConfig system:
 
 - The migration happens automatically on first startup
 - Your existing configurations are converted to credentials
-- Check **Settings → Models** to verify the migration succeeded
+- Check **Manage → Models** to verify the migration succeeded
 - If you see issues, check the API logs for migration messages
 
 ---
@@ -356,7 +356,7 @@ API keys stored in the database are encrypted using Fernet (AES-128-CBC + HMAC-S
 
 ### Provider Shows "Not Configured"
 
-1. Check if a credential exists for this provider (Settings → Models)
+1. Check if a credential exists for this provider (Manage → Models)
 2. Test the credential connection
 3. Verify key format matches provider requirements
 4. Re-discover and register models if needed

--- a/docs/3-USER-GUIDE/api-configuration.md
+++ b/docs/3-USER-GUIDE/api-configuration.md
@@ -70,8 +70,8 @@ API keys stored in the database are encrypted using Fernet (AES-128-CBC + HMAC-S
 
 ## Accessing Credential Configuration
 
-1. Click **Settings** in the navigation bar
-2. Select **Models** tab
+1. In the sidebar, find the **Manage** section
+2. Click **Models**
 3. You'll see existing credentials and an **Add Credential** button
 
 ```

--- a/docs/3-USER-GUIDE/index.md
+++ b/docs/3-USER-GUIDE/index.md
@@ -136,7 +136,7 @@ Task: "I'm exploring a concept without knowing exact words"
 → Use: Search / Vector Search (semantic similarity)
 
 Task: "I need to add or change my AI provider API keys"
-→ Use: Settings / Models (configure providers without editing files)
+→ Use: Manage → Models (configure providers without editing files)
 ```
 
 ---

--- a/docs/4-AI-PROVIDERS/index.md
+++ b/docs/4-AI-PROVIDERS/index.md
@@ -245,7 +245,7 @@ Any use: Free (electricity only)
 
 1. **You've chosen a provider** (from this comparison guide)
 2. **Follow the setup guide**: [AI Providers Configuration](../5-CONFIGURATION/ai-providers.md)
-3. **Add your credential** in Settings → Models
+3. **Add your credential** in Manage → Models
 4. **Test your connection** and discover models
 5. **Start using Open Notebook!**
 

--- a/docs/5-CONFIGURATION/advanced.md
+++ b/docs/5-CONFIGURATION/advanced.md
@@ -197,7 +197,7 @@ ESPERANTO_SSL_VERIFY=false
 
 ### Use Different Providers for Different Tasks
 
-Configure multiple AI providers via **Settings → Models**. Each provider gets its own credential:
+Configure multiple AI providers via **Manage → Models**. Each provider gets its own credential:
 
 1. Add a credential for your main language model provider (e.g., OpenAI, Anthropic)
 2. Add a credential for embeddings (e.g., Voyage AI, or use the same provider)
@@ -208,7 +208,7 @@ Configure multiple AI providers via **Settings → Models**. Each provider gets 
 
 When using OpenAI-Compatible providers, you can configure per-service URLs in a single credential:
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **OpenAI-Compatible**
 3. Configure separate URLs for LLM, Embedding, TTS, and STT
 4. Click **Save**, then **Test Connection**
@@ -302,7 +302,7 @@ See [Content Processing Engines → Optional engines](../3-USER-GUIDE/content-pr
 OPEN_NOTEBOOK_ENCRYPTION_KEY    # Required for storing credentials
 ```
 
-AI provider API keys are configured via **Settings → Models** (not environment variables).
+AI provider API keys are configured via **Manage → Models** (not environment variables).
 
 ### Database
 ```env
@@ -336,7 +336,7 @@ ESPERANTO_LLM_TIMEOUT
 TTS_BATCH_SIZE
 ```
 
-> **Note:** `ELEVENLABS_API_KEY` is deprecated. Configure ElevenLabs via **Settings → Models**.
+> **Note:** `ELEVENLABS_API_KEY` is deprecated. Configure ElevenLabs via **Manage → Models**.
 
 ### Debugging
 ```env

--- a/docs/5-CONFIGURATION/ai-providers.md
+++ b/docs/5-CONFIGURATION/ai-providers.md
@@ -61,7 +61,7 @@ Heavy use: $50-100+/month
 ```
 
 **Troubleshooting:**
-- "Invalid API key" → Check key starts with "sk-proj-" and test the connection in Settings
+- "Invalid API key" → Check key starts with "sk-proj-" and test the connection in Manage → Models
 - "Rate limit exceeded" → Wait or upgrade account
 - "Model not available" → Try gpt-4o-mini instead, or re-discover models
 
@@ -109,7 +109,7 @@ Opus: $10-50+/month
 - Fast processing
 
 **Troubleshooting:**
-- "Invalid API key" → Check it starts with "sk-ant-" and test in Settings
+- "Invalid API key" → Check it starts with "sk-ant-" and test in Manage → Models
 - "Overloaded" → Anthropic is busy, retry later
 - "Model unavailable" → Re-discover models from the credential
 

--- a/docs/5-CONFIGURATION/ai-providers.md
+++ b/docs/5-CONFIGURATION/ai-providers.md
@@ -11,7 +11,7 @@ Complete setup instructions for each AI provider via the **Settings UI**.
 Open Notebook uses a **credential-based system** for managing AI providers:
 
 1. **Get your API key** from the provider's website
-2. **Open Settings** → **Models** → **Add Credential**
+2. Open **Manage** → **Models** → **Add Credential**
 3. **Test the connection** to verify it works
 4. **Discover & Register Models** to make them available
 5. **Start using** the provider in your notebooks
@@ -33,7 +33,7 @@ Open Notebook uses a **credential-based system** for managing AI providers:
 4. Add $5+ credits to account
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **OpenAI**
 4. Give it a name (e.g., "My OpenAI Key")
@@ -78,7 +78,7 @@ Heavy use: $50-100+/month
 4. Create new API key (starts with "sk-ant-")
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Anthropic**
 4. Give it a name, paste your API key
@@ -119,7 +119,7 @@ Opus: $10-50+/month
 
 Use this provider for services that implement the Anthropic Messages API at a custom URL.
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Add an **Anthropic Compatible** credential
 3. Enter the provider's API key and base URL (the API root, with or without a trailing `/v1`)
 4. Save and test the connection
@@ -139,7 +139,7 @@ Only language models are supported for Anthropic-compatible credentials.
 3. Create new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Google Gemini**
 4. Give it a name, paste your API key
@@ -179,7 +179,7 @@ Only language models are supported for Anthropic-compatible credentials.
 3. Create new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Groq**
 4. Give it a name, paste your API key
@@ -223,7 +223,7 @@ Only language models are supported for Anthropic-compatible credentials.
 4. Create new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **OpenRouter**
 4. Give it a name, paste your API key
@@ -283,7 +283,7 @@ Heavy use: Depends on models chosen
 4. Create a new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **DashScope (Qwen)**
 4. Give it a name, paste your API key
@@ -317,7 +317,7 @@ Heavy use: Depends on models chosen
 4. Create a new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **MiniMax**
 4. Give it a name, paste your API key
@@ -352,7 +352,7 @@ Heavy use: Depends on models chosen
 3. Create a new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Cohere**
 4. Give it a name, paste your API key
@@ -383,7 +383,7 @@ Heavy use: Depends on models chosen
 3. Create a new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Novita**
 4. Give it a name, paste your API key
@@ -409,7 +409,7 @@ Heavy use: Depends on models chosen
 3. Create a new API key
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **PayPerQ**
 4. Give it a name, paste your API key
@@ -438,7 +438,7 @@ Heavy use: Depends on models chosen
 3. Download a model: `ollama pull mistral`
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **Ollama**
 4. Give it a name (e.g., "Local Ollama")
@@ -456,7 +456,7 @@ See [Ollama Setup Guide](ollama.md) for detailed network configuration.
 Ollama models default to a **8,192-token** context window. This default is intentionally
 conservative so models run reliably on consumer GPUs (≈8GB VRAM) without running out of memory.
 If your hardware can handle more, set an optional **Context Window (num_ctx)** value on the
-Ollama credential (Settings → Models → edit the Ollama credential). It applies to all models
+Ollama credential (Manage → Models → edit the Ollama credential). It applies to all models
 that use that credential. Leave it empty to keep the default.
 
 - Raise it (e.g. `32768`) when ingesting large documents or using long chat histories.
@@ -523,7 +523,7 @@ CPU-only:
 3. Load models in the oMLX admin UI
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **oMLX**
 4. Base URL defaults to `http://localhost:11435/v1` (use `http://host.docker.internal:11435/v1` if Open Notebook is in Docker)
@@ -546,7 +546,7 @@ See [oMLX Setup Guide](omlx.md) for port conflict details and troubleshooting.
 5. Start server (default port: 1234)
 
 **Configure in Open Notebook:**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **OpenAI-Compatible**
 4. Give it a name (e.g., "LM Studio")
@@ -571,7 +571,7 @@ See [oMLX Setup Guide](omlx.md) for port conflict details and troubleshooting.
 
 For Text Generation UI, vLLM, or other OpenAI-compatible endpoints:
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential**
 3. Select provider: **OpenAI-Compatible**
 4. Enter the base URL for your endpoint (e.g., `http://localhost:8000/v1`)
@@ -593,7 +593,7 @@ See [OpenAI-Compatible Setup](openai-compatible.md) for detailed instructions.
 1. Create Azure OpenAI service in Azure portal
 2. Deploy GPT-4/3.5-turbo model
 3. Get your endpoint and key
-4. Go to **Settings** → **Models**
+4. Go to **Manage** → **Models**
 5. Click **Add Credential**
 6. Select provider: **Azure OpenAI**
 7. Fill in: API Key, Endpoint, API Version
@@ -650,7 +650,7 @@ Use OpenAI
 1. **Choose your provider** from above
 2. **Get API key** (if cloud) or install locally (if Ollama)
 3. **Set `OPEN_NOTEBOOK_ENCRYPTION_KEY`** in your docker-compose.yml (required for storing credentials)
-4. **Open Settings** → **Models** → **Add Credential**
+4. Open **Manage** → **Models** → **Add Credential**
 5. **Test Connection** to verify it works
 6. **Discover & Register Models** to make them available
 7. **Verify it works** with a test chat
@@ -665,7 +665,7 @@ Done!
 
 > **Deprecated**: Configuring AI provider API keys via environment variables is deprecated. Use the Settings UI instead. Environment variables may still work as a fallback but are no longer the recommended approach.
 
-If you are migrating from an older version that used environment variables, go to **Settings** → **Models** and click the **Migrate to Database** button to import your existing keys into the credential system.
+If you are migrating from an older version that used environment variables, go to **Manage** → **Models** and click the **Migrate to Database** button to import your existing keys into the credential system.
 
 ---
 

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -193,7 +193,7 @@ SURREAL_PASSWORD=password
 SURREAL_NAMESPACE=open_notebook
 SURREAL_DATABASE=open_notebook
 ```
-Then configure AI providers via **Settings → Models** in the browser.
+Then configure AI providers via **Manage → Models** in the browser.
 
 ### Production Deployment
 ```
@@ -259,7 +259,7 @@ env | grep -E "^[A-Z_]+=" | sort
 - **Quote values:** Use quotes for values with spaces: `API_URL="http://my server:5055"`
 - **Restart required:** Changes take effect after restarting services
 - **Secrets:** Don't commit encryption keys or passwords to git
-- **AI Providers:** Configure via **Settings → Models** in the browser. The provider env vars listed under [Legacy](#legacy-ai-provider-environment-variables-deprecated) are a deprecated fallback
+- **AI Providers:** Configure via **Manage → Models** in the browser. The provider env vars listed under [Legacy](#legacy-ai-provider-environment-variables-deprecated) are a deprecated fallback
 - **Migration:** Use Settings UI to migrate existing env vars to the credential system. See [API Configuration](../3-USER-GUIDE/api-configuration.md#migrating-from-environment-variables)
 
 ---
@@ -269,7 +269,7 @@ env | grep -E "^[A-Z_]+=" | sort
 - [ ] Set `OPEN_NOTEBOOK_ENCRYPTION_KEY` in docker-compose.yml
 - [ ] Set database credentials (`SURREAL_*`)
 - [ ] Start services
-- [ ] Open browser → Go to **Settings → Models**
+- [ ] Open browser → Go to **Manage → Models**
 - [ ] **Add Credential** for your AI provider
 - [ ] **Test Connection** to verify
 - [ ] **Discover & Register Models**
@@ -283,35 +283,35 @@ Done!
 
 ## Legacy: AI Provider Environment Variables (Deprecated)
 
-> **Deprecated**: The following AI provider environment variables are a deprecated fallback. They still work today (the runtime reads the database first and falls back to the environment), but there is no guarantee they keep working in future releases, and new automation should not be built on them. Configure providers via **Settings → Models** instead.
+> **Deprecated**: The following AI provider environment variables are a deprecated fallback. They still work today (the runtime reads the database first and falls back to the environment), but there is no guarantee they keep working in future releases, and new automation should not be built on them. Configure providers via **Manage → Models** instead.
 
 Why the UI is the source of truth: credentials in the database are encrypted at rest (via `OPEN_NOTEBOOK_ENCRYPTION_KEY`), can be added or rotated at runtime without restarts, and support multiple credentials per provider — none of which a single env var can express.
 
 **Headless, CI/CD and Docker deployments:** a declarative provisioning contract over the credentials API (a file describing providers and credentials, with `${VAR}`-style references resolved from the environment) is being designed in [Discussion #765](https://github.com/lfnovo/open-notebook/discussions/765). Until it ships, the env fallback is the only unattended path — use it knowing it is deprecated.
 
-If you have these variables configured from a previous installation, click the **Migrate to Database** button in **Settings → Models** to import them into the credential system, then remove them from your configuration.
+If you have these variables configured from a previous installation, click the **Migrate to Database** button in **Manage → Models** to import them into the credential system, then remove them from your configuration.
 
 | Variable | Provider | Replacement |
 |----------|----------|-------------|
-| `OPENAI_API_KEY` | OpenAI | Settings → Models → Add OpenAI Credential |
-| `ANTHROPIC_API_KEY` | Anthropic | Settings → Models → Add Anthropic Credential |
-| `GOOGLE_API_KEY` | Google Gemini | Settings → Models → Add Google Credential |
+| `OPENAI_API_KEY` | OpenAI | Manage → Models → Add OpenAI Credential |
+| `ANTHROPIC_API_KEY` | Anthropic | Manage → Models → Add Anthropic Credential |
+| `GOOGLE_API_KEY` | Google Gemini | Manage → Models → Add Google Credential |
 | `GEMINI_API_BASE_URL` | Google Gemini | Configure in Google Gemini credential |
-| `VERTEX_PROJECT` | Vertex AI | Settings → Models → Add Vertex AI Credential |
+| `VERTEX_PROJECT` | Vertex AI | Manage → Models → Add Vertex AI Credential |
 | `VERTEX_LOCATION` | Vertex AI | Configure in Vertex AI credential |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Vertex AI | Configure in Vertex AI credential |
-| `GROQ_API_KEY` | Groq | Settings → Models → Add Groq Credential |
-| `MISTRAL_API_KEY` | Mistral | Settings → Models → Add Mistral Credential |
-| `DEEPSEEK_API_KEY` | DeepSeek | Settings → Models → Add DeepSeek Credential |
-| `XAI_API_KEY` | xAI | Settings → Models → Add xAI Credential |
-| `OLLAMA_API_BASE` | Ollama | Settings → Models → Add Ollama Credential |
-| `OMLX_API_BASE` | oMLX | Settings → Models → Add oMLX Credential |
+| `GROQ_API_KEY` | Groq | Manage → Models → Add Groq Credential |
+| `MISTRAL_API_KEY` | Mistral | Manage → Models → Add Mistral Credential |
+| `DEEPSEEK_API_KEY` | DeepSeek | Manage → Models → Add DeepSeek Credential |
+| `XAI_API_KEY` | xAI | Manage → Models → Add xAI Credential |
+| `OLLAMA_API_BASE` | Ollama | Manage → Models → Add Ollama Credential |
+| `OMLX_API_BASE` | oMLX | Manage → Models → Add oMLX Credential |
 | `OMLX_API_KEY` | oMLX | Optional; only if oMLX was started with `--api-key` |
-| `OPENROUTER_API_KEY` | OpenRouter | Settings → Models → Add OpenRouter Credential |
+| `OPENROUTER_API_KEY` | OpenRouter | Manage → Models → Add OpenRouter Credential |
 | `OPENROUTER_BASE_URL` | OpenRouter | Configure in OpenRouter credential |
-| `VOYAGE_API_KEY` | Voyage AI | Settings → Models → Add Voyage AI Credential |
-| `ELEVENLABS_API_KEY` | ElevenLabs | Settings → Models → Add ElevenLabs Credential |
-| `OPENAI_COMPATIBLE_BASE_URL` | OpenAI-Compatible | Settings → Models → Add OpenAI-Compatible Credential |
+| `VOYAGE_API_KEY` | Voyage AI | Manage → Models → Add Voyage AI Credential |
+| `ELEVENLABS_API_KEY` | ElevenLabs | Manage → Models → Add ElevenLabs Credential |
+| `OPENAI_COMPATIBLE_BASE_URL` | OpenAI-Compatible | Manage → Models → Add OpenAI-Compatible Credential |
 | `OPENAI_COMPATIBLE_API_KEY` | OpenAI-Compatible | Configure in OpenAI-Compatible credential |
 | `OPENAI_COMPATIBLE_BASE_URL_LLM` | OpenAI-Compatible | Configure per-service URL in credential |
 | `OPENAI_COMPATIBLE_API_KEY_LLM` | OpenAI-Compatible | Configure per-service key in credential |
@@ -321,12 +321,12 @@ If you have these variables configured from a previous installation, click the *
 | `OPENAI_COMPATIBLE_API_KEY_STT` | OpenAI-Compatible | Configure per-service key in credential |
 | `OPENAI_COMPATIBLE_BASE_URL_TTS` | OpenAI-Compatible | Configure per-service URL in credential |
 | `OPENAI_COMPATIBLE_API_KEY_TTS` | OpenAI-Compatible | Configure per-service key in credential |
-| `DASHSCOPE_API_KEY` | DashScope (Qwen) | Settings → Models → Add DashScope Credential |
-| `MINIMAX_API_KEY` | MiniMax | Settings → Models → Add MiniMax Credential |
-| `NOVITA_API_KEY` | Novita | Settings → Models → Add Novita Credential |
-| `PPQ_API_KEY` | PayPerQ (PPQ) | Settings → Models → Add PayPerQ Credential |
-| `COHERE_API_KEY` | Cohere | Settings → Models → Add Cohere Credential |
-| `AZURE_OPENAI_API_KEY` | Azure OpenAI | Settings → Models → Add Azure OpenAI Credential |
+| `DASHSCOPE_API_KEY` | DashScope (Qwen) | Manage → Models → Add DashScope Credential |
+| `MINIMAX_API_KEY` | MiniMax | Manage → Models → Add MiniMax Credential |
+| `NOVITA_API_KEY` | Novita | Manage → Models → Add Novita Credential |
+| `PPQ_API_KEY` | PayPerQ (PPQ) | Manage → Models → Add PayPerQ Credential |
+| `COHERE_API_KEY` | Cohere | Manage → Models → Add Cohere Credential |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI | Manage → Models → Add Azure OpenAI Credential |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI | Configure in Azure OpenAI credential |
 | `AZURE_OPENAI_API_VERSION` | Azure OpenAI | Configure in Azure OpenAI credential |
 | `AZURE_OPENAI_API_KEY_LLM` | Azure OpenAI | Configure per-service in credential |

--- a/docs/5-CONFIGURATION/index.md
+++ b/docs/5-CONFIGURATION/index.md
@@ -93,7 +93,7 @@ We need access to LLMs in order for the app to work. AI provider credentials are
 
 1. Set `OPEN_NOTEBOOK_ENCRYPTION_KEY` in your environment (required for storing credentials)
 2. Start services
-3. Go to **Settings → Models → Add Credential**
+3. Go to **Manage → Models → Add Credential**
 4. Select your provider, paste your API key
 5. **Test Connection** → **Discover Models** → **Register Models**
 
@@ -102,9 +102,9 @@ We need access to LLMs in order for the app to work. AI provider credentials are
 OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
 ```
 
-> **Ollama users**: Add an Ollama credential in Settings → Models with the correct base URL. See [Ollama Setup](ollama.md) for network configuration help.
+> **Ollama users**: Add an Ollama credential in Manage → Models with the correct base URL. See [Ollama Setup](ollama.md) for network configuration help.
 
-> **LM Studio / OpenAI-Compatible**: Add an OpenAI-Compatible credential in Settings → Models. See [OpenAI-Compatible Guide](openai-compatible.md).
+> **LM Studio / OpenAI-Compatible**: Add an OpenAI-Compatible credential in Manage → Models. See [OpenAI-Compatible Guide](openai-compatible.md).
 
 
 ### API URL (If Behind Reverse Proxy)
@@ -126,7 +126,7 @@ Auto-detection works for most setups.
 # In docker.env:
 OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
 # Everything else uses defaults
-# Then configure AI provider in Settings → Models
+# Then configure AI provider in Manage → Models
 ```
 
 ### Scenario 2: Docker on Remote Server
@@ -148,14 +148,14 @@ API_URL=https://your-domain.com
 ```env
 # In .env:
 OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
-# Then add Ollama credential in Settings → Models
+# Then add Ollama credential in Manage → Models
 ```
 
 ### Scenario 5: Using Azure OpenAI
 ```env
 # In docker.env:
 OPEN_NOTEBOOK_ENCRYPTION_KEY=my-secret-key
-# Then add Azure OpenAI credential in Settings → Models
+# Then add Azure OpenAI credential in Manage → Models
 ```
 
 ---
@@ -241,7 +241,7 @@ The recommended way to configure AI providers:
 
 ```
 1. Open Open Notebook in your browser
-2. Go to Settings → Models
+2. Go to Manage → Models
 3. Click "Add Credential"
 4. Select provider, enter API key
 5. Click Save, then Test Connection
@@ -282,7 +282,7 @@ After configuration, verify it works:
 
 ```
 1. Open your notebook
-2. Go to Settings → Models
+2. Go to Manage → Models
 3. You should see your configured provider
 4. Try a simple Chat question
 5. If it responds, configuration is correct!
@@ -294,7 +294,7 @@ After configuration, verify it works:
 
 | Mistake | Problem | Fix |
 |---------|---------|-----|
-| No credential configured | Models not available | Add credential in Settings → Models |
+| No credential configured | Models not available | Add credential in Manage → Models |
 | Missing encryption key | Can't save credentials | Set OPEN_NOTEBOOK_ENCRYPTION_KEY |
 | Wrong database URL | Can't start API | Check SURREAL_URL format |
 | Expose port 5055 | "Can't connect to server" | Expose 5055 in docker-compose |
@@ -326,7 +326,7 @@ Once configured:
 **Minimal configuration to run:**
 1. Set `OPEN_NOTEBOOK_ENCRYPTION_KEY` in your environment
 2. Start services
-3. Add AI provider credential in Settings → Models
+3. Add AI provider credential in Manage → Models
 4. Done!
 
 Everything else is optional optimization.

--- a/docs/5-CONFIGURATION/index.md
+++ b/docs/5-CONFIGURATION/index.md
@@ -23,7 +23,7 @@ Three things:
 - **Google Gemini** (multi-modal, long context)
 - **Groq** (ultra-fast inference)
 
-Setup: Get API key → Add credential in Settings UI → Done
+Setup: Get API key → Add credential in Manage → Models → Done
 
 → Go to **[AI Providers Guide](ai-providers.md)**
 

--- a/docs/5-CONFIGURATION/local-stt.md
+++ b/docs/5-CONFIGURATION/local-stt.md
@@ -74,7 +74,7 @@ You should see the transcribed text in the response.
 ### Step 4: Configure Open Notebook
 
 **Via Settings UI (Recommended):**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **OpenAI-Compatible**
 3. Enter base URL for STT: `http://host.docker.internal:8969/v1` (Docker) or `http://localhost:8969/v1` (local)
 4. Click **Save**, then **Test Connection**
@@ -93,7 +93,7 @@ export OPENAI_COMPATIBLE_BASE_URL_STT=http://localhost:8969/v1
 
 ### Step 5: Add Model in Open Notebook
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Model** in Speech-to-Text section
 3. Configure:
    - **Provider**: `openai_compatible`
@@ -174,7 +174,7 @@ This is recommended if you have enough RAM/VRAM, as loading the model can take a
 
 ## Docker Networking
 
-When configuring your OpenAI-Compatible credential in **Settings → Models**, use the appropriate STT base URL for your setup:
+When configuring your OpenAI-Compatible credential in **Manage → Models**, use the appropriate STT base URL for your setup:
 
 ### Open Notebook in Docker (macOS/Windows)
 
@@ -334,7 +334,7 @@ docker stats speaches
 
 ## Using Both TTS and STT
 
-Speaches supports both TTS and STT in one server. In **Settings → Models**, add a single **OpenAI-Compatible** credential and configure both the TTS and STT base URLs to point to the same Speaches server (e.g., `http://localhost:8969/v1`).
+Speaches supports both TTS and STT in one server. In **Manage → Models**, add a single **OpenAI-Compatible** credential and configure both the TTS and STT base URLs to point to the same Speaches server (e.g., `http://localhost:8969/v1`).
 
 See **[Local TTS Setup](local-tts.md)** for TTS configuration.
 
@@ -354,7 +354,7 @@ Any OpenAI-compatible STT server works:
 The key requirements:
 
 1. Server implements `/v1/audio/transcriptions` endpoint
-2. Add an OpenAI-Compatible credential in **Settings → Models** with the STT base URL
+2. Add an OpenAI-Compatible credential in **Manage → Models** with the STT base URL
 3. Add model with provider `openai_compatible`
 
 ---

--- a/docs/5-CONFIGURATION/local-tts.md
+++ b/docs/5-CONFIGURATION/local-tts.md
@@ -75,7 +75,7 @@ Play `test.mp3` to verify.
 ### Step 4: Configure Open Notebook
 
 **Via Settings UI (Recommended):**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **OpenAI-Compatible**
 3. Enter base URL for TTS: `http://host.docker.internal:8969/v1` (Docker) or `http://localhost:8969/v1` (local)
 4. Click **Save**, then **Test Connection**
@@ -94,7 +94,7 @@ export OPENAI_COMPATIBLE_BASE_URL_TTS=http://localhost:8969/v1
 
 ### Step 5: Add Model in Open Notebook
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Model** in Text-to-Speech section
 3. Configure:
    - **Provider**: `openai_compatible`
@@ -175,7 +175,7 @@ volumes:
 
 ## Docker Networking
 
-When configuring your OpenAI-Compatible credential in **Settings → Models**, use the appropriate TTS base URL for your setup:
+When configuring your OpenAI-Compatible credential in **Manage → Models**, use the appropriate TTS base URL for your setup:
 
 ### Open Notebook in Docker (macOS/Windows)
 
@@ -331,7 +331,7 @@ docker stats speaches
 Any OpenAI-compatible TTS server works. The key is:
 
 1. Server implements `/v1/audio/speech` endpoint
-2. Add an OpenAI-Compatible credential in **Settings → Models** with the TTS base URL
+2. Add an OpenAI-Compatible credential in **Manage → Models** with the TTS base URL
 3. Add model with provider `openai_compatible`
 
 ---

--- a/docs/5-CONFIGURATION/ollama.md
+++ b/docs/5-CONFIGURATION/ollama.md
@@ -39,7 +39,7 @@ ollama pull mxbai-embed-large  # Best embedding model for Ollama
 ### 3. Configure Open Notebook
 
 **Via Settings UI (Recommended):**
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **Ollama**
 3. Enter the base URL (see [Network Configuration](#network-configuration-guide) below for correct URL)
 4. Click **Save**, then **Test Connection**
@@ -53,17 +53,17 @@ export OLLAMA_API_BASE=http://localhost:11434
 export OLLAMA_API_BASE=http://host.docker.internal:11434
 ```
 
-> **Deprecated**: `OLLAMA_API_BASE` is a deprecated fallback. It still works today, but there is no guarantee it keeps working in future releases, and new automation should not be built on it. Configure Ollama via **Settings → Models** instead. For headless/CI/Docker setups, see the [environment reference](environment-reference.md#legacy-ai-provider-environment-variables-deprecated) and the provisioning discussion in [#765](https://github.com/lfnovo/open-notebook/discussions/765).
+> **Deprecated**: `OLLAMA_API_BASE` is a deprecated fallback. It still works today, but there is no guarantee it keeps working in future releases, and new automation should not be built on it. Configure Ollama via **Manage → Models** instead. For headless/CI/Docker setups, see the [environment reference](environment-reference.md#legacy-ai-provider-environment-variables-deprecated) and the provisioning discussion in [#765](https://github.com/lfnovo/open-notebook/discussions/765).
 
 ## Network Configuration Guide
 
-When adding an Ollama credential in **Settings → Models**, you need to enter the correct base URL. The correct URL depends on your deployment scenario:
+When adding an Ollama credential in **Manage → Models**, you need to enter the correct base URL. The correct URL depends on your deployment scenario:
 
 ### Scenario 1: Local Installation (Same Machine)
 
 When both Open Notebook and Ollama run directly on your machine:
 
-**Base URL to enter in Settings → Models:** `http://localhost:11434`
+**Base URL to enter in Manage → Models:** `http://localhost:11434`
 
 Alternative: `http://127.0.0.1:11434` (use if you have DNS resolution issues with localhost)
 
@@ -71,7 +71,7 @@ Alternative: `http://127.0.0.1:11434` (use if you have DNS resolution issues wit
 
 When Open Notebook runs in Docker but Ollama runs on your host machine:
 
-**Base URL to enter in Settings → Models:** `http://host.docker.internal:11434`
+**Base URL to enter in Manage → Models:** `http://host.docker.internal:11434`
 
 **⚠️ CRITICAL: Ollama must accept external connections:**
 ```bash
@@ -113,7 +113,7 @@ httpcore.ConnectError: [Errno -2] Name or service not known
 
 When both Open Notebook and Ollama run in the same Docker Compose stack:
 
-**Base URL to enter in Settings → Models:** `http://ollama:11434`
+**Base URL to enter in Manage → Models:** `http://ollama:11434`
 
 **Docker Compose Example:**
 
@@ -157,7 +157,7 @@ volumes:
 
 When Ollama runs on a different machine in your network:
 
-**Base URL to enter in Settings → Models:** `http://192.168.1.100:11434` (replace with your Ollama server's IP)
+**Base URL to enter in Manage → Models:** `http://192.168.1.100:11434` (replace with your Ollama server's IP)
 
 **Security Note:** Only use this in trusted networks. Ollama doesn't have built-in authentication.
 
@@ -170,7 +170,7 @@ If you've configured Ollama to use a different port:
 OLLAMA_HOST=0.0.0.0:8080 ollama serve
 ```
 
-**Base URL to enter in Settings → Models:** `http://localhost:8080`
+**Base URL to enter in Manage → Models:** `http://localhost:8080`
 
 ## Model Recommendations
 
@@ -276,7 +276,7 @@ qwen3:32b                   030ee887880f    20 GB     9 days ago
 
 **Step 3: Configure in Open Notebook**
 
-1. Go to **Settings → Models**
+1. Go to **Manage → Models**
 2. Click **Add Model**
 3. Enter the **exact name** from `ollama list`
 4. Select provider: `ollama`
@@ -294,7 +294,7 @@ curl http://localhost:11434/api/tags
 ```
 
 **Verify credential is configured:**
-Check **Settings → Models** for an Ollama credential with the correct base URL.
+Check **Manage → Models** for an Ollama credential with the correct base URL.
 
 **⚠️ IMPORTANT: Enable external connections (most common fix):**
 ```bash
@@ -373,7 +373,7 @@ netstat -tulpn | grep 11434
 ```bash
 OLLAMA_HOST=0.0.0.0:8080 ollama serve
 ```
-Then update the base URL in **Settings → Models** to `http://localhost:8080`
+Then update the base URL in **Manage → Models** to `http://localhost:8080`
 
 **6. "Failed to send message" in Chat**
 
@@ -385,7 +385,7 @@ Error executing chat: Model is not a LanguageModel: None
 **Causes (in order of likelihood):**
 
 1. **Model name mismatch**: The model name in Open Notebook doesn't exactly match `ollama list`
-2. **No default model configured**: You haven't set a default chat model in Settings → Models
+2. **No default model configured**: You haven't set a default chat model in Manage → Models
 3. **Model was deleted**: You removed the model from Ollama but didn't update Open Notebook's defaults
 4. **Model record deleted**: The model was removed from Open Notebook but is still set as default
 
@@ -397,11 +397,11 @@ Error executing chat: Model is not a LanguageModel: None
 ollama list
 
 # Compare with what's configured in Open Notebook
-# Go to Settings → Models and verify the names match EXACTLY
+# Go to Manage → Models and verify the names match EXACTLY
 ```
 
 **Check 2: Verify default models are set**
-1. Go to **Settings → Models**
+1. Go to **Manage → Models**
 2. Scroll to **Default Models** section
 3. Ensure **Default Chat Model** has a value selected
 4. If empty, select an available language model
@@ -409,7 +409,7 @@ ollama list
 **Check 3: Refresh after changes**
 If you've added/removed models in Ollama:
 1. Refresh the Open Notebook page
-2. Go to Settings → Models
+2. Go to Manage → Models
 3. Re-add any missing models with exact names from `ollama list`
 4. Re-select default models if needed
 
@@ -436,7 +436,7 @@ services:
     # ... rest of your config
 ```
 
-Then in **Settings → Models**, use base URL: `http://host.docker.internal:11434`
+Then in **Manage → Models**, use base URL: `http://host.docker.internal:11434`
 
 This maps `host.docker.internal` to your host machine's IP. macOS/Windows Docker Desktop does this automatically, but Linux requires explicit configuration.
 
@@ -445,7 +445,7 @@ This maps `host.docker.internal` to your host machine's IP. macOS/Windows Docker
 # Use host networking if host.docker.internal doesn't work
 docker run --network host lfnovo/open_notebook:v1-latest  # for quick testing only
 ```
-Then in **Settings → Models**, use base URL: `http://localhost:11434`
+Then in **Manage → Models**, use base URL: `http://localhost:11434`
 
 **3. Custom bridge network:**
 ```yaml
@@ -464,7 +464,7 @@ services:
       - ollama_network
 ```
 
-Then in **Settings → Models**, use base URL: `http://ollama:11434`
+Then in **Manage → Models**, use base URL: `http://ollama:11434`
 
 **4. Firewall issues:**
 ```bash
@@ -542,7 +542,7 @@ export OLLAMA_MAX_QUEUE=512            # Request queue size
 export OLLAMA_NUM_PARALLEL=4           # Parallel request handling
 export OLLAMA_FLASH_ATTENTION=1        # Enable flash attention (if supported)
 
-# Open Notebook configuration (configure via Settings → Models instead)
+# Open Notebook configuration (configure via Manage → Models instead)
 # OLLAMA_API_BASE=http://localhost:11434  # Deprecated fallback — works today, no guarantee
 ```
 

--- a/docs/5-CONFIGURATION/omlx.md
+++ b/docs/5-CONFIGURATION/omlx.md
@@ -2,7 +2,7 @@
 
 [oMLX](https://omlx.ai/) is a macOS-native inference server for Apple Silicon. It runs [MLX](https://opensource.apple.com/projects/mlx/) models locally and exposes an **OpenAI-compatible API** at `/v1`, so Open Notebook can use it for language and embedding models without sending data to the cloud.
 
-Open Notebook treats **oMLX** as a first-class provider in Settings → Models. Identity comes from Esperanto’s built-in `omlx` [OpenAI-compatible profile](https://github.com/lfnovo/esperanto/issues/228) (`AIFactory.create_language("omlx", ...)` / `create_embedding("omlx", ...)`). There is no remapping to the generic `openai-compatible` provider and no `OPENAI_COMPATIBLE_*` env mirroring.
+Open Notebook treats **oMLX** as a first-class provider in Manage → Models. Identity comes from Esperanto’s built-in `omlx` [OpenAI-compatible profile](https://github.com/lfnovo/esperanto/issues/228) (`AIFactory.create_language("omlx", ...)` / `create_embedding("omlx", ...)`). There is no remapping to the generic `openai-compatible` provider and no `OPENAI_COMPATIBLE_*` env mirroring.
 
 ## Why Choose oMLX?
 
@@ -61,7 +61,7 @@ http://localhost:11435/v1
 
 ## Configure Open Notebook
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → select **oMLX**
 3. Set **Base URL** to `http://localhost:11435/v1` (prefilled by default)
 4. Optionally set an **API key** if you started oMLX with `--api-key`

--- a/docs/5-CONFIGURATION/openai-compatible.md
+++ b/docs/5-CONFIGURATION/openai-compatible.md
@@ -41,7 +41,7 @@ Open Notebook can connect to any server using this format.
 3. Download a model (e.g., Llama 3)
 4. Start the local server (default: port 1234)
 
-### Step 2: Configure in Settings UI (Recommended)
+### Step 2: Configure in Manage → Models (Recommended)
 
 1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **OpenAI-Compatible**

--- a/docs/5-CONFIGURATION/openai-compatible.md
+++ b/docs/5-CONFIGURATION/openai-compatible.md
@@ -43,7 +43,7 @@ Open Notebook can connect to any server using this format.
 
 ### Step 2: Configure in Settings UI (Recommended)
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **OpenAI-Compatible**
 3. Enter base URL: `http://host.docker.internal:1234/v1` (Docker) or `http://localhost:1234/v1` (local)
 4. API key: `lm-studio` (placeholder, LM Studio doesn't require one)
@@ -57,7 +57,7 @@ export OPENAI_COMPATIBLE_API_KEY=not-needed
 
 ### Step 3: Add Model in Open Notebook
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Model**
 3. Configure:
    - **Provider**: `openai_compatible`
@@ -71,7 +71,7 @@ export OPENAI_COMPATIBLE_API_KEY=not-needed
 
 The recommended way to configure OpenAI-compatible providers is through the Settings UI:
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Credential** → Select **OpenAI-Compatible**
 3. Enter your base URL and API key (if needed)
 4. Optionally configure per-service URLs for LLM, Embedding, TTS, and STT
@@ -113,7 +113,7 @@ OPENAI_COMPATIBLE_API_KEY_STT=optional-api-key
 
 ## Docker Networking
 
-When Open Notebook runs in Docker and your compatible server runs on the host, use the appropriate base URL when adding your credential in **Settings → Models**:
+When Open Notebook runs in Docker and your compatible server runs on the host, use the appropriate base URL when adding your credential in **Manage → Models**:
 
 ### macOS / Windows
 
@@ -140,7 +140,7 @@ services:
       - "1234:1234"
 ```
 
-**Base URL in Settings → Models:** `http://lm-studio:1234/v1`
+**Base URL in Manage → Models:** `http://lm-studio:1234/v1`
 
 ---
 
@@ -154,7 +154,7 @@ python server.py --api --listen
 
 ### Configure Open Notebook
 
-In **Settings → Models**, add an **OpenAI-Compatible** credential with base URL: `http://localhost:5000/v1`
+In **Manage → Models**, add an **OpenAI-Compatible** credential with base URL: `http://localhost:5000/v1`
 
 ### Docker Compose Example
 
@@ -177,7 +177,7 @@ services:
       - text-gen
 ```
 
-Then in **Settings → Models**, add an **OpenAI-Compatible** credential with base URL: `http://text-gen:5000/v1`
+Then in **Manage → Models**, add an **OpenAI-Compatible** credential with base URL: `http://text-gen:5000/v1`
 
 ---
 
@@ -193,7 +193,7 @@ python -m vllm.entrypoints.openai.api_server \
 
 ### Configure Open Notebook
 
-In **Settings → Models**, add an **OpenAI-Compatible** credential with base URL: `http://localhost:8000/v1`
+In **Manage → Models**, add an **OpenAI-Compatible** credential with base URL: `http://localhost:8000/v1`
 
 ### Docker Compose with GPU
 
@@ -225,7 +225,7 @@ services:
       - vllm
 ```
 
-Then in **Settings → Models**, add an **OpenAI-Compatible** credential with base URL: `http://vllm:8000/v1`
+Then in **Manage → Models**, add an **OpenAI-Compatible** credential with base URL: `http://vllm:8000/v1`
 
 ---
 
@@ -233,7 +233,7 @@ Then in **Settings → Models**, add an **OpenAI-Compatible** credential with ba
 
 ### Via Settings UI
 
-1. Go to **Settings** → **Models**
+1. Go to **Manage** → **Models**
 2. Click **Add Model** in appropriate section
 3. Select **Provider**: `openai_compatible`
 4. Enter **Model Name**: exactly as the server expects
@@ -321,7 +321,7 @@ Problem: 401 or authentication failed
 
 Solutions:
 1. Check if server requires API key
-2. Set the API key in your credential (Settings → Models)
+2. Set the API key in your credential (Manage → Models)
 3. Some servers need any non-empty key (use a placeholder like "not-needed")
 ```
 
@@ -341,7 +341,7 @@ Solutions:
 
 ## Multiple Compatible Endpoints
 
-You can use different compatible servers for different purposes. When adding an **OpenAI-Compatible** credential in **Settings → Models**, you can configure per-service URLs:
+You can use different compatible servers for different purposes. When adding an **OpenAI-Compatible** credential in **Manage → Models**, you can configure per-service URLs:
 
 - **LLM URL**: e.g., `http://localhost:1234/v1` (LM Studio)
 - **Embedding URL**: e.g., `http://localhost:8080/v1` (different server)

--- a/docs/6-TROUBLESHOOTING/ai-chat-issues.md
+++ b/docs/6-TROUBLESHOOTING/ai-chat-issues.md
@@ -19,7 +19,7 @@ Error executing chat: Model is not a LanguageModel: None
 
 ### Solution 1: Check Default Model Configuration
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Scroll to "Default Models" section
 3. Verify "Default Chat Model" has a model selected
 4. If empty, select an available language model
@@ -42,7 +42,7 @@ ollama list
 ### Solution 3: Re-add Missing Models
 ```
 1. Note the exact model names from your provider
-2. Go to Settings → Models
+2. Go to Manage → Models
 3. Delete any misconfigured models
 4. Add models with exact names
 5. Set new defaults
@@ -63,7 +63,7 @@ ollama list
 
 ## "Models not available" or "Models not showing"
 
-**Symptom:** Settings → Models shows empty, or "No models configured"
+**Symptom:** Manage → Models shows empty, or "No models configured"
 
 **Cause:** No credential configured, or credential has invalid API key
 
@@ -71,18 +71,18 @@ ollama list
 
 ### Solution 1: Add Credential via Settings UI
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Click "Add Credential"
 3. Select your provider (e.g., OpenAI, Anthropic, Google)
 4. Enter your API key
 5. Click Save, then Test Connection
 6. Click Discover Models → Register Models
-7. Go to Settings → Models to verify
+7. Go to Manage → Models to verify
 ```
 
 ### Solution 2: Check Key is Valid
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Click "Test Connection" on your credential
 3. If it shows "Invalid API key":
    - Get a fresh key from the provider's website
@@ -91,10 +91,10 @@ ollama list
 
 ### Solution 3: Switch Provider
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Add a credential for a different provider
 3. Test Connection → Discover Models → Register Models
-4. Go to Settings → Models to select the new provider's models
+4. Go to Manage → Models to select the new provider's models
 ```
 
 ---
@@ -109,7 +109,7 @@ ollama list
 
 ### Step 1: Test Your Credential
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Click "Test Connection" on your credential
 3. If it fails, proceed to Step 2
 ```
@@ -126,7 +126,7 @@ Generate new key and copy exactly (no extra spaces)
 
 ### Step 3: Update Credential
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Delete the old credential
 3. Click "Add Credential" → select provider
 4. Paste the new key
@@ -136,7 +136,7 @@ Generate new key and copy exactly (no extra spaces)
 
 ### Step 4: Verify in UI
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. Verify models are available
 3. Try a test chat
 ```
@@ -178,7 +178,7 @@ Anthropic:
   Current: claude-3-5-haiku → Switch to: claude-3-5-sonnet
 
 To change:
-1. Settings → Models
+1. Manage → Models
 2. Select model
 3. Try chat again
 ```
@@ -206,7 +206,7 @@ Fast: OpenAI gpt-4o-mini
 Medium: Anthropic claude-3-5-haiku
 Slow: Anthropic claude-3-5-sonnet
 
-Switch in: Settings → Models
+Switch in: Manage → Models
 ```
 
 ### Solution 2: Reduce Context
@@ -307,7 +307,7 @@ Google: Google Cloud Console
 Current: GPT-4o (128K tokens) → Switch to: Claude (200K tokens)
 Current: Claude Haiku (200K) → Switch to: Gemini (1M tokens)
 
-To change: Settings → Models
+To change: Manage → Models
 ```
 
 ### Solution 2: Reduce Context
@@ -350,7 +350,7 @@ Groq: Check website
 
 ### Use Different Model/Provider
 ```
-1. Settings → Models
+1. Manage → Models
 2. Try different provider
 3. If OpenAI down, use Anthropic
 ```

--- a/docs/6-TROUBLESHOOTING/connection-issues.md
+++ b/docs/6-TROUBLESHOOTING/connection-issues.md
@@ -429,7 +429,7 @@ ESPERANTO_SSL_VERIFY=false
 ### Solution 3: Use HTTP Instead
 If services are on a trusted local network, HTTP is acceptable:
 ```
-Change the base URL in your credential (Settings → Models) from https:// to http://
+Change the base URL in your credential (Manage → Models) from https:// to http://
 Example: http://localhost:1234/v1
 ```
 

--- a/docs/6-TROUBLESHOOTING/index.md
+++ b/docs/6-TROUBLESHOOTING/index.md
@@ -220,7 +220,7 @@ SURREAL_COMMANDS_MAX_TASKS=2
 **High costs?**
 ```bash
 # Switch to cheaper model
-# In Settings → Models → Choose gpt-4o-mini (OpenAI)
+# In Manage → Models → Choose gpt-4o-mini (OpenAI)
 # Or use Ollama (free)
 ```
 

--- a/docs/6-TROUBLESHOOTING/quick-fixes.md
+++ b/docs/6-TROUBLESHOOTING/quick-fixes.md
@@ -37,19 +37,19 @@ docker compose restart
 
 ## #2: "Invalid API key" or "Models not showing"
 
-**Symptom:** Settings → Models shows "No models available"
+**Symptom:** Manage → Models shows "No models available"
 
 **Cause:** No credential configured, or credential has invalid API key
 
 **Solution (1 minute):**
 
 ```
-1. Go to Settings → Models
+1. Go to Manage → Models
 2. If no credential exists, click "Add Credential" and add one
 3. If a credential exists, click "Test Connection"
 4. If test fails, delete and re-create with correct key
 5. After test passes, click "Discover Models" → "Register Models"
-6. Go to Settings → Models to verify models appear
+6. Go to Manage → Models to verify models appear
 ```
 
 **If still broken:**
@@ -122,7 +122,7 @@ docker compose restart
 
 ```bash
 # Step 1: Check which model you're using
-# Settings → Models
+# Manage → Models
 # Note the model name
 
 # Step 2: Try a cheaper/faster model

--- a/docs/7-DEVELOPMENT/development-setup.md
+++ b/docs/7-DEVELOPMENT/development-setup.md
@@ -66,7 +66,7 @@ LOG_LEVEL=DEBUG
 
 After starting the API and frontend, configure your AI provider via the Settings UI:
 
-1. Open **http://localhost:3000** → **Settings** → **Models**
+1. Open **http://localhost:3000** → **Manage** → **Models**
 2. Click **Add Credential** → Select your provider
 3. Enter your API key (get from provider dashboard)
 4. Click **Save**, then **Test Connection**
@@ -436,7 +436,7 @@ ollama pull mistral
 ```
 
 Then configure via the Settings UI:
-1. Go to **Settings** → **Models** → **Add Credential** → **Ollama**
+1. Go to **Manage** → **Models** → **Add Credential** → **Ollama**
 2. Enter base URL: `http://localhost:11434`
 3. Click **Save**, then **Test Connection**
 4. Click **Discover Models** → **Register Models**

--- a/examples/docker-compose-speaches.yml
+++ b/examples/docker-compose-speaches.yml
@@ -97,7 +97,7 @@ volumes:
 #    - Base URL for STT: (same as TTS)
 # 4. Click Save → Test Connection
 #
-# 5. Go to Settings → Models
+# 5. Go to Manage → Models
 # 6. Add TTS Model:
 #    - Provider: openai_compatible
 #    - Model Name: speaches-ai/Kokoro-82M-v1.0-ONNX

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -358,7 +358,7 @@ class ModelManager:
         if not model_id:
             logger.warning(
                 f"No default model configured for type '{model_type}'. "
-                f"Please go to Settings → Models and set a default model."
+                f"Please go to Manage → Models and set a default model."
             )
             return None
 
@@ -368,7 +368,7 @@ class ModelManager:
             logger.error(
                 f"Failed to load default model for type '{model_type}': {e}. "
                 f"The configured model_id '{model_id}' may have been deleted or misconfigured. "
-                f"Please go to Settings → Models and reconfigure the default model."
+                f"Please go to Manage → Models and reconfigure the default model."
             )
             return None
 

--- a/open_notebook/ai/provision.py
+++ b/open_notebook/ai/provision.py
@@ -40,11 +40,11 @@ async def provision_langchain_model(
             f"Model provisioning failed: No model found. "
             f"Selection reason: {selection_reason}. "
             f"model_id={model_id}, default_type={default_type}. "
-            f"Please check Settings → Models and ensure a default model is configured for '{default_type}'."
+            f"Please check Manage → Models and ensure a default model is configured for '{default_type}'."
         )
         raise ConfigurationError(
             f"No model configured for {selection_reason}. "
-            f"Please go to Settings → Models and configure a default model for '{default_type}'."
+            f"Please go to Manage → Models and configure a default model for '{default_type}'."
         )
 
     if not isinstance(model, LanguageModel):


### PR DESCRIPTION
## Summary

Follow-up to the P2 note on #1313 (rename "API Keys" → "Models"): the docs mixed two navigation paths for the same page, `Settings → Models` (~150 occurrences) and `Manage → Models` (3). This PR standardizes everything on **Manage → Models**.

## Why "Manage → Models"

The Models page lives at `/settings/models`, which makes `Settings → Models` look natural, but that is only the URL. In the actual sidebar (`frontend/src/components/layout/AppSidebar.tsx`, `getNavigation`) **Models is a top-level item inside the "Manage" section**, a sibling of Settings, Transformations and Advanced, not a child of Settings. There is no "Models" entry inside the Settings page. #1313 already fixed the sidebar highlight for exactly this reason and updated a handful of docs to "Manage → Models"; this PR finishes the job.

## Changes

- `docs/**`: every `Settings → Models` / `**Settings** → **Models**` / `Settings / Models` → `Manage → Models` (23 files).
- `open_notebook/ai/models.py`, `open_notebook/ai/provision.py`: the user-facing "Please go to Settings → Models…" error hints now say "Manage → Models" (string-only change).
- `examples/docker-compose-speaches.yml`: setup comment.
- **Not touched**: `CHANGELOG.md` (historical entries), routes, redirects, i18n keys, any behaviour. Mentions of a third-party console's "API Keys section" (DashScope, MiniMax) are about those vendors' dashboards and were left as-is.

## Testing

- `python3 scripts/check_md_links.py` → all relative markdown links resolve
- `uv run ruff check` on the two touched Python files → clean
- `uv run pytest -k "provision or models"` → 43 passed
- `grep -rnE "Settings.{0,12}Models" docs/ open_notebook examples` → no leftovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012heLWVTmopC5FkipUgnvsN


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

