### PR TITLE
docs: point examples and .env.example at Manage → Models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ SURREAL_DATABASE=open_notebook
 # =============================================================================
 # DEPRECATED: AI Provider API Keys (environment-variable fallback)
 # =============================================================================
-# Configure AI providers via the UI: Settings → API Keys. Credentials are
+# Configure AI providers via the UI: Manage → Models. Credentials are
 # stored encrypted, can be rotated without restarts, and support multiple
 # credentials per provider.
 #
@@ -54,10 +54,10 @@ SURREAL_DATABASE=open_notebook
 # External API URL (for webhooks, callbacks, etc.)
 # API_URL=http://localhost:5055
 
-# Ollama endpoint — DEPRECATED fallback, configure via Settings → API Keys instead
+# Ollama endpoint — DEPRECATED fallback, configure via Manage → Models instead
 # OLLAMA_API_BASE=http://localhost:11434
 
-# oMLX (Apple Silicon) — DEPRECATED fallback, configure via Settings → API Keys instead
+# oMLX (Apple Silicon) — DEPRECATED fallback, configure via Manage → Models instead
 # Port 11435 avoids clashing with SurrealDB on 8000
 # OMLX_API_BASE=http://localhost:11435/v1
 # OMLX_API_KEY=  # optional; only if oMLX was started with --api-key

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,7 +67,7 @@ templates playground.
 1. Copy to your project folder as `docker-compose.yml`
 2. Run: `docker compose up -d`
 3. Pull a model: `docker exec open_notebook-ollama-1 ollama pull mistral`
-4. Configure in UI: Settings → API Keys → Add Ollama (URL: `http://ollama:11434`)
+4. Configure in UI: Manage → Models → Add Ollama (URL: `http://ollama:11434`)
 
 **Recommended models:**
 - **LLM**: `mistral`, `llama3.1`, `qwen2.5`

--- a/examples/docker-compose-full-local.yml
+++ b/examples/docker-compose-full-local.yml
@@ -124,13 +124,13 @@ volumes:
 # ==========================================
 #
 # 1. Configure Ollama:
-#    - Go to Settings → API Keys
+#    - Go to Manage → Models
 #    - Add Credential → Select "Ollama"
 #    - Base URL: http://ollama:11434
 #    - Save → Test Connection → Discover Models → Register Models
 #
 # 2. Configure Speaches (TTS/STT):
-#    - Go to Settings → API Keys
+#    - Go to Manage → Models
 #    - Add Credential → Select "OpenAI-Compatible"
 #    - Name: "Local Speaches"
 #    - Base URL for TTS: http://host.docker.internal:8969/v1  (macOS/Windows)

--- a/examples/docker-compose-ollama.yml
+++ b/examples/docker-compose-ollama.yml
@@ -8,7 +8,7 @@
 #   2. Change OPEN_NOTEBOOK_ENCRYPTION_KEY below
 #   3. Run: docker compose up -d
 #   4. Pull a model: docker exec open_notebook-ollama-1 ollama pull mistral
-#   5. Configure Ollama in UI: Settings → API Keys → Add Ollama (URL: http://ollama:11434)
+#   5. Configure Ollama in UI: Manage → Models → Add Ollama (URL: http://ollama:11434)
 
 services:
   surrealdb:

--- a/examples/docker-compose-speaches.yml
+++ b/examples/docker-compose-speaches.yml
@@ -15,7 +15,7 @@
 #   2. Change OPEN_NOTEBOOK_ENCRYPTION_KEY below
 #   3. Run: docker compose up -d
 #   4. Download models (see instructions below)
-#   5. Configure in UI: Settings → API Keys → Add OpenAI-Compatible
+#   5. Configure in UI: Manage → Models → Add OpenAI-Compatible
 #
 # Full documentation:
 # - TTS setup: https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/local-tts.md
@@ -88,7 +88,7 @@ volumes:
 # CONFIGURATION IN OPEN NOTEBOOK
 # ==========================================
 #
-# 1. Go to Settings → API Keys
+# 1. Go to Manage → Models
 # 2. Click "Add Credential" → Select "OpenAI-Compatible"
 # 3. Configure:
 #    - Name: "Local Speaches"

--- a/examples/easypanel/README.md
+++ b/examples/easypanel/README.md
@@ -23,4 +23,4 @@ the template generates one and stores it in the app service environment as
 `OPEN_NOTEBOOK_PASSWORD`.
 
 After deployment, open the EasyPanel domain and configure AI providers from
-Open Notebook's Settings > API Keys page.
+Open Notebook's Manage > Models page.


### PR DESCRIPTION
Follow-up to #1313 and #1330. The old `Settings → API Keys` nav path survived in `.env.example` and `examples/**` (10 occurrences), which are the first files a self-hoster reads. Replaced with `Manage → Models` to match the docs sweep.

No code changes.

## Test plan
- `grep -rn "API Keys" .env.example examples/` returns only the deprecated-section heading, which describes the variables themselves, not the nav path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnMHW3qrSc8Nhi7xTPfZuv

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->