### PR TITLE
fix: show insights after long-running generation

### DIFF
--- a/frontend/src/components/sources/SourceDetailContent.test.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.test.tsx
@@ -1,10 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SourceDetailContent } from './SourceDetailContent'
 import { sourcesApi } from '@/lib/api/sources'
+import { insightsApi } from '@/lib/api/insights'
+import { transformationsApi } from '@/lib/api/transformations'
 import { QUERY_KEYS } from '@/lib/api/query-client'
 import { SourceDetailResponse } from '@/lib/types/api'
+import { toast } from 'sonner'
 
 // useTranslation is mocked globally in setup.ts (t returns the key string)
 
@@ -17,6 +20,8 @@ vi.mock('@/lib/api/sources', () => ({
 vi.mock('@/lib/api/insights', () => ({
   insightsApi: {
     listForSource: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    waitForCommand: vi.fn(),
   },
 }))
 
@@ -40,7 +45,40 @@ vi.mock('@/components/sources/NotebookAssociations', () => ({
   NotebookAssociations: () => null,
 }))
 
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children, onValueChange, ...props }: React.PropsWithChildren<{
+    onValueChange: (value: string) => void
+  }>) => (
+    <select {...props} aria-label="transformation" onChange={event => onValueChange(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SelectItem: ({ children, value }: React.PropsWithChildren<{ value: string }>) => (
+    <option value={value}>{children}</option>
+  ),
+}))
+
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  TabsList: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  TabsTrigger: ({ children }: React.PropsWithChildren) => <button>{children}</button>,
+  TabsContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
 const mockSourcesGet = vi.mocked(sourcesApi.get)
+const mockCreateInsight = vi.mocked(insightsApi.create)
+const mockWaitForCommand = vi.mocked(insightsApi.waitForCommand)
+const mockListTransformations = vi.mocked(transformationsApi.list)
 
 const notFoundError = Object.assign(new Error('Request failed with status code 404'), {
   isAxiosError: true,
@@ -52,18 +90,49 @@ const networkError = Object.assign(new Error('Network Error'), {
   response: undefined,
 })
 
-function renderContent(onClose?: () => void) {
+function renderContent(onClose?: () => void, sourceId = 'source:missing') {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
-      <SourceDetailContent sourceId="source:missing" onClose={onClose} />
+      <SourceDetailContent sourceId={sourceId} onClose={onClose} />
     </QueryClientProvider>
   )
+}
+
+const loadedSource: SourceDetailResponse = {
+  id: 'source:loaded',
+  title: 'Loaded source',
+  asset: null,
+  embedded: false,
+  embedded_chunks: 0,
+  insights_count: 0,
+  created: '2026-01-01T00:00:00Z',
+  updated: '2026-01-01T00:00:00Z',
+  full_text: 'Source content',
+}
+
+async function startInsightGeneration() {
+  await screen.findByText('Loaded source')
+  fireEvent.change(screen.getByRole('combobox', { name: 'transformation' }), {
+    target: { value: 'transformation:summary' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'common.create' }))
 }
 
 describe('SourceDetailContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockListTransformations.mockResolvedValue([{
+      id: 'transformation:summary',
+      title: 'Summary',
+      name: 'summary',
+      description: '',
+      prompt: 'Summarize',
+      apply_default: false,
+      model_id: null,
+      created: '2026-01-01T00:00:00Z',
+      updated: '2026-01-01T00:00:00Z',
+    }])
   })
 
   it('shows the shared not-found state when the source returns 404', async () => {
@@ -141,5 +210,53 @@ describe('SourceDetailContent', () => {
     })
     screen.getByText('common.close').click()
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not start polling when creation finishes after unmount', async () => {
+    mockSourcesGet.mockResolvedValue(loadedSource)
+    let resolveCreate!: (value: Awaited<ReturnType<typeof insightsApi.create>>) => void
+    mockCreateInsight.mockReturnValue(new Promise(resolve => {
+      resolveCreate = resolve
+    }))
+
+    const view = renderContent(undefined, loadedSource.id)
+    await startInsightGeneration()
+    await waitFor(() => expect(mockCreateInsight).toHaveBeenCalled())
+
+    view.unmount()
+    await act(async () => {
+      resolveCreate({
+        status: 'pending',
+        message: 'started',
+        source_id: loadedSource.id,
+        transformation_id: 'transformation:summary',
+        command_id: 'job-1',
+      })
+    })
+
+    expect(mockWaitForCommand).not.toHaveBeenCalled()
+  })
+
+  it('shows the backend error when insight generation fails', async () => {
+    mockSourcesGet.mockResolvedValue(loadedSource)
+    mockCreateInsight.mockResolvedValue({
+      status: 'pending',
+      message: 'started',
+      source_id: loadedSource.id,
+      transformation_id: 'transformation:summary',
+      command_id: 'job-1',
+    })
+    mockWaitForCommand.mockResolvedValue({
+      job_id: 'job-1',
+      status: 'failed',
+      error_message: 'Model ran out of memory',
+    })
+
+    renderContent(undefined, loadedSource.id)
+    await startInsightGeneration()
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Model ran out of memory')
+    })
   })
 })

--- a/frontend/src/components/sources/SourceDetailContent.test.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.test.tsx
@@ -76,6 +76,7 @@ vi.mock('sonner', () => ({
 }))
 
 const mockSourcesGet = vi.mocked(sourcesApi.get)
+const mockListInsights = vi.mocked(insightsApi.listForSource)
 const mockCreateInsight = vi.mocked(insightsApi.create)
 const mockWaitForCommand = vi.mocked(insightsApi.waitForCommand)
 const mockListTransformations = vi.mocked(transformationsApi.list)
@@ -122,6 +123,7 @@ async function startInsightGeneration() {
 describe('SourceDetailContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockListInsights.mockResolvedValue([])
     mockListTransformations.mockResolvedValue([{
       id: 'transformation:summary',
       title: 'Summary',
@@ -258,5 +260,36 @@ describe('SourceDetailContent', () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Model ran out of memory')
     })
+  })
+
+  it('does not apply terminal effects when unmounted during the final refresh', async () => {
+    mockSourcesGet.mockResolvedValue(loadedSource)
+    let resolveRefresh!: (value: Awaited<ReturnType<typeof insightsApi.listForSource>>) => void
+    mockListInsights
+      .mockResolvedValueOnce([])
+      .mockReturnValueOnce(new Promise(resolve => {
+        resolveRefresh = resolve
+      }))
+    mockCreateInsight.mockResolvedValue({
+      status: 'pending',
+      message: 'started',
+      source_id: loadedSource.id,
+      transformation_id: 'transformation:summary',
+      command_id: 'job-1',
+    })
+    mockWaitForCommand.mockResolvedValue({
+      job_id: 'job-1',
+      status: 'failed',
+      error_message: 'Stale failure',
+    })
+
+    const view = renderContent(undefined, loadedSource.id)
+    await startInsightGeneration()
+    await waitFor(() => expect(mockListInsights).toHaveBeenCalledTimes(2))
+
+    view.unmount()
+    await act(async () => resolveRefresh([]))
+
+    expect(toast.error).not.toHaveBeenCalledWith('Stale failure')
   })
 })

--- a/frontend/src/components/sources/SourceDetailContent.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.tsx
@@ -166,35 +166,38 @@ function SourceDetailContentInner({
       return
     }
 
+    insightPollingRef.current?.abort()
+    const controller = new AbortController()
+    insightPollingRef.current = controller
+
     try {
       setCreatingInsight(true)
       const response = await insightsApi.create(sourceId, {
         transformation_id: selectedTransformation
       })
+      if (controller.signal.aborted) return
+
       // Show toast for async operation
       toast.success(t('sources.insightGenerationStarted'))
       setSelectedTransformation('')
 
       // Poll for command completion if we have a command_id
       if (response.command_id) {
-        insightPollingRef.current?.abort()
-        const controller = new AbortController()
-        insightPollingRef.current = controller
-
         // Poll in background (don't block UI)
         insightsApi.waitForCommand(response.command_id, {
           intervalMs: 2000,
           signal: controller.signal,
-        }).then(async success => {
+        }).then(async status => {
           if (controller.signal.aborted) return
 
           await fetchInsights()
           // Invalidate sources queries so notebook page refreshes with updated insights_count
           queryClient.invalidateQueries({ queryKey: ['sources'] })
-          if (!success) {
-            toast.error(t('common.error'))
+          if (status?.status !== 'completed') {
+            toast.error(status?.error_message || t('common.error'))
           }
         }).catch(err => {
+          if (controller.signal.aborted) return
           console.error('Error waiting for insight command:', err)
           toast.error(t('common.error'))
         }).finally(() => {
@@ -205,16 +208,26 @@ function SourceDetailContentInner({
       } else {
         // Fallback: refresh after delay if no command_id
         setTimeout(() => {
+          if (controller.signal.aborted) return
           void fetchInsights()
           // Also invalidate sources queries
           queryClient.invalidateQueries({ queryKey: ['sources'] })
+          if (insightPollingRef.current === controller) {
+            insightPollingRef.current = null
+          }
         }, 5000)
       }
     } catch (err) {
+      if (controller.signal.aborted) return
       console.error('Failed to create insight:', err)
       toast.error(t('common.error'))
+      if (insightPollingRef.current === controller) {
+        insightPollingRef.current = null
+      }
     } finally {
-      setCreatingInsight(false)
+      if (!controller.signal.aborted) {
+        setCreatingInsight(false)
+      }
     }
   }
 

--- a/frontend/src/components/sources/SourceDetailContent.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { MarkdownRenderer } from '@/components/ui/markdown-renderer'
 import { sourcesApi } from '@/lib/api/sources'
@@ -114,6 +114,7 @@ function SourceDetailContentInner({
   const [selectedInsight, setSelectedInsight] = useState<SourceInsightResponse | null>(null)
   const [insightToDelete, setInsightToDelete] = useState<string | null>(null)
   const [deletingInsight, setDeletingInsight] = useState(false)
+  const insightPollingRef = useRef<AbortController | null>(null)
 
   // A 404 means the source was deleted (e.g. a dangling chat/ask reference) —
   // handled by the shared "content no longer exists" state. The global query
@@ -157,6 +158,8 @@ function SourceDetailContentInner({
     }
   }, [fetchInsights, fetchTransformations, sourceId])
 
+  useEffect(() => () => insightPollingRef.current?.abort(), [])
+
   const createInsight = async () => {
     if (!selectedTransformation) {
       toast.error(t('sources.selectTransformation'))
@@ -174,18 +177,30 @@ function SourceDetailContentInner({
 
       // Poll for command completion if we have a command_id
       if (response.command_id) {
+        insightPollingRef.current?.abort()
+        const controller = new AbortController()
+        insightPollingRef.current = controller
+
         // Poll in background (don't block UI)
         insightsApi.waitForCommand(response.command_id, {
-          maxAttempts: 120, // Up to 4 minutes (120 * 2s)
-          intervalMs: 2000
-        }).then(success => {
-          if (success) {
-            void fetchInsights()
-            // Invalidate sources queries so notebook page refreshes with updated insights_count
-            queryClient.invalidateQueries({ queryKey: ['sources'] })
+          intervalMs: 2000,
+          signal: controller.signal,
+        }).then(async success => {
+          if (controller.signal.aborted) return
+
+          await fetchInsights()
+          // Invalidate sources queries so notebook page refreshes with updated insights_count
+          queryClient.invalidateQueries({ queryKey: ['sources'] })
+          if (!success) {
+            toast.error(t('common.error'))
           }
         }).catch(err => {
           console.error('Error waiting for insight command:', err)
+          toast.error(t('common.error'))
+        }).finally(() => {
+          if (insightPollingRef.current === controller) {
+            insightPollingRef.current = null
+          }
         })
       } else {
         // Fallback: refresh after delay if no command_id

--- a/frontend/src/components/sources/SourceDetailContent.tsx
+++ b/frontend/src/components/sources/SourceDetailContent.tsx
@@ -191,6 +191,7 @@ function SourceDetailContentInner({
           if (controller.signal.aborted) return
 
           await fetchInsights()
+          if (controller.signal.aborted) return
           // Invalidate sources queries so notebook page refreshes with updated insights_count
           queryClient.invalidateQueries({ queryKey: ['sources'] })
           if (status?.status !== 'completed') {

--- a/frontend/src/lib/api/insights.test.ts
+++ b/frontend/src/lib/api/insights.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import apiClient from './client'
+import { insightsApi } from './insights'
+
+vi.mock('./client', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+const mockGet = vi.mocked(apiClient.get)
+
+describe('insightsApi.waitForCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps polling while a command remains pending', async () => {
+    mockGet.mockImplementation(async () => ({
+      data: {
+        job_id: 'job-1',
+        status: mockGet.mock.calls.length > 60 ? 'completed' : 'running',
+      },
+    }))
+
+    await expect(
+      insightsApi.waitForCommand('job-1', { intervalMs: 0 })
+    ).resolves.toBe(true)
+    expect(mockGet).toHaveBeenCalledTimes(61)
+  })
+
+  it('stops polling when aborted', async () => {
+    const controller = new AbortController()
+    mockGet.mockResolvedValue({ data: { job_id: 'job-1', status: 'running' } })
+
+    const polling = insightsApi.waitForCommand('job-1', {
+      intervalMs: 60_000,
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1))
+
+    controller.abort()
+
+    await expect(polling).resolves.toBe(false)
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/lib/api/insights.test.ts
+++ b/frontend/src/lib/api/insights.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import apiClient from './client'
 import { insightsApi } from './insights'
 
@@ -13,6 +13,10 @@ const mockGet = vi.mocked(apiClient.get)
 describe('insightsApi.waitForCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('keeps polling while a command remains pending', async () => {
@@ -54,12 +58,34 @@ describe('insightsApi.waitForCommand', () => {
     expect(mockGet).toHaveBeenCalledTimes(1)
   })
 
+  it('stops polling when the job reports an error', async () => {
+    const controller = new AbortController()
+    mockGet.mockResolvedValue({ data: { job_id: 'job-1', status: 'error' } })
+    const abort = setTimeout(() => controller.abort(), 20)
+
+    const status = await insightsApi.waitForCommand('job-1', {
+      intervalMs: 1,
+      signal: controller.signal,
+    })
+    clearTimeout(abort)
+
+    expect(status).toMatchObject({ status: 'error' })
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
   it('stops after three consecutive status errors', async () => {
-    mockGet.mockRejectedValue(new Error('status unavailable'))
+    const statusError = Object.assign(new Error('status unavailable'), {
+      config: { headers: { Authorization: 'Bearer secret' } },
+    })
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockGet.mockRejectedValue(statusError)
 
     await expect(
       insightsApi.waitForCommand('job-1', { intervalMs: 0 })
     ).resolves.toBeNull()
     expect(mockGet).toHaveBeenCalledTimes(3)
+    expect(errorLog).toHaveBeenNthCalledWith(1, 'Error checking command status')
+    expect(errorLog).toHaveBeenNthCalledWith(2, 'Error checking command status')
+    expect(errorLog).toHaveBeenNthCalledWith(3, 'Error checking command status')
   })
 })

--- a/frontend/src/lib/api/insights.test.ts
+++ b/frontend/src/lib/api/insights.test.ts
@@ -19,14 +19,14 @@ describe('insightsApi.waitForCommand', () => {
     mockGet.mockImplementation(async () => ({
       data: {
         job_id: 'job-1',
-        status: mockGet.mock.calls.length > 60 ? 'completed' : 'running',
+        status: mockGet.mock.calls.length > 120 ? 'completed' : 'running',
       },
     }))
 
     await expect(
       insightsApi.waitForCommand('job-1', { intervalMs: 0 })
-    ).resolves.toBe(true)
-    expect(mockGet).toHaveBeenCalledTimes(61)
+    ).resolves.toMatchObject({ status: 'completed' })
+    expect(mockGet).toHaveBeenCalledTimes(121)
   })
 
   it('stops polling when aborted', async () => {
@@ -41,7 +41,25 @@ describe('insightsApi.waitForCommand', () => {
 
     controller.abort()
 
-    await expect(polling).resolves.toBe(false)
+    await expect(polling).resolves.toBeNull()
     expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops polling when the job is unknown', async () => {
+    mockGet.mockResolvedValue({ data: { job_id: 'job-1', status: 'unknown' } })
+
+    await expect(
+      insightsApi.waitForCommand('job-1', { intervalMs: 0 })
+    ).resolves.toMatchObject({ status: 'unknown' })
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops after three consecutive status errors', async () => {
+    mockGet.mockRejectedValue(new Error('status unavailable'))
+
+    await expect(
+      insightsApi.waitForCommand('job-1', { intervalMs: 0 })
+    ).resolves.toBeNull()
+    expect(mockGet).toHaveBeenCalledTimes(3)
   })
 })

--- a/frontend/src/lib/api/insights.ts
+++ b/frontend/src/lib/api/insights.ts
@@ -62,29 +62,33 @@ export const insightsApi = {
 
   /**
    * Poll command status until completed or failed.
-   * Returns true if completed successfully, false if failed.
+   * Returns the terminal status, or null if polling is aborted or repeatedly errors.
    */
   waitForCommand: async (
     commandId: string,
     options?: { intervalMs?: number; signal?: AbortSignal }
-  ): Promise<boolean> => {
+  ): Promise<CommandJobStatusResponse | null> => {
     const intervalMs = options?.intervalMs ?? 2000 // Default 2 seconds
     const signal = options?.signal
+    let consecutiveErrors = 0
 
     while (!signal?.aborted) {
+      let status: CommandJobStatusResponse | undefined
       try {
-        const status = await insightsApi.getCommandStatus(commandId, signal)
-        if (status.status === 'completed') {
-          return true
-        }
+        status = await insightsApi.getCommandStatus(commandId, signal)
+        consecutiveErrors = 0
+      } catch (error) {
+        if (signal?.aborted) return null
+        console.error('Error checking command status:', error)
+        consecutiveErrors += 1
+        if (consecutiveErrors >= 3) return null
+      }
+
+      if (status && ['completed', 'failed', 'canceled', 'unknown'].includes(status.status)) {
         if (status.status === 'failed' || status.status === 'canceled') {
           console.error('Command failed:', status.error_message)
-          return false
         }
-      } catch (error) {
-        if (signal?.aborted) return false
-        console.error('Error checking command status:', error)
-        // Continue polling on error
+        return status
       }
 
       await new Promise<void>(resolve => {
@@ -105,6 +109,6 @@ export const insightsApi = {
       })
     }
 
-    return false
+    return null
   }
 }

--- a/frontend/src/lib/api/insights.ts
+++ b/frontend/src/lib/api/insights.ts
@@ -52,9 +52,10 @@ export const insightsApi = {
     await apiClient.delete(`/insights/${insightId}`)
   },
 
-  getCommandStatus: async (commandId: string) => {
+  getCommandStatus: async (commandId: string, signal?: AbortSignal) => {
     const response = await apiClient.get<CommandJobStatusResponse>(
-      `/commands/jobs/${commandId}`
+      `/commands/jobs/${commandId}`,
+      { signal }
     )
     return response.data
   },
@@ -65,14 +66,14 @@ export const insightsApi = {
    */
   waitForCommand: async (
     commandId: string,
-    options?: { maxAttempts?: number; intervalMs?: number }
+    options?: { intervalMs?: number; signal?: AbortSignal }
   ): Promise<boolean> => {
-    const maxAttempts = options?.maxAttempts ?? 60 // Default 60 attempts
     const intervalMs = options?.intervalMs ?? 2000 // Default 2 seconds
+    const signal = options?.signal
 
-    for (let i = 0; i < maxAttempts; i++) {
+    while (!signal?.aborted) {
       try {
-        const status = await insightsApi.getCommandStatus(commandId)
+        const status = await insightsApi.getCommandStatus(commandId, signal)
         if (status.status === 'completed') {
           return true
         }
@@ -80,16 +81,30 @@ export const insightsApi = {
           console.error('Command failed:', status.error_message)
           return false
         }
-        // Still running, wait and retry
-        await new Promise(resolve => setTimeout(resolve, intervalMs))
       } catch (error) {
+        if (signal?.aborted) return false
         console.error('Error checking command status:', error)
         // Continue polling on error
-        await new Promise(resolve => setTimeout(resolve, intervalMs))
       }
+
+      await new Promise<void>(resolve => {
+        if (signal?.aborted) {
+          resolve()
+          return
+        }
+
+        const onAbort = () => {
+          clearTimeout(timeout)
+          resolve()
+        }
+        const timeout = setTimeout(() => {
+          signal?.removeEventListener('abort', onAbort)
+          resolve()
+        }, intervalMs)
+        signal?.addEventListener('abort', onAbort, { once: true })
+      })
     }
-    // Timeout
-    console.warn('Command polling timed out')
+
     return false
   }
 }

--- a/frontend/src/lib/api/insights.ts
+++ b/frontend/src/lib/api/insights.ts
@@ -61,7 +61,7 @@ export const insightsApi = {
   },
 
   /**
-   * Poll command status until completed or failed.
+   * Poll command status until it reaches a terminal state.
    * Returns the terminal status, or null if polling is aborted or repeatedly errors.
    */
   waitForCommand: async (
@@ -77,14 +77,14 @@ export const insightsApi = {
       try {
         status = await insightsApi.getCommandStatus(commandId, signal)
         consecutiveErrors = 0
-      } catch (error) {
+      } catch {
         if (signal?.aborted) return null
-        console.error('Error checking command status:', error)
+        console.error('Error checking command status')
         consecutiveErrors += 1
         if (consecutiveErrors >= 3) return null
       }
 
-      if (status && ['completed', 'failed', 'canceled', 'unknown'].includes(status.status)) {
+      if (status && ['completed', 'failed', 'canceled', 'error', 'unknown'].includes(status.status)) {
         if (status.status === 'failed' || status.status === 'canceled') {
           console.error('Command failed:', status.error_message)
         }


### PR DESCRIPTION
## Context

Insight generation can legitimately take longer than four minutes with local models and large sources. The source detail UI stopped checking the command after 120 attempts, so a completed insight remained hidden until the user navigated away and returned.

Fixes #1264

## Changes

- Keep checking insight commands while their status remains non-terminal; stop on worker terminal states or three consecutive status-request failures.
- Pass an `AbortSignal` through status requests, cancel on unmount or replacement, and re-check cancellation after the terminal refetch.
- Perform a final insight refetch for terminal success or failure, update source query data, and surface terminal failures with a toast.
- Cover polling beyond the previous limit, terminal/error stops, sanitized status-error logging, unmount races, and backend error display with API and component tests.

## User impact

Long-running insights now appear in the open Insights tab as soon as generation completes. Leaving the source stops its browser-side polling, and failed jobs no longer end silently.

## Verification

- `npm test` — 27 test files passed, 164 tests passed.
- `npm run lint` — 0 errors; 7 existing warnings in unchanged files.
- `npm run build` — production build, TypeScript check, and static page generation passed.
- Browser reproduction at 1440×1000 with identical mocked responses — the base build stopped after 120 pending checks and continued to show the empty state; this branch completed check 121, refetched, and rendered the insight without navigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Tested locally with development setup
- [x] Added new unit tests
- [x] Existing frontend tests pass
- [x] Manual browser testing performed

## Design Alignment

- [x] Simplicity Over Features
- [x] Async-First for Performance

The existing polling path remains in place; this removes its arbitrary duration limit and gives it lifecycle cancellation.

## Checklist

### Code Quality

- [x] My code follows TypeScript best practices
- [x] I have performed a self-review of the complete diff
- [x] I have commented the lifecycle behavior where appropriate
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally
- [x] I ran frontend linting
- [x] I ran TypeScript checking through the production build

### Documentation, Database, and Breaking Changes

- [x] No documentation update is needed
- [x] No database change or migration is needed
- [x] No API contract or breaking change is introduced

## Screenshots

| Before: polling stops after 120 checks | After: the completed insight appears on check 121 |
| --- | --- |
| ![The Insights tab remains empty after the old polling limit](https://raw.githubusercontent.com/justadityaraj/open-notebook/evidence/1264-insight-polling/evidence/1264/before.png) | ![The completed Paper Analysis insight appears without navigation](https://raw.githubusercontent.com/justadityaraj/open-notebook/evidence/1264-insight-polling/evidence/1264/after.png) |

## Pre-Submission Verification

- [x] I have read the contributing guide
- [x] I have read the project vision and frontend rules
- [x] This PR addresses approved, `ready` issue #1264
- [x] I have not included unrelated changes
- [x] The PR title follows the repository's conventional commit format


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/open-notebook/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

